### PR TITLE
[feat] MiniGameReadyPage 구현

### DIFF
--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: 0 20px;
+`;
+
+export const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 30px;
+`;
+
+export const Time = styled.span`
+  font-size: 150px;
+  font-weight: 900;
+  color: white;
+`;

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
@@ -17,6 +17,12 @@ export const Wrapper = styled.div`
   margin-bottom: 30px;
 `;
 
+export const DescriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
 export const Timer = styled.span`
   font-size: 150px;
   font-weight: 900;

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.styled.ts
@@ -9,7 +9,7 @@ export const Container = styled.div`
   padding: 0 20px;
 `;
 
-export const TextContainer = styled.div`
+export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,7 +17,7 @@ export const TextContainer = styled.div`
   margin-bottom: 30px;
 `;
 
-export const Time = styled.span`
+export const Timer = styled.span`
   font-size: 150px;
   font-weight: 900;
   color: white;

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
@@ -14,19 +14,20 @@ const MiniGameReadyPage = () => {
   const { roomId, miniGameId } = useParams();
 
   useEffect(() => {
+    if (countdown <= 0) return;
+
     const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          navigate(`/room/${roomId}/${miniGameId}/play`);
-          return 0;
-        }
-        return prev - 1;
-      });
+      setCountdown((prev) => prev - 1);
     }, COUNTDOWN_INTERVAL);
 
     return () => clearInterval(timer);
-  }, [navigate, roomId, miniGameId]);
+  }, [countdown]);
+
+  useEffect(() => {
+    if (countdown <= 0) {
+      navigate(`/room/${roomId}/${miniGameId}/play`);
+    }
+  }, [countdown, navigate, roomId, miniGameId]);
 
   return (
     <Layout color="point-400">

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
@@ -5,8 +5,11 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import * as S from './MiniGameReadyPage.styled';
 
+const INITIAL_COUNTDOWN_SECONDS = 3;
+const COUNTDOWN_INTERVAL = 1000;
+
 const MiniGameReadyPage = () => {
-  const [countdown, setCountdown] = useState(3);
+  const [countdown, setCountdown] = useState(INITIAL_COUNTDOWN_SECONDS);
   const navigate = useNavigate();
   const { roomId, miniGameId } = useParams();
 
@@ -20,7 +23,7 @@ const MiniGameReadyPage = () => {
         }
         return prev - 1;
       });
-    }, 1000);
+    }, COUNTDOWN_INTERVAL);
 
     return () => clearInterval(timer);
   }, [navigate, roomId, miniGameId]);
@@ -28,15 +31,15 @@ const MiniGameReadyPage = () => {
   return (
     <Layout color="point-400">
       <S.Container>
-        <S.TextContainer>
+        <S.Wrapper>
           <Headline1 color="white">곧 게임이 시작돼요</Headline1>
           <Description color="white">
             게임이 시작될 때까지
             <br />
             조금만 기다려주세요
           </Description>
-        </S.TextContainer>
-        <S.Time>{countdown}</S.Time>
+        </S.Wrapper>
+        <S.Timer>{countdown}</S.Timer>
       </S.Container>
     </Layout>
   );

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
@@ -33,11 +33,10 @@ const MiniGameReadyPage = () => {
       <S.Container>
         <S.Wrapper>
           <Headline1 color="white">곧 게임이 시작돼요</Headline1>
-          <Description color="white">
-            게임이 시작될 때까지
-            <br />
-            조금만 기다려주세요
-          </Description>
+          <S.DescriptionWrapper>
+            <Description color="white">게임이 시작될 때까지</Description>
+            <Description color="white">조금만 기다려주세요</Description>
+          </S.DescriptionWrapper>
         </S.Wrapper>
         <S.Timer>{countdown}</S.Timer>
       </S.Container>

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
@@ -1,18 +1,23 @@
+import Headline1 from '@/components/@common/Headline1/Headline1';
+import Layout from '@/layouts/Layout';
+import * as S from './MiniGameReadyPage.styled';
+import Description from '@/components/@common/Description/Description';
+
 const MiniGameReadyPage = () => {
   return (
-    <div>
-      <h1>미니게임 준비</h1>
-      <p>미니게임을 시작하기 전 준비 화면입니다.</p>
-      <div>
-        <h3>게임 규칙</h3>
-        <ul>
-          <li>규칙 1</li>
-          <li>규칙 2</li>
-          <li>규칙 3</li>
-        </ul>
-      </div>
-      <button>준비 완료</button>
-    </div>
+    <Layout color="point-400">
+      <S.Container>
+        <S.TextContainer>
+          <Headline1 color="white">곧 게임이 시작돼요</Headline1>
+          <Description color="white">
+            게임이 시작될 때까지
+            <br />
+            조금만 기다려주세요
+          </Description>
+        </S.TextContainer>
+        <S.Time>3</S.Time>
+      </S.Container>
+    </Layout>
   );
 };
 

--- a/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
+++ b/frontend/src/pages/MiniGameReadyPage/MiniGameReadyPage.tsx
@@ -1,9 +1,30 @@
+import Description from '@/components/@common/Description/Description';
 import Headline1 from '@/components/@common/Headline1/Headline1';
 import Layout from '@/layouts/Layout';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import * as S from './MiniGameReadyPage.styled';
-import Description from '@/components/@common/Description/Description';
 
 const MiniGameReadyPage = () => {
+  const [countdown, setCountdown] = useState(3);
+  const navigate = useNavigate();
+  const { roomId, miniGameId } = useParams();
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          navigate(`/room/${roomId}/${miniGameId}/play`);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [navigate, roomId, miniGameId]);
+
   return (
     <Layout color="point-400">
       <S.Container>
@@ -15,7 +36,7 @@ const MiniGameReadyPage = () => {
             조금만 기다려주세요
           </Description>
         </S.TextContainer>
-        <S.Time>3</S.Time>
+        <S.Time>{countdown}</S.Time>
       </S.Container>
     </Layout>
   );


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #93 

# 🚀 작업 내용

1. 미니 게임 대기 화면 UI를 구현했습니다.

<img width="375" height="629" alt="image" src="https://github.com/user-attachments/assets/78cc9737-c1fd-4425-a6cb-b759b2686c58" />


2. 각 게임 사이의 대기 시간은 3초로 설정했습니다. 3초가 지나면 게임 시작 화면으로 이동하며, url을 `/room/1/2/ready` -> `/room/1/2/play`로 넘어가도록 구현했습니다.

# 💬 리뷰 중점사항

페이지 가장 바깥쪽에 공통 컴포넌트인 `Layout`을 적용해서 구현해봤는데, 의도대로 사용된 건지 확인부탁드립니다.

# 논의 사항

지금 `Description` 태그로 `게임이 시작될 때까지 조금만 기다려주세요`라는 텍스트를 넣어놨는데, `line-height` 속성이 없어서 텍스트 사이의 줄 높이가 붙어있는 느낌이 들었습니다. 전체적으로 `line-height`를 피그마 기반으로 설정하는건 어떻게 생각하시나용 ?..?