### PR TITLE
[feat] 방 생성 API 기능 구현

### DIFF
--- a/frontend/src/components/@common/SelectBox/SelectBox.stories.tsx
+++ b/frontend/src/components/@common/SelectBox/SelectBox.stories.tsx
@@ -76,7 +76,10 @@ export const Disabled: Story = {
 };
 
 export const Interactive = () => {
-  const [selectedValue, setSelectedValue] = useState<string>('');
+  const [selectedValue, setSelectedValue] = useState<Option>({
+    value: '',
+    label: '',
+  });
 
   const coffeeOptions: Option[] = [
     { value: 'americano', label: '아이스 아메리카노' },
@@ -95,7 +98,7 @@ export const Interactive = () => {
         </label>
         <SelectBox
           options={coffeeOptions}
-          value={selectedValue}
+          value={selectedValue.label}
           onChange={setSelectedValue}
           placeholder="커피를 선택하세요"
           width="300px"

--- a/frontend/src/components/@common/SelectBox/SelectBox.tsx
+++ b/frontend/src/components/@common/SelectBox/SelectBox.tsx
@@ -14,7 +14,7 @@ export type Props = Omit<ComponentProps<'div'>, 'onChange'> & {
   disabled?: boolean;
   width?: string;
   height?: string;
-  onChange?: (value: string) => void;
+  onChange?: (value: Option) => void;
   onFocus?: () => void;
   onBlur?: () => void;
 };
@@ -29,15 +29,15 @@ const SelectBox = ({
   onChange,
   onFocus,
   onBlur,
-  ...restProps
+  ...rest
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
 
-  const selectedOption = options.find((option) => option.value === value);
+  const selectedOption = options.find((option) => option.label === value);
 
-  const handleOptionClick = (optionValue: string) => {
+  const handleOptionClick = (optionValue: Option) => {
     if (disabled) return;
 
     onChange?.(optionValue);
@@ -92,7 +92,7 @@ const SelectBox = ({
   }, [onBlur]);
 
   return (
-    <S.Container ref={containerRef} $width={width} $height={height} {...restProps}>
+    <S.Container ref={containerRef} $width={width} $height={height} {...rest}>
       <S.Trigger
         ref={triggerRef}
         $disabled={disabled}
@@ -116,8 +116,8 @@ const SelectBox = ({
           <S.Item
             key={option.value}
             $disabled={option.disabled}
-            $selected={option.value === value}
-            onClick={() => !option.disabled && handleOptionClick(option.value)}
+            $selected={option.label === value}
+            onClick={() => !option.disabled && handleOptionClick(option)}
             role="option"
             aria-selected={option.value === value}
           >

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -6,7 +6,7 @@ import Headline3 from '@/components/@common/Headline3/Headline3';
 import SelectBox, { Option } from '@/components/@common/SelectBox/SelectBox';
 import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './EntryMenuPage.styled';
 
 // TODO: category 타입 따로 관리 필요 (string이 아니라 유니온 타입으로 지정해서 아이콘 매핑해야함)
@@ -16,12 +16,26 @@ type MenusResponse = {
   category: string;
 }[];
 
+type CreateRoomRequest = {
+  hostName: string;
+  menuId: number;
+};
+
+type CreateRoomResponse = {
+  joinCode: string;
+};
+
 const EntryMenuPage = () => {
-  const [selectedValue, setSelectedValue] = useState('');
+  const [selectedValue, setSelectedValue] = useState({
+    value: '',
+    label: '',
+  });
+
   const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { state } = useLocation();
 
   useEffect(() => {
     (async () => {
@@ -49,8 +63,32 @@ const EntryMenuPage = () => {
   }, []);
 
   const handleNavigateToName = () => navigate('/entry/name');
-  const handleNavigateToLobby = () => navigate('/room/:roomId/lobby');
-  const isButtonDisabled = selectedValue === '';
+  const handleNavigateToLobby = async () => {
+    if (!state.nickName) {
+      alert('닉네임을 다시 입력해주세요.');
+      navigate(-1);
+      return;
+    }
+
+    const menuId = Number(selectedValue.value);
+    if (menuId === -1) {
+      alert('메뉴를 선택하지 않았습니다.');
+      return;
+    }
+
+    const { joinCode } = await api.post<CreateRoomResponse, CreateRoomRequest>('/rooms', {
+      hostName: state.nickName,
+      menuId,
+    });
+
+    navigate('/room/:roomId/lobby', {
+      state: {
+        joinCode,
+      },
+    });
+  };
+
+  const isButtonDisabled = selectedValue.label === '';
 
   return (
     <Layout>
@@ -65,8 +103,8 @@ const EntryMenuPage = () => {
           ) : (
             <SelectBox
               options={coffeeOptions}
-              value={selectedValue}
-              onChange={setSelectedValue}
+              value={selectedValue.label}
+              onChange={(value: Option) => setSelectedValue(value)}
               placeholder="메뉴를 선택해주세요"
             />
           )}

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -13,7 +13,12 @@ const EntryNamePage = () => {
   const [value, setValue] = useState('');
   const navigate = useNavigate();
 
-  const handleNavigateToMenu = () => navigate('/entry/menu');
+  const handleNavigateToMenu = () =>
+    navigate('/entry/menu', {
+      state: {
+        nickName: value,
+      },
+    });
   const isButtonDisabled = value.length === 0;
 
   return (

--- a/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
+++ b/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
@@ -19,7 +19,10 @@ type Props = {
 
 const MenuModifyModal = ({ onClose }: Props) => {
   // TODO: 현재 메뉴를 초깃값으로 설정 (웹소켓: 현재 본인 메뉴)
-  const [modifiedMenu, setModifiedMenu] = useState<string>('');
+  const [modifiedMenu, setModifiedMenu] = useState<Option>({
+    value: '',
+    label: '',
+  });
   const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +71,7 @@ const MenuModifyModal = ({ onClose }: Props) => {
         <div>{error}</div>
       ) : (
         <SelectBox
-          value={modifiedMenu}
+          value={modifiedMenu.label}
           options={coffeeOptions}
           onChange={(value) => setModifiedMenu(value)}
         />

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -5,6 +6,12 @@ import webpack from 'webpack';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const env = dotenv.config().parsed;
+
+const envKeys = Object.keys(env).reduce((acc, key) => {
+  acc[`process.env.${key}`] = JSON.stringify(env[key]);
+  return acc;
+}, {});
 
 export default {
   entry: './src/main.tsx',
@@ -41,9 +48,7 @@ export default {
     new HtmlWebpackPlugin({
       template: './public/index.html',
     }),
-    new webpack.DefinePlugin({
-      'process.env': JSON.stringify(process.env),
-    }),
+    new webpack.DefinePlugin(envKeys),
   ],
   devServer: {
     compress: true,


### PR DESCRIPTION
# 🔥 연관 이슈

- close #227 

# 🚀 작업 내용

1. `dotenv`을 사용하여 환경 변수를 `webpack`에 정의하는 속성을 추가했습니다.
2. `SelectBox` 컴포넌트에서 선택된 값의 `id`를 받아오기 위해서 기존에 사용했던 `Option` 타입으로 변경해 주었습니다.

```javascript
export type Option = {
  value: string;
  label: string;
  disabled?: boolean;
};
```

3. 방을 생성하는 `api`를 연동했습니다.

# 💬 리뷰 중점사항
중점사항
