### PR TITLE
[feat] 게임 결과 참가자 리스트 구현

### DIFF
--- a/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.styled.ts
+++ b/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.styled.ts
@@ -15,3 +15,42 @@ export const DescriptionWrapper = styled.div`
   flex-direction: column;
   gap: 5px;
 `;
+
+export const ResultList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const PlayerCardWrapper = styled.div<{ isHighlighted?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 12px;
+  background-color: ${({ isHighlighted, theme }) =>
+    isHighlighted ? theme.color.point[100] : 'transparent'};
+`;
+
+export const RankNumber = styled.div<{ rank: number }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 35px;
+  height: 35px;
+  border-radius: 12px;
+  background-color: ${({ rank }) => {
+    switch (rank) {
+      case 1:
+        return '#FFDE65';
+      case 2:
+        return '#E5E7EB';
+      case 3:
+        return '#FFC8A4';
+      default:
+        return 'none';
+    }
+  }};
+  font-size: 20px;
+  font-weight: 600;
+  color: ${({ rank }) => (rank <= 3 ? '#FFFFFF' : '#666')};
+`;

--- a/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.tsx
+++ b/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.tsx
@@ -4,6 +4,18 @@ import Layout from '@/layouts/Layout';
 import * as S from './MiniGameResultPage.styled';
 import { useNavigate, useParams } from 'react-router-dom';
 import Description from '@/components/@common/Description/Description';
+import Headline4 from '@/components/@common/Headline4/Headline4';
+import PlayerCard from '@/components/@composition/PlayerCard/PlayerCard';
+import { IconColor } from '@/components/@composition/PlayerCard/utils/getPlayerIcon';
+import Headline3 from '@/components/@common/Headline3/Headline3';
+
+const gameResults = [
+  { id: 1, name: '다이앤', score: 20, iconColor: 'red' as IconColor, rank: 1 },
+  { id: 2, name: '니야', score: 18, iconColor: 'red' as IconColor, rank: 2 },
+  { id: 3, name: '메리', score: 15, iconColor: 'red' as IconColor, rank: 3 },
+  { id: 4, name: '엠제이', score: 13, iconColor: 'red' as IconColor, rank: 4 },
+  { id: 5, name: '루키', score: 10, iconColor: 'red' as IconColor, rank: 5 },
+];
 
 const MiniGameResultPage = () => {
   const navigate = useNavigate();
@@ -26,7 +38,20 @@ const MiniGameResultPage = () => {
           </S.DescriptionWrapper>
         </S.Banner>
       </Layout.Banner>
-      <Layout.Content></Layout.Content>
+      <Layout.Content>
+        <S.ResultList>
+          {gameResults.map((player) => (
+            <S.PlayerCardWrapper key={player.id} isHighlighted={player.rank === 4}>
+              <Headline3>
+                <S.RankNumber rank={player.rank}>{player.rank}</S.RankNumber>
+              </Headline3>
+              <PlayerCard name={player.name} iconColor={player.iconColor}>
+                <Headline4>{player.score}점</Headline4>
+              </PlayerCard>
+            </S.PlayerCardWrapper>
+          ))}
+        </S.ResultList>
+      </Layout.Content>
       <Layout.ButtonBar>
         <Button variant="primary" onClick={handleViewRouletteResult}>
           룰렛 현황 보러가기


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #165 

# 🚀 작업 내용

1. 게임 결과 참가자 리스트를 구현했습니다.

<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/1896cd09-0b81-45ef-bf21-426cac2f3079" />


# 참고 사항

- 지금은 더미 데이터로 넣어놨지만 서버 데이터 구조에 따라 구조적인 개선이 있을 것 같습니다.
- 서버에서 전달받는 데이터에 따라 `isHighlighted`의 값을 결정하는 방식이 바뀔 것 같습니다.