### PR TITLE
chore: frontend-cd에서 중첩 와일드카드 경로 수정

### DIFF
--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
                 --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} \
-                --paths "/${{ env.FE_PROD_PATH }}${{ env.FE_CACHE_PATH }}/*"
+                --paths "/${{ env.FE_PROD_PATH }}${{ env.FE_CACHE_PATH }}"

--- a/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.tsx
+++ b/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.tsx
@@ -1,9 +1,9 @@
+import Description from '@/components/@common/Description/Description';
+import Headline1 from '@/components/@common/Headline1/Headline1';
+import Layout from '@/layouts/Layout';
+import { RoundKey } from '@/types/round';
 import { PropsWithChildren } from 'react';
 import * as S from './MiniGameTransition.styled';
-import Layout from '@/layouts/Layout';
-import Headline1 from '@/components/@common/Headline1/Headline1';
-import Description from '@/components/@common/Description/Description';
-import { RoundKey } from '@/types/round';
 
 type Props = {
   prevRound: RoundKey;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🚀 작업 내용

- frontend-cd에서 fe-prod/*/* 중첩 와일드카드 경로 수정
- MiniGameTransition import 순서 변경
