### PR TITLE
[feat] CircularProgress 타이머 이슈

### DIFF
--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.stories.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.stories.tsx
@@ -29,24 +29,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const FullProgress: Story = {
-  args: {
-    current: 0,
-    total: 10,
-  },
-};
-
-export const NoProgress: Story = {
-  args: {
-    current: 10,
-    total: 10,
-  },
-};
-
 export const CountdownAnimation: Story = {
   render: () => {
-    const [current, setCurrent] = useState(10);
     const [key, setKey] = useState(0);
+    const [current, setCurrent] = useState(10);
 
     useEffect(() => {
       if (current > 0) {

--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.stories.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.stories.tsx
@@ -46,18 +46,24 @@ export const NoProgress: Story = {
 export const CountdownAnimation: Story = {
   render: () => {
     const [current, setCurrent] = useState(10);
+    const [key, setKey] = useState(0);
 
     useEffect(() => {
       if (current > 0) {
-        const timer = setTimeout(() => setCurrent(current - 1), 1_000);
+        const timer = setTimeout(() => setCurrent(current - 1), 1000);
         return () => clearTimeout(timer);
       }
     }, [current]);
 
+    const handleReset = () => {
+      setCurrent(10);
+      setKey((prev) => prev + 1);
+    };
+
     return (
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1rem' }}>
-        <CircularProgress current={current} total={10} />
-        <button onClick={() => setCurrent(10)}>리셋 버튼</button>
+        <CircularProgress key={key} current={current} total={10} />
+        <button onClick={handleReset}>리셋 버튼</button>
       </div>
     );
   },

--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import * as S from './CircularProgress.styled';
 
 type Props = {
@@ -6,20 +7,31 @@ type Props = {
   size?: string;
 };
 
+const RADIUS = 45;
+const circumference = 2 * Math.PI * RADIUS;
+
 const CircularProgress = ({ current, total, size = '2rem' }: Props) => {
-  const progress = total > 0 ? (total - current) / total : 0;
-  const radius = 45;
-  const circumference = 2 * Math.PI * radius;
-  const strokeDashoffset = circumference * (1 - progress);
+  const [strokeDashoffset, setStrokeDashoffset] = useState(circumference);
+
+  useEffect(() => {
+    if (total <= 0) {
+      setStrokeDashoffset(circumference);
+      return;
+    }
+
+    const progress = Math.min(1, (total - current + 1) / total);
+    const newStrokeDashoffset = circumference * (1 - progress);
+    setStrokeDashoffset(newStrokeDashoffset);
+  }, [current, total]);
 
   return (
     <S.Container $size={size}>
       <S.ProgressRing width="100%" height="100%" viewBox="0 0 100 100">
-        <S.BackgroundCircle cx="50" cy="50" r={radius} fill="none" />
+        <S.BackgroundCircle cx="50" cy="50" r={RADIUS} fill="none" />
         <S.ProgressCircle
           cx="50"
           cy="50"
-          r={radius}
+          r={RADIUS}
           fill="none"
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #131 

# 🚀 작업 내용

## 1️⃣ 문제 상황

예시로 타이머를 10초로 맞춰놓고 테스트를 진행했는데, 시작할 때 10초에서 바로 9초로 바뀐 상태로 진행되는 문제가 있었습니다.
아래 영상을 보면 알 수 있는데, 리셋 버튼을 눌렀을 때 1초동안 10이 화면에 띄워진 상태에서 진행바가 움직이지 않는 모습을 볼 수 있습니다.
그리고 마지막에 0으로 표시된 상태일 때도 1초가 지난 후에 진행바가 꽉 채워지게 됩니다.
그렇기 때문에 실질적으로는 **11초가 세어지는 것**이었습니다.

https://github.com/user-attachments/assets/dcfc4f2c-4bc9-40aa-b88c-3f30a64da115

아래는 구글 타이머인데요, 보통은 10초부터 카운트가 들어가야 합니다. 그래서 끝날 때 1초로 표시된 상태로 1초가 지나면 0이 되고 타이머가 종료됩니다. 하지만, 제가 구현한 타이머에서는 화면에 0으로 표시된 상태에서 1초가 지나고 종료가 됩니다.

https://github.com/user-attachments/assets/a4fd6734-eb96-4753-bbf9-7fa6658e2242

게임 타이머의 경우에는 사용자 입장에서 게임을 진행할 때 매우 예민한 부분이고 중요하다고 판단하여 수정하기로 했습니다.

## 2️⃣ 문제 원인 분석

문제 원인 분석 전에 코드 이해를 돕기 위해서 각각의 변수가 어떤 역할을 하는지 요약해둘게요!

- `current`: 현재 남은 시간
- `total`: 전체 타이머 시간
- `progress`: 진행률 (0~1 사잇값)
- `radius`: 반지름 (고정 상수)
- `circumference`: 원의 둘레 (고정 상수)
- `strokeDashoffset`: 현재 비워진 만큼의 둘레 (호의 길이)
- `strokeDasharray`: 채워져야 하는 전체 원의 둘레 (원주)

문제 원인 자체는 `progress` 계산 방식에 있었습니다.

```tsx
const progress = total > 0 ? (total - current) / total : 0;
```

위 코드는 기존의 `progress` 계산 코드입니다.

current = 10, total = 10 이라고 가정했을 때, 다음과 같이 됩니다.

10초인 시점 즉, 막 타이머가 시작했을 때의 진행률은 `progress = (10 - 10) / 10 = 0`로 0이 됩니다.
즉 10초일 때 진행바가 아예 움직이지 않게 되는 것입니다.

제가 원하는 방향은 10초일 때 진행률이 0.1이 되는 것이었어요.
그래야 화면에 '10'이 보이는 시점에 1초 동안 진행바가 0.1을 움직일 수 있는 거죠.

쉽게 정리하자면 다음과 같아요.

```md
// 기존 로직
10초일 때, 진행률 0 (진행바 멈춘 상태)
9초일 때, 진행률 0~0.1
...
1초일 때, 진행률 0.8~0.9
0초일 때, 진행률 0.9~1 (마지막으로 채워지는 상태)

// 원하는 로직
10초일 때, 진행률 0~0.1 (진행바 움직이기 시작)
9초일 때, 진행률 0.1~0.2
...
1초일 때, 진행률 0.9~1
0초일 때, 진행률 1 (이미 다 채워진 상태)
````

## 3️⃣ 해결 방법

위와 같이 로직을 수정해주기 위해서 총 3가지를 수정했습니다!

1. progress 계산할 때 current에 미리 1초 더해주기
2. strokeDashoffset 초깃값을 원의 둘레로 설정해주기 위해 useState 사용하기
3. progress 계산 시 Math.min을 사용해 진행률이 1 넘어가지 못하게 막아주기

### 1. progress 계산할 때 current에 미리 1초 더해주기

단순하게 생각했을 때는 우선 current 즉, 현재 남은 시간에 1초를 더해주는 것이었습니다.
그러면 progress 계산할 때 다음처럼 됩니다. (기준은 모두 total=10 입니다)
`progress = (10 - 10 + 1) / 10 = 0.1`
이렇게 되면, 10초가 보여지는 동안 진행률이 0.1이 되는 것입니다.

하지만 여기서 2가지 문제가 있었습니다. 방금처럼 1초를 더해서 계산해주었기 때문에 진행률 시작점 자체가 0.1이었고, 종료 시점도 이미 진행률 최댓값인 1을 넘어선 1.1 이 되어 버렸습니다. 그래서 다음과 같이 실행이 되었어요.

https://github.com/user-attachments/assets/6ad20f6b-017f-4a06-9775-2ede726cef8d

그래서 이 문제를 아래 2가지 방식으로 해결해주었습니다.

### 2. strokeDashoffset 초깃값을 원의 둘레로 설정해주기 위해 useState 사용하기

```tsx
const [strokeDashoffset, setStrokeDashoffset] = useState(circumference);
```
이렇게 강제로 strokeDashoffset의 초깃값을 원의 둘레인 circumference 로 설정해두는 것이었습니다.
이렇게 되면 useEffect가 실행되기 전에 useState에 의해 strokeDashoffset의 초깃값이 설정되고 맨처음 화면에서는 진행률이 0인 상태로 보이게 됩니다. 그러면서 useEffect가 실행되어 progress가 계산되고 strokeDashoffset 값이 재조정되면 다시 CircularProgress 컴포넌트가 리렌더링 되면서 transition에 의해 진행바가 움직이게 됩니다.

### 3. progress 계산 시 Math.min을 사용해 진행률이 1 넘어가지 못하게 막아주기

0초일 때는 `progress = (10 - 0 + 1) / 10 = 1.1` 즉, 진행률이 1.1이 되어버리는 문제가 있었습니다.
원 자체는 진행률 최대 1을 기준으로 계산이 되기 때문에 진행률 1을 넘어버리면 기존 원 한바퀴 이상으로 넘어가버립니다.

그래서 이를 막아주기 위해서 progress 계산할 때 `Math.min` 로 최대 1을 초과하지 않도록 고정해두었습니다.

```tsx
const progress = Math.min(1, (total - current + 1) / total);
```

## 4️⃣ 결과

결과적으로, 10초부터 카운트가 시작되고, 0초가 되는 시점에 타이머 진행률이 Full 상태가 됩니다. 제가 원하는 대로 구현이 되었습니다!

https://github.com/user-attachments/assets/8472eecf-3d69-4bb7-8b0d-eb283fffda7c

## 🐞 Bug (추후 또는 조만간 해결할 문제)

약간의 버그가 있다면, 초기화된 상태에서는 1초가 이미 차 있는 상태로 멈춰있습니다.
아래 영상을 보면 '시작' 버튼을 누르면 진행률 0부터 잘 실행이 되는데요, '리셋' 버튼을 누르면 total = 10 기준으로 봤을 때 0.1%가 진행된 상태로 초기화해 버립니다.

<img width="66" height="55" alt="image" src="https://github.com/user-attachments/assets/33bcb6a4-3692-40d5-94ff-4931dbc974e8" />

https://github.com/user-attachments/assets/87121fdc-a0f5-45cf-9414-258e6a254290

물론 해당 컴포넌트 렌더링 시점에 타이머가 바로 실행되는 경우에는 progress(진행률)가 0%인 상태로 실행되기 때문에 문제가 없긴 합니다. 그래서 게임 구현에 있어서는 아마 화면 전환 되자마자 타이머가 실행되어서 큰 문제는 없을 것 같아요. 하지만, 추후 개선하면 좋을 부분이기 때문에 작성해둡니다!

문제를 적어보자면, `CircularProgress` 컴포넌트가 렌더링이 되고  `useEffect`가 한 번 실행되기 때문에 발생하는 문제인데요. 

이 컴포넌트를 사용할 때는 해당 컴포넌트의 Props에 변화가 있어야 리렌더링이 되거나, 완전 처음에 마운트 될 때 실행이 됩니다.

하지만, 타이머 로직 자체가 `CircularProgress` 컴포넌트를 호출하는 상위 컴포넌트에 존재하고 있고, 거기서 타이머를 강제로 멈춰버리기 때문에, 이미 `useEffect`가 실행된 상태로 멈춰버리게 되고, 그게 초기 UI가 되어버립니다.

```tsx
const progress = Math.min(1, (total - current + 1) / total);
```
해당 부분이 문제 발생 요인인데요, 하지만, 이 로직이 존재하지 않으면 앞서 해결하고자 했던 문제를 해결할 수 없기 때문에 우선 지금처럼 두는 것이 맞다고 생각했어요.

좀 더 자세히 적어보자면, 위 공식대로 계산이 된다면, `current = 10, total = 10` 일 때, `progress = (10 - 10 + 1) / 10 = 0.1 `즉, 10% 진행이 되기 때문에, 원이 10% 채워진 후에 이 상태로 멈춰버리게 됩니다!

# 🚀 번외: 스토리북 예제

## 1️⃣ 문제 상황
기존에는 '리셋' 버튼을 누르면 transition 속성에 의해서 채워진 부분이 뒤로 다시 천천히 돌아가면서 초기화가 되었습니다.
하지만, 구현하고자 했던 목적은 '리셋' 버튼을 누르면 아예 처음부터 원 자체가 초기화 되어야 한다고 생각했어요.

https://github.com/user-attachments/assets/c9e0f9e8-4a98-4e26-9b96-aac3c46ad0c9

## 2️⃣ 해결 및 결론
결론적으로 `CircularProgress`에 key 값을 부여하여, 버튼 클릭 시 key 값을 증가시켜 컴포넌트를 완전히 리마운트할 수 있도록 수정했습니다. 

이렇게 key Prop이 변경되게 되면, 리액트 내부적으로 새로운 컴포넌트라 판단하여 해당 컴포넌트를 완전 새로 마운트하게 됩니다! 그래서 이전 상태가 초기화되고 새로 카운트다운을 시작하게 됩니다. 

CSS만으로 해결할 수는 없을까 하는 생각을 해봤는데, `transition`을 부분적으로 특정 상황에만 적용할 수는 없을 것 같다는 생각이 들어서 이 방식대로 수정을 해봤어요! (다른 해결 방법이 있다면 제안해주시면 감사하겠습니당!)

우선 저희 프로젝트 진행할 때는 하나의 화면에서 여러 개의 타이머가 반복적으로 실행될 상황이 없을 것 같다는 생각이긴 하지만, 그래도 스토리북을 왜 이렇게 수정하게 되었는지 궁금해하실 것 같아서 적어둡니다! 나중에 필요한 부분일 수 있을 것 같아요. (물론 이 코드도 추후에 수정될 가능성이 있다고 생각합니다.)

https://github.com/user-attachments/assets/8f4ed20c-9d8a-481c-abc2-c4ac6228a66a
