### PR TITLE
[fix] 주문 리스트 페이지 스크롤 안됨

### DIFF
--- a/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.styled.ts
+++ b/frontend/src/pages/MiniGameResultPage/MiniGameResultPage.styled.ts
@@ -20,6 +20,12 @@ export const ResultList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  height: 100%;
+  overflow: scroll;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 export const PlayerCardWrapper = styled.div<{ isHighlighted?: boolean }>`


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #173 

# 🚀 작업 내용

- 주문 리스트 페이지에서 스크롤이 되도록 아래 `css` 속성을 추가했습니다.

```css
  height: 100%;
  overflow: scroll;

  &::-webkit-scrollbar {
    display: none;
  }
```

# 💬 리뷰 중점사항

중점사항
