### PR TITLE
[refactor] WebSocket의 Data파싱과 에러 처리 추가 

### DIFF
--- a/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
@@ -3,6 +3,20 @@ import { Client } from '@stomp/stompjs';
 import { createStompClient } from '../createStompClient';
 import { WebSocketContext, WebSocketContextType } from './WebSocketContext';
 
+type WebSocketSuccess<T> = {
+  success: true;
+  data: T;
+  errorMessage: null;
+};
+
+type WebSocketError = {
+  success: false;
+  data: null;
+  errorMessage: string;
+};
+
+type WebSocketMessage<T> = WebSocketSuccess<T> | WebSocketError;
+
 export const WebSocketProvider = ({ children }: PropsWithChildren) => {
   const [client, setClient] = useState<Client | null>(null);
   const [isConnected, setIsConnected] = useState(false);
@@ -51,7 +65,7 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
 
     return client.subscribe(requestUrl, (message) => {
       try {
-        const parsedMessage = JSON.parse(message.body);
+        const parsedMessage = JSON.parse(message.body) as WebSocketMessage<T>;
         const isSuccess = parsedMessage.success;
 
         if (!isSuccess) {

--- a/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
@@ -51,8 +51,16 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
 
     return client.subscribe(requestUrl, (message) => {
       try {
-        const parsedData = JSON.parse(message.body) as T;
-        onData(parsedData);
+        const parsedMessage = JSON.parse(message.body);
+        const isSuccess = parsedMessage.success;
+
+        if (!isSuccess) {
+          throw new Error(parsedMessage.errorMessage);
+        }
+
+        const data = parsedMessage.data as T;
+
+        onData(data);
       } catch (error) {
         console.error('❌ 데이터 파싱 실패:', error);
       }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #276 

# 🚀 작업 내용

응답 타입 지정을 성공/에러를 나눠서 적용했습니다. 

```js
type WebSocketSuccess<T> = {
  success: true;
  data: T;
  errorMessage: null;
};

type WebSocketError = {
  success: false;
  data: null;
  errorMessage: string;
};
```

isSuccess가 false일때 에러 던지는 로직 추가 
```js
   const parsedMessage = JSON.parse(message.body) as WebSocketMessage<T>;
        const isSuccess = parsedMessage.success;

        if (!isSuccess) {
          throw new Error(parsedMessage.errorMessage);
        }

        const data = parsedMessage.data as T;

```

# 💬 리뷰 중점사항
중점사항
