### PR TITLE
[refactor] 미니게임 선택 시, 항상 리스트로 선택된 게임 서버로 전송

### DIFF
--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -72,22 +72,14 @@ public class RoomService {
                 .toList();
     }
 
-    public List<MiniGameType> selectMiniGame(String joinCode, String hostName, MiniGameType miniGameType) {
+    public List<MiniGameType> updateMiniGames(String joinCode, String hostName, List<MiniGameType> miniGameTypes) {
         final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
-        final Playable miniGame = miniGameType.createMiniGame();
+        room.clearMiniGames();
 
-        room.addMiniGame(new PlayerName(hostName), miniGame);
-
-        return room.getAllMiniGame().stream()
-                .map(Playable::getMiniGameType)
-                .toList();
-    }
-
-    public List<MiniGameType> unselectMiniGame(String joinCode, String hostName, MiniGameType miniGameType) {
-        final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
-        final Playable miniGame = miniGameType.createMiniGame();
-
-        room.removeMiniGame(new PlayerName(hostName), miniGame);
+        miniGameTypes.forEach(miniGameType -> {
+            final Playable miniGame = miniGameType.createMiniGame();
+            room.addMiniGame(new PlayerName(hostName), miniGame);
+        });
 
         return room.getAllMiniGame().stream()
                 .map(Playable::getMiniGameType)

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -148,6 +148,10 @@ public class Room {
         return currentGame;
     }
 
+    public void clearMiniGames() {
+        this.miniGames.clear();
+    }
+
     public boolean hasDuplicatePlayerName(PlayerName guestName) {
         return players.hasDuplicateName(guestName);
     }

--- a/backend/src/main/java/coffeeshout/room/ui/RoomWebSocketController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomWebSocketController.java
@@ -55,19 +55,10 @@ public class RoomWebSocketController {
                 WebSocketResponse.success(responses));
     }
 
-    @MessageMapping("/room/{joinCode}/select-minigames")
-    public void broadcastSelectedMinigames(@DestinationVariable String joinCode, MiniGameSelectMessage message) {
-        final List<MiniGameType> responses = roomService.selectMiniGame(joinCode, message.hostName(),
-                message.miniGameType());
-
-        messagingTemplate.convertAndSend("/topic/room/" + joinCode + "/minigame",
-                WebSocketResponse.success(responses));
-    }
-
-    @MessageMapping("/room/{joinCode}/unselect-minigames")
-    public void broadcastUnselectedMinigames(@DestinationVariable String joinCode, MiniGameSelectMessage message) {
-        final List<MiniGameType> responses = roomService.unselectMiniGame(joinCode, message.hostName(),
-                message.miniGameType());
+    @MessageMapping("/room/{joinCode}/update-minigames")
+    public void broadcastMiniGames(@DestinationVariable String joinCode, MiniGameSelectMessage message) {
+        final List<MiniGameType> responses = roomService.updateMiniGames(joinCode, message.hostName(),
+                message.miniGameTypes());
 
         messagingTemplate.convertAndSend("/topic/room/" + joinCode + "/minigame",
                 WebSocketResponse.success(responses));

--- a/backend/src/main/java/coffeeshout/room/ui/request/MiniGameSelectMessage.java
+++ b/backend/src/main/java/coffeeshout/room/ui/request/MiniGameSelectMessage.java
@@ -2,9 +2,10 @@ package coffeeshout.room.ui.request;
 
 
 import coffeeshout.minigame.domain.MiniGameType;
+import java.util.List;
 
 public record MiniGameSelectMessage(
         String hostName,
-        MiniGameType miniGameType
+        List<MiniGameType> miniGameTypes
 ) {
 }

--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -267,30 +267,12 @@ class RoomServiceTest {
         Room createdRoom = roomService.createRoom(hostName, 1L);
 
         // when
-        List<MiniGameType> selectedMiniGames = roomService.selectMiniGame(createdRoom.getJoinCode().value(), hostName,
-                MiniGameType.CARD_GAME);
+        List<MiniGameType> selectedMiniGames = roomService.updateMiniGames(createdRoom.getJoinCode().value(), hostName,
+                List.of(MiniGameType.CARD_GAME));
 
         // then
         assertThat(selectedMiniGames).hasSize(1);
         assertThat(selectedMiniGames.get(0)).isEqualTo(MiniGameType.CARD_GAME);
-    }
-
-    @Test
-    void 미니게임을_선택_취소한다() {
-        // given
-        String hostName = "호스트";
-        Room createdRoom = roomService.createRoom(hostName, 1L);
-        roomService.selectMiniGame(createdRoom.getJoinCode().value(), hostName, MiniGameType.CARD_GAME);
-
-        // when
-        List<MiniGameType> selectedMiniGames = roomService.unselectMiniGame(
-                createdRoom.getJoinCode().value(),
-                hostName,
-                MiniGameType.CARD_GAME
-        );
-
-        // then
-        assertThat(selectedMiniGames).isEmpty();
     }
 
     @Test
@@ -303,7 +285,9 @@ class RoomServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> roomService.selectMiniGame(createdRoom.getJoinCode().value(), guestName, MiniGameType.CARD_GAME))
+                () -> roomService.updateMiniGames(createdRoom.getJoinCode().value(),
+                        guestName,
+                        List.of(MiniGameType.CARD_GAME)))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -314,11 +298,11 @@ class RoomServiceTest {
         String guestName = "게스트";
         Room createdRoom = roomService.createRoom(hostName, 1L);
         roomService.enterRoom(createdRoom.getJoinCode().value(), guestName, 2L);
-        roomService.selectMiniGame(createdRoom.getJoinCode().value(), hostName, MiniGameType.CARD_GAME);
+        roomService.updateMiniGames(createdRoom.getJoinCode().value(), hostName, List.of(MiniGameType.CARD_GAME));
 
         // when & then
-        assertThatThrownBy(() -> roomService.unselectMiniGame(createdRoom.getJoinCode().value(), guestName,
-                MiniGameType.CARD_GAME))
+        assertThatThrownBy(() -> roomService.updateMiniGames(createdRoom.getJoinCode().value(), guestName,
+                List.of(MiniGameType.CARD_GAME)))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/backend/src/test/java/coffeeshout/room/ui/RoomWebSocketControllerTest.java
+++ b/backend/src/test/java/coffeeshout/room/ui/RoomWebSocketControllerTest.java
@@ -127,7 +127,8 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
         // when
         MessageCollector<WebSocketResponse<List<PlayerResponse>>> subscribe = session.subscribe(
                 "/topic/room/" + nonExistentJoinCode,
-                new TypeReference<WebSocketResponse<List<PlayerResponse>>>() {}
+                new TypeReference<WebSocketResponse<List<PlayerResponse>>>() {
+                }
         );
 
         // then
@@ -206,7 +207,7 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
                 }
         );
 
