### PR TITLE
[feat] 모바일 터치 효과 제거

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,7 +2,10 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>커피빵 ☕️</title>
     <link
       rel="stylesheet"

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -16,3 +16,94 @@ body {
   height: 100dvh;
   margin: 0 auto;
 }
+
+/* 전체 페이지 확대/축소 완전 차단 */
+html,
+body {
+  overflow-x: hidden;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  -webkit-user-scalable: no;
+  -moz-user-scalable: no;
+  -ms-user-scalable: no;
+
+  /* 모바일 전체 더블탭 확대 차단 */
+  touch-action: manipulation;
+}
+
+/* 모든 요소에 대한 확대 방지 */
+* {
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+/* 모든 요소에 터치 액션 제한 */
+* {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* 모바일 터치 효과 제거 */
+button {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  outline: none;
+}
+
+/* 링크 터치 효과 제거 */
+a {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+}
+
+/* 이미지 터치 효과 제거 */
+img {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
+/* 모바일 input 자동 확대 방지 */
+input,
+textarea,
+select {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* 텍스트 요소 터치 효과 및 드래그 제거 */
+p,
+span,
+div,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,3 +1,20 @@
+/* 전체 페이지 확대/축소 완전 차단 */
+html,
+body {
+  overflow-x: hidden;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+
+  /* 전체 페이지 확대/축소 차단 */
+  -webkit-user-scalable: no;
+  -moz-user-scalable: no;
+  -ms-user-scalable: no;
+
+  /* 모바일 더블탭 확대 차단 */
+  touch-action: manipulation;
+}
+
 body {
   font-family:
     'Pretendard Variable',
@@ -6,7 +23,6 @@ body {
     BlinkMacSystemFont,
     system-ui,
     sans-serif;
-
   color: #364153;
 }
 
@@ -17,80 +33,27 @@ body {
   margin: 0 auto;
 }
 
-/* 전체 페이지 확대/축소 완전 차단 */
-html,
-body {
-  overflow-x: hidden;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  -webkit-user-scalable: no;
-  -moz-user-scalable: no;
-  -ms-user-scalable: no;
-
-  /* 모바일 전체 더블탭 확대 차단 */
-  touch-action: manipulation;
-}
-
-/* 모든 요소에 대한 확대 방지 */
+/* 모든 요소에 확대/터치/선택/효과 제거 */
 * {
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   text-size-adjust: 100%;
-}
 
-/* 모든 요소에 터치 액션 제한 */
-* {
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
+
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 }
 
-/* 모바일 터치 효과 제거 */
-button {
-  -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  outline: none;
-}
-
-/* 링크 터치 효과 제거 */
-a {
-  -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-}
-
-/* 이미지 터치 효과 제거 */
-img {
-  -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-drag: none;
-  user-select: none;
-}
-
-/* 모바일 input 자동 확대 방지 */
+/* 요소 드래그 제거 */
 input,
 textarea,
-select {
-  -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-/* 텍스트 요소 터치 효과 및 드래그 제거 */
+select,
+img,
 p,
 span,
 div,
@@ -100,10 +63,5 @@ h3,
 h4,
 h5,
 h6 {
-  -webkit-tap-highlight-color: transparent;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+  -webkit-user-drag: none;
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #148 

# 🚀 작업 내용

모바일 테스트 시 UX 문제있는 부분들을 해결하기 위해 모바일 터치 효과들을 제거해두었습니다.
테스트해보고 불편사항 있으면 추가 이슈 부탁드려요!

## 전체 스타일 개선 관련 속성 설명

#### `html, body`

* `overflow-x: hidden`
  → 가로 스크롤 방지 (콘텐츠 튐 방지)
* `position: fixed`, `width: 100%`, `height: 100%`
  → 모바일 환경에서 전체 뷰포트를 고정하여 레이아웃 안정화
* `-webkit-user-scalable: no`, `-moz-user-scalable: no`, `-ms-user-scalable: no`
  → 사용자의 핀치 줌(확대/축소) 비활성화
* `touch-action: manipulation`
  → 터치 시 더블탭 확대 및 브라우저 기본 동작 방지

---

#### `*` (전체 요소 공통)

* `-webkit-text-size-adjust: 100%`, `-ms-text-size-adjust: 100%`, `text-size-adjust: 100%`
  → 텍스트 자동 확대 방지
* `touch-action: manipulation`
  → 터치 관련 기본 브라우저 동작 제거 (이중 탭 확대 등)
* `-webkit-tap-highlight-color: transparent`
  → 터치 시 파란 하이라이트 제거
* `-webkit-touch-callout: none`
  → 길게 누를 때 나오는 시스템 메뉴 비활성화
* `-webkit-user-select`, `-moz-user-select`, `-ms-user-select`, `user-select: none`
  → 텍스트 선택 비활성화

---

#### `input, textarea, select, img, p, span, div, h1~h6`

* `-webkit-user-drag: none`
  → 요소(특히 이미지, 텍스트)의 드래그 동작 비활성화

---

## 문제 상황 및 해결

- 버튼 클릭 시 하이라이트되는 부분 -> 하이라이트 제거
- 모달이나 Input 클릭 시, 화면 넘어갈 때 계속 화면이 확대되는 현상 -> 화면 확대 방지
- 화면 전체가 잡혀서 움직이는 부분 -> 전체 화면 고정
- 텍스트나 이미지 드래그 되는 현상 -> 제거
- 텍스트나 이미지 꾹 눌렀을 때 시스템 설정 뜨는 현상 -> 제거