### PR TITLE
[refactor] Input 및 Modal의 X 버튼 아이콘 일원화

### DIFF
--- a/frontend/src/assets/close-icon.svg
+++ b/frontend/src/assets/close-icon.svg
@@ -1,4 +1,0 @@
-<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.8438 4.15625L4.15625 14.8438" stroke="#D1D5DC" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14.8438 14.8438L4.15625 4.15625" stroke="#D1D5DC" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frontend/src/assets/close.svg
+++ b/frontend/src/assets/close.svg
@@ -1,4 +1,0 @@
-<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14.8438 4.15625L4.15625 14.8438" stroke="#585555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14.8438 14.8438L4.15625 4.15625" stroke="#585555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
+++ b/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
@@ -1,9 +1,9 @@
 import { SVGProps } from 'react';
 
-interface Props extends SVGProps<SVGSVGElement> {
+type Props = {
   stroke?: string;
   strokeWidth?: number;
-}
+} & SVGProps<SVGSVGElement>;
 
 const CloseIcon = ({ stroke = '#99A1AF', strokeWidth = 2, ...rest }: Props) => {
   return (

--- a/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
+++ b/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
@@ -5,7 +5,7 @@ interface Props extends SVGProps<SVGSVGElement> {
   strokeWidth?: number;
 }
 
-const CloseIcon = ({ stroke = '#D1D5DC', strokeWidth = 2, ...rest }: Props) => {
+const CloseIcon = ({ stroke = '#99A1AF', strokeWidth = 2, ...rest }: Props) => {
   return (
     <svg
       width="19"

--- a/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
+++ b/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
@@ -1,0 +1,36 @@
+import { SVGProps } from 'react';
+
+interface Props extends SVGProps<SVGSVGElement> {
+  stroke?: string;
+  strokeWidth?: number;
+}
+
+const CloseIcon = ({ stroke = '#D1D5DC', strokeWidth = 2, ...rest }: Props) => {
+  return (
+    <svg
+      width="19"
+      height="19"
+      viewBox="0 0 19 19"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      <path
+        d="M14.8438 4.15625L4.15625 14.8438"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.8438 14.8438L4.15625 4.15625"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default CloseIcon;

--- a/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
+++ b/frontend/src/components/@common/CloseIcon/CloseIcon.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import { SVGProps } from 'react';
 
 type Props = {
@@ -5,7 +6,10 @@ type Props = {
   strokeWidth?: number;
 } & SVGProps<SVGSVGElement>;
 
-const CloseIcon = ({ stroke = '#99A1AF', strokeWidth = 2, ...rest }: Props) => {
+const CloseIcon = ({ stroke, strokeWidth = 2, ...rest }: Props) => {
+  const theme = useTheme();
+  const iconStroke = stroke ?? theme.color.gray[400];
+
   return (
     <svg
       width="19"
@@ -17,14 +21,14 @@ const CloseIcon = ({ stroke = '#99A1AF', strokeWidth = 2, ...rest }: Props) => {
     >
       <path
         d="M14.8438 4.15625L4.15625 14.8438"
-        stroke={stroke}
+        stroke={iconStroke}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M14.8438 14.8438L4.15625 4.15625"
-        stroke={stroke}
+        stroke={iconStroke}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/frontend/src/components/@common/Input/Input.styled.ts
+++ b/frontend/src/components/@common/Input/Input.styled.ts
@@ -53,8 +53,3 @@ export const ClearButton = styled.button<ClearButtonProps>`
   cursor: pointer;
   visibility: ${({ $hasValue }) => ($hasValue ? 'visible' : 'hidden')};
 `;
-
-export const CloseIcon = styled.img`
-  -webkit-user-drag: none;
-  user-select: none;
-`;

--- a/frontend/src/components/@common/Input/Input.tsx
+++ b/frontend/src/components/@common/Input/Input.tsx
@@ -1,5 +1,5 @@
-import CloseIcon from '@/assets/close-icon.svg';
 import { ComponentProps } from 'react';
+import CloseIcon from '../CloseIcon/CloseIcon';
 import * as S from './Input.styled';
 
 type Props = {
@@ -19,7 +19,7 @@ const Input = ({ height = '32px', onClear, value, onChange, ref, ...rest }: Prop
         aria-label="입력 내용 지우기"
         $hasValue={hasValue}
       >
-        <S.CloseIcon src={CloseIcon} />
+        <CloseIcon />
       </S.ClearButton>
     </S.Container>
   );

--- a/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.styled.ts
+++ b/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.styled.ts
@@ -24,8 +24,3 @@ export const CloseButton = styled.button`
   right: 0;
   top: 0;
 `;
-
-export const CloseIcon = styled.img`
-  -webkit-user-drag: none;
-  user-select: none;
-`;

--- a/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
+++ b/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
@@ -1,5 +1,5 @@
-import CloseIcon from '@/assets/close.svg';
 import Headline3 from '@/components/@common/Headline3/Headline3';
+import CloseIcon from '../../CloseIcon/CloseIcon';
 import * as S from './ModalHeader.styled';
 
 type Props = {
@@ -14,7 +14,7 @@ const ModalHeader = ({ title, onClose, showCloseButton = true }: Props) => {
       <Headline3>{title}</Headline3>
       {showCloseButton && (
         <S.CloseButton onClick={onClose}>
-          <S.CloseIcon src={CloseIcon} alt="close-icon" />
+          <CloseIcon stroke="#585555" />
         </S.CloseButton>
       )}
     </S.Container>

--- a/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
+++ b/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
@@ -1,5 +1,6 @@
-import Headline3 from '@/components/@common/Headline3/Headline3';
 import CloseIcon from '@/components/@common/CloseIcon/CloseIcon';
+import Headline3 from '@/components/@common/Headline3/Headline3';
+import { useTheme } from '@emotion/react';
 import * as S from './ModalHeader.styled';
 
 type Props = {
@@ -9,12 +10,14 @@ type Props = {
 };
 
 const ModalHeader = ({ title, onClose, showCloseButton = true }: Props) => {
+  const theme = useTheme();
+
   return (
     <S.Container>
       <Headline3>{title}</Headline3>
       {showCloseButton && (
         <S.CloseButton onClick={onClose}>
-          <CloseIcon stroke="#585555" />
+          <CloseIcon stroke={theme.color.gray[600]} />
         </S.CloseButton>
       )}
     </S.Container>

--- a/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
+++ b/frontend/src/components/@common/Modal/ModalHeader/ModalHeader.tsx
@@ -1,5 +1,5 @@
 import Headline3 from '@/components/@common/Headline3/Headline3';
-import CloseIcon from '../../CloseIcon/CloseIcon';
+import CloseIcon from '@/components/@common/CloseIcon/CloseIcon';
 import * as S from './ModalHeader.styled';
 
 type Props = {

--- a/frontend/src/layouts/Layout.stories.tsx
+++ b/frontend/src/layouts/Layout.stories.tsx
@@ -1,9 +1,9 @@
-import CloseIcon from '@/assets/close.svg';
 import BackButton from '@/components/@common/BackButton/BackButton';
 import Button from '@/components/@common/Button/Button';
-import { ColorKey } from '@/constants/color';
+import CloseIcon from '@/components/@common/CloseIcon/CloseIcon';
 import { ModalProvider } from '@/components/@common/Modal/ModalContext';
 import useModal from '@/components/@common/Modal/useModal';
+import { ColorKey } from '@/constants/color';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { ReactNode } from 'react';
 import Layout from './Layout';
@@ -172,7 +172,7 @@ const ModalWithLayoutComponent = () => {
                   justifyContent: 'center',
                 }}
               >
-                <img src={CloseIcon} alt="닫기" width="19" height="19" />
+                <CloseIcon />
               </button>
             }
             align={['center', 'center', 'start']}

--- a/frontend/src/styles/emotion.d.ts
+++ b/frontend/src/styles/emotion.d.ts
@@ -2,8 +2,8 @@ import '@emotion/react';
 import { theme } from './theme';
 
 declare module '@emotion/react' {
-  export type Theme = {
+  export interface Theme {
     color: typeof theme.color;
     typography: typeof theme.typography;
-  };
+  }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #147 

# 🚀 작업 내용

## 동일한 아이콘 통합

ModalHeader와 Input에 있는 Close(X) 버튼 아이콘이 stroke(색상)과 strokeWidth(두께)을 제외하고 동일한 속성을 가지고 있어서 통합해주었습니다.
이때 동적 스타일링을 위해 tsx 로 만들어 Props로 자유롭게 스타일링 조정 가능하도록 해주었습니다.

기존에는 Input 부분의 strokeWidth가 1.3, ModalHeader 부분의 strokeWidth가 2였는데요, 사실상 2로 통합해도 UI상 큰 문제는 없고 훨씬 또렷하게 화면에 나타나는 것 같다고 느껴서 2로 통일해주었습니다. 사실상 기존과 큰 차이는 없어요!

<img width="454" height="147" alt="image" src="https://github.com/user-attachments/assets/8c7042b3-8949-49da-b71d-dcfb4a35ce09" />

<img width="406" height="80" alt="image" src="https://github.com/user-attachments/assets/e124b04d-1b53-46ff-b9f1-58a0c9e7ab9d" />

## 파일 위치 고민

아이콘 tsx 파일을 어느 위치에 둘까 고민하다가, 우선 `components/common` 하위에 CloseIcon으로 두었습니다.
실질적으로 SVG를 tsx 코드로 인라인(import) 관리하는 경우가 많아진다면 Icon 폴더를 하나 더 감싸줄 생각이었는데, 저희 프로젝트에서는 동적 스타일링이 필요한 SVG가 해당 아이콘을 제외하고는 거의 존재하지 않는 것 같아서 우선은 지금 그대로 두었어요!

## SVG 관리 방식

SVG를 전부 tsx 로 관리할지 아니면 지금처럼 assets에 보관하여 s3 버킷에 올려둘지 고민을 했는데요.
결론적으로는, **동적 스타일링이 필요한 부분은 전자, 단순 정적 파일인 경우에는 assets로 관리**하고자 합니다.

그 이유는 간단하게 말하자면 다음과 같은데요,

**tsx로 관리**
- 장점: 동적 스타일링 유용, 애니메이션이나 인터랙션 쉽게 가능, 즉시 렌더링(별도 네트워크 요청 필요 X)
- 단점: 브라우저 캐싱 불가, CDN 캐싱 불가, 번들 크기 증가(JS 번들 커짐) -> 초기 로딩 속도 저하

**assets 관리**
- 장점: 브라우저 캐싱 활용 가능, 초기 번들 크기 작음, CDN 활용 가능 -> 로딩 속도 향상
- 단점: 이미지 하나 당 HTTP 요청 발생, 로딩 중 깜빡임 이슈, 동적 스타일링 불가능

현재 프로젝트 특성상, SVG 자체보다는 다른 UI 요소에서의 인터랙션이 더 많을 것 같다는 생각이 들어서, 
두 가지 방식을 병행하여, 이미지 렌더링 품질이나 초기 로딩 속도를 잘 고려해서 SVG 목적이나 성격에 따라서 선택적으로 관리하면 좋을 것 같다는 생각이 들었습니다.

## 아이콘 드래그 속성 제거
각 아이콘에 있는 드래그 관련 속성은 `global.css` 에 있는 속성과 중복되고 있어서 제거해주었습니다.
```css
-webkit-user-drag: none;
user-select: none;
```

# 💬 리뷰 중점사항

제가 작성한 내용 중에 궁금한 점이나 제안사항이 있다면 말씀 부탁드립니다!