### PR TITLE
[feat] 미니게임 목록 조회 API 기능 구현

### DIFF
--- a/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
@@ -1,29 +1,69 @@
+import { api } from '@/apis/api';
+import { ApiError, NetworkError } from '@/apis/error';
 import GameActionButton from '@/components/@common/GameActionButton/GameActionButton';
 import SectionTitle from '@/components/@composition/SectionTitle/SectionTitle';
+import { useEffect, useState } from 'react';
 import * as S from './MiniGameSection.styled';
-import { useState } from 'react';
+
+type MiniGameType = 'CARD_GAME' | '31_GAME';
+
+const MINI_GAME_NAME_MAP: Record<MiniGameType, string> = {
+  CARD_GAME: '카드게임',
+  '31_GAME': '랜덤 31',
+};
+
+type MiniGames = {
+  miniGameType: MiniGameType;
+}[];
 
 export const MiniGameSection = () => {
-  const [selectedGame, setSelectedGame] = useState<number>(-1);
+  const [selectedMiniGame, setSelectedMiniGame] = useState<string | null>(null);
+  const [miniGames, setMiniGames] = useState<MiniGameType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleGameClick = (gameId: number) => {
-    setSelectedGame(gameId);
+  const handleGameClick = (gameType: string) => {
+    setSelectedMiniGame(gameType);
   };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+
+        const _miniGames = await api.get<MiniGames>('http://api.coffee-shout.com/rooms/minigames');
+        console.log(_miniGames);
+        setMiniGames(_miniGames.map((game) => game.miniGameType));
+      } catch (error) {
+        if (error instanceof ApiError) {
+          setError(error.message);
+        } else if (error instanceof NetworkError) {
+          setError('네트워크 연결을 확인해주세요');
+        } else {
+          setError('알 수 없는 오류가 발생했습니다');
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
 
   return (
     <>
       <SectionTitle title="미니게임" description="미니게임을 선택해주세요" />
       <S.Wrapper>
-        <GameActionButton
-          onClick={() => handleGameClick(0)}
-          isSelected={selectedGame === 0}
-          gameName="카드게임"
-        />
-        <GameActionButton
-          onClick={() => handleGameClick(1)}
-          isSelected={selectedGame === 1}
-          gameName="랜덤31"
-        />
+        {loading && <div>로딩 중...</div>}
+        {!loading && error && <div>{error}</div>}
+        {!loading &&
+          !error &&
+          miniGames.map((miniGame) => (
+            <GameActionButton
+              key={miniGame}
+              isSelected={selectedMiniGame === miniGame}
+              gameName={MINI_GAME_NAME_MAP[miniGame]}
+              onClick={() => handleGameClick(miniGame)}
+            />
+          ))}
       </S.Wrapper>
     </>
   );


### PR DESCRIPTION
# 🔥 연관 이슈

- close #229 

# 🚀 작업 내용

`MiniGameSection`에 미니게임 목록 조회 API 연동했습니다.

# 💬 리뷰 중점사항

미니게임 각 타입별로 미니게임 제목을 매핑해줬는데 괜찮나요?

```tsx
const MINI_GAME_NAME_MAP: Record<MiniGameType, string> = {
  CARD_GAME: '카드게임',
  '31_GAME': '랜덤 31',
};
```

백엔드에서 miniGame 타입 자체를 식별자로 쓰고 있어서 key 자체도 miniGame으로 해줬습니다. 
```tsx
<GameActionButton
  key={miniGame}
  isSelected={selectedMiniGame === miniGame}
  gameName={MINI_GAME_NAME_MAP[miniGame]}
  onClick={() => handleGameClick(miniGame)}
/>
```

### 컨벤션 리뷰
전반적으로 컨벤션 쪽으로 리뷰해주시면 좋을 것 같아요.
기존에 game 부분을 모두 miniGame으로 통일해주었습니다.
근데 아직 좀 이것저것 혼용되어있는 느낌이 들어서 한 번씩 컨벤션 쪽으로 검토해주시면 감사하겠습니다 :)