### PR TITLE
[design] 타이머 진행 방식이 호가 줄어드는 방향으로 변경되도록 개선

### DIFF
--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
@@ -11,7 +11,7 @@ const RADIUS = 45;
 const circumference = 2 * Math.PI * RADIUS;
 
 const CircularProgress = ({ current, total, size = '2rem' }: Props) => {
-  const [strokeDashoffset, setStrokeDashoffset] = useState(circumference);
+  const [strokeDashoffset, setStrokeDashoffset] = useState(0);
 
   useEffect(() => {
     if (total <= 0) {
@@ -20,7 +20,7 @@ const CircularProgress = ({ current, total, size = '2rem' }: Props) => {
     }
 
     const progress = Math.min(1, (total - current + 1) / total);
-    const newStrokeDashoffset = circumference * (1 - progress);
+    const newStrokeDashoffset = circumference * progress;
     setStrokeDashoffset(newStrokeDashoffset);
   }, [current, total]);
 
@@ -35,7 +35,7 @@ const CircularProgress = ({ current, total, size = '2rem' }: Props) => {
           fill="none"
           strokeDasharray={circumference}
           strokeDashoffset={strokeDashoffset}
-          transform="rotate(-90 50 50)"
+          transform="rotate(90 50 50) scale(-1,1) translate(-100, 0)"
         />
       </S.ProgressRing>
       <S.CountText>{current}</S.CountText>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #158 

# 🚀 작업 내용

엠제이가 원하는 바대로 빨간 호가 깎이는 방식으로 개선해봤어요! 방향 자체도 우측에서 우선적으로 깎이도록 수정했습니다.

https://github.com/user-attachments/assets/60114656-a8e3-4b57-a78d-c8ad0ca5b7b8

- `strokeDashoffset` 초깃값 `0`으로 수정
  - 비어있는 부분을 0으로 하여 초기에 빨간 호가 꽉 차있도록 수정
- 진행률에 따른 `strokeDashoffset`을 업데이트할 때, 기존의 `1-진행률`이 아닌 `진행률`대로 계산되도록 수정
  - total이 10일 때 진행률이 0.1이면, 비어있는 공간인 `strokeDashoffset`도 0.1이 되어야함. (즉, 빨간 호가 0.9 차있도록 함)
- 타이머 좌우 반전 적용
  - 기존에는 12시 방향에서 왼쪽으로 진행했는데, 오른쪽으로 진행하도록 수정함

```tsx
// 동일한 코드
transform="rotate(90 50 50) scale(-1,1) translate(-100, 0)" // 1
transform="rotate(-90 50 50) scale(1,-1) translate(0, -100)" // 2
```

**rotate(angle, cx, cy)**: (cx, cy)를 중심으로 angle만큼 회전
- 양수 angle → 반시계 방향
- 음수 angle → 시계 방향
- 기본값 0: 3시 방향에서 시작
따라서, **rotate(0, 50, 50)** 인 경우, 3시 방향에서 반시계 방향으로 빨간 호가 깎임

**scale(1, 1)**: 원래대로 그림
**scale(-1, 1)**: x축 기준 상하 반전
**scale(1, -1)**: y축 기준 좌우 반전

반전은 기준점(0,0)을 기준으로 적용됨 ← 이게 중요 (이것 때문에 나중에 translate 해주는 것임)

**1번 코드)** 0에서 90도 회전한 6시 방향에서 반시계 방향으로 호가 깎이는데, x축 기준으로 반전이 들어가서 12시 방향의 시계 방향으로 바뀜. 근데 반전되면서 원이 원의 지름만큼 이동해버림. 따라서 x축으로 -100을 하여 원래 자리로 돌려놓음

**2번 코드)** 0에서 -90도 회전한 12시 방향에서 반시계 방향으로 호가 깎이는데, y축 기준으로 반전이 들어가서 12시 방향의 시계 방향으로 바뀜. 근데 반전되면서 원이 원의 지름만큼 이동해버림. 따라서 y축으로 -100을 하여 원래 자리로 돌려놓음

