### PR TITLE
[refactor] api 요청에 쓰이는 파라미터 이름을 data -> body로 수정

### DIFF
--- a/frontend/src/apis/rest/api.ts
+++ b/frontend/src/apis/rest/api.ts
@@ -2,28 +2,28 @@ import { ApiConfig, apiRequest, ApiRequestOptions } from './apiRequest';
 
 export const api = {
   get: <T>(url: string, options: Omit<ApiRequestOptions<T>, 'method' | 'data'> = {}) =>
-    apiRequest<T, undefined>(url, { ...options, method: 'GET' }),
+    apiRequest<T, undefined>(url, { ...options, method: 'GET', body: undefined }),
 
   post: <T, TData>(
     url: string,
     data?: TData,
     options: Omit<ApiRequestOptions<TData>, 'method' | 'data'> = {}
-  ) => apiRequest<T, TData>(url, { ...options, method: 'POST', data }),
+  ) => apiRequest<T, TData>(url, { ...options, method: 'POST', body: data }),
 
   put: <T, TData>(
     url: string,
     data?: TData,
     options: Omit<ApiRequestOptions<TData>, 'method' | 'data'> = {}
-  ) => apiRequest<T, TData>(url, { ...options, method: 'PUT', data }),
+  ) => apiRequest<T, TData>(url, { ...options, method: 'PUT', body: data }),
 
   patch: <T, TData>(
     url: string,
     data?: TData,
     options: Omit<ApiRequestOptions<TData>, 'method' | 'data'> = {}
-  ) => apiRequest<T, TData>(url, { ...options, method: 'PATCH', data }),
+  ) => apiRequest<T, TData>(url, { ...options, method: 'PATCH', body: data }),
 
   delete: <T>(url: string, options: Omit<ApiRequestOptions<T>, 'method' | 'data'> = {}) =>
-    apiRequest<T, undefined>(url, { ...options, method: 'DELETE' }),
+    apiRequest<T, undefined>(url, { ...options, method: 'DELETE', body: undefined }),
 
   setDefaultConfig: (config: ApiConfig) => {
     api.defaultConfig = { ...api.defaultConfig, ...config };

--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -7,7 +7,7 @@ type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 export type ApiRequestOptions<TData> = {
   method?: Method;
   headers?: Record<string, string>;
-  data?: TData;
+  body?: TData;
   params?: Record<string, string | number | boolean | null | undefined>;
   retry?: {
     count: number;
@@ -28,7 +28,7 @@ export const apiRequest = async <T, TData>(
   const {
     method = 'GET',
     headers = {},
-    data = null,
+    body = null,
     params = null,
     retry = { count: 0, delay: 1000 },
   } = options;
@@ -55,14 +55,14 @@ export const apiRequest = async <T, TData>(
     ...headers,
   };
 
-  const body = data ? JSON.stringify(data) : null;
+  const parsedBody = body ? JSON.stringify(body) : null;
 
   const makeRequest = async (retryCount = 0): Promise<T> => {
     try {
       const fetchOptions: ApiConfig = {
         method: method,
         headers: defaultHeaders,
-        body: method !== 'GET' && body ? body : null,
+        body: method !== 'GET' && parsedBody ? parsedBody : null,
       };
 
       const response = await fetch(requestUrl, fetchOptions);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #243 

# 🚀 작업 내용

1. `api` 요청 시 파라미터 이름을 `data` -> `body`로 수정했습니다.

# 💬 리뷰 중점사항
중점사항