-        MiniGameSelectMessage message = new MiniGameSelectMessage("호스트꾹이", MiniGameType.CARD_GAME);
+        MiniGameSelectMessage message = new MiniGameSelectMessage("호스트꾹이", List.of(MiniGameType.CARD_GAME));
         session.send("/app/room/" + joinCode + "/minigames/select", message);
 
         List<MiniGameType> responses = subscribe.get().data();
@@ -227,7 +228,7 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
                 }
         );
 
-        MiniGameSelectMessage message = new MiniGameSelectMessage("호스트꾹이", MiniGameType.CARD_GAME);
+        MiniGameSelectMessage message = new MiniGameSelectMessage("호스트꾹이", List.of(MiniGameType.CARD_GAME));
         session.send("/app/room/" + joinCode + "/minigames/select", message);
 
         List<MiniGameType> responses = subscribe.get().data();
@@ -235,7 +236,7 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
         assertThat(responses.get(0)).isEqualTo(MiniGameType.CARD_GAME);
 
         // when
-        MiniGameSelectMessage message2 = new MiniGameSelectMessage("호스트꾹이", MiniGameType.CARD_GAME);
+        MiniGameSelectMessage message2 = new MiniGameSelectMessage("호스트꾹이", List.of(MiniGameType.CARD_GAME));
         session.send("/app/room/" + joinCode + "/minigames/unselect", message2);
 
         List<MiniGameType> responses2 = subscribe.get().data();
@@ -256,14 +257,14 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
                 "/topic/room/" + joinCode + "/minigame", new TypeReference<>() {
                 }
         );
-        
-        MiniGameSelectMessage selectMessage = new MiniGameSelectMessage(hostName, MiniGameType.CARD_GAME);
+
+        MiniGameSelectMessage selectMessage = new MiniGameSelectMessage(hostName, List.of(MiniGameType.CARD_GAME));
         session.send("/app/room/" + joinCode + "/minigames/select", selectMessage);
-        
+
         // 미니게임 선택 응답 확인
         List<MiniGameType> selectedGames = miniGameSubscribe.get().data();
         assertThat(selectedGames).hasSize(1);
-        
+
         // 미니게임을 시작해서 방 상태를 PLAYING으로 변경
         testRoom.startNextGame(hostName);
 
@@ -281,11 +282,11 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
         // then
         assertThat(response.success()).isTrue();
         assertThat(response.data()).isNotNull();
-        
+
         PlayerResponse winner = response.data();
         assertThat(winner.playerName()).isNotBlank();
         assertThat(winner.menuResponse()).isNotNull();
-        
+
         // 선택된 패배자는 방에 있는 플레이어 중 하나여야 함
         List<String> playerNames = List.of("호스트꾹이", "플레이어한스", "플레이어루키", "플레이어엠제이");
         assertThat(playerNames).contains(winner.playerName());


### PR DESCRIPTION


# 🔥 연관 이슈

- close #296 

# 🚀 작업 내용

- select/unselectMiniGame 메서드 제거 및 updateMiniGames 메서드 도입
- Room 객체의 미니게임 초기화 메서드(clearMiniGames) 추가
- MiniGameSelectMessage의 miniGameType 필드를 miniGameTypes(List)로 변경
- WebSocket 요청 URL을 update-minigames로 통합
- 관련 테스트 코드 수정 및 매핑 로직 반영

# 💬 리뷰 중점사항
중점사항
