### PR TITLE
[fix] 모달이 기준화면을 넘어서 화면 전체를 차지하는 오류 수정

### DIFF
--- a/frontend/src/features/ui/Modal/Modal.styled.ts
+++ b/frontend/src/features/ui/Modal/Modal.styled.ts
@@ -11,6 +11,11 @@ export const Backdrop = styled.div`
   inset: 0;
   position: fixed;
   z-index: ${Z_INDEX.MODAL};
+
+  max-width: 430px;
+  width: 100%;
+  height: 100dvh;
+  margin: 0 auto;
 `;
 
 export const Container = styled.div`


### PR DESCRIPTION
root에 적용한 모바일 레이아웃과 동일하게 모달 레이아웃에도 적용

# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #137 

# 🚀 작업 내용

`global.css`에 적용되어 있는 `#root` 스타일을 `modal`의 `backdrop`에 동일하게 적용

# 💬 리뷰 중점사항

중점사항
