### PR TITLE
[feat] 미니 게임 선택 웹소켓 연동

### DIFF
--- a/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
@@ -1,5 +1,5 @@
-import { useState, PropsWithChildren } from 'react';
 import { Client } from '@stomp/stompjs';
+import { PropsWithChildren, useState } from 'react';
 import { createStompClient } from '../createStompClient';
 import { WebSocketContext, WebSocketContextType } from './WebSocketContext';
 
@@ -81,7 +81,7 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
     });
   };
 
-  const send = <T,>(url: string, body: T | null = null) => {
+  const send = <T,>(url: string, body?: T) => {
     if (!client || !isConnected) {
       console.warn('❌ 메시지 전송 실패: WebSocket 연결 안됨');
       return;
@@ -89,9 +89,18 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
 
     const requestUrl = '/app' + url;
 
+    let payload: string;
+    if (body == null) {
+      payload = '';
+    } else if (typeof body === 'object') {
+      payload = JSON.stringify(body);
+    } else {
+      payload = String(body);
+    }
+
     client.publish({
       destination: requestUrl,
-      body: JSON.stringify(body),
+      body: payload,
     });
   };
 

--- a/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
@@ -1,23 +1,16 @@
 import { StompSubscription } from '@stomp/stompjs';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useWebSocket } from '../contexts/WebSocketContext';
 
 export const useWebSocketSubscription = <T>(destination: string, onData: (data: T) => void) => {
   const { subscribe, isConnected } = useWebSocket();
   const subscriptionRef = useRef<StompSubscription | null>(null);
 
-  const memoizedOnData = useCallback(
-    (data: T) => {
-      onData(data);
-    },
-    [onData]
-  );
-
   useEffect(() => {
     if (!isConnected) return;
 
     try {
-      const subscription = subscribe<T>(destination, memoizedOnData);
+      const subscription = subscribe<T>(destination, onData);
       subscriptionRef.current = subscription;
 
       return () => {
@@ -29,5 +22,5 @@ export const useWebSocketSubscription = <T>(destination: string, onData: (data: 
     } catch (error) {
       console.error('❌ 웹소켓 구독 실패:', error);
     }
-  }, [isConnected, subscribe, destination, memoizedOnData]);
+  }, [isConnected, subscribe, destination, onData]);
 };

--- a/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
@@ -1,16 +1,23 @@
-import { useEffect, useRef } from 'react';
 import { StompSubscription } from '@stomp/stompjs';
+import { useCallback, useEffect, useRef } from 'react';
 import { useWebSocket } from '../contexts/WebSocketContext';
 
 export const useWebSocketSubscription = <T>(destination: string, onData: (data: T) => void) => {
   const { subscribe, isConnected } = useWebSocket();
   const subscriptionRef = useRef<StompSubscription | null>(null);
 
+  const memoizedOnData = useCallback(
+    (data: T) => {
+      onData(data);
+    },
+    [onData]
+  );
+
   useEffect(() => {
     if (!isConnected) return;
 
     try {
-      const subscription = subscribe<T>(destination, onData);
+      const subscription = subscribe<T>(destination, memoizedOnData);
       subscriptionRef.current = subscription;
 
       return () => {
@@ -22,5 +29,5 @@ export const useWebSocketSubscription = <T>(destination: string, onData: (data: 
     } catch (error) {
       console.error('❌ 웹소켓 구독 실패:', error);
     }
-  }, [isConnected, subscribe, destination, onData]);
+  }, [isConnected, subscribe, destination, memoizedOnData]);
 };

--- a/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
@@ -16,15 +16,15 @@ type MiniGamesResponse = {
   miniGameType: MiniGameType;
 }[];
 
-export const MiniGameSection = () => {
-  const [selectedMiniGame, setSelectedMiniGame] = useState<string | null>(null);
+type Props = {
+  selectedMiniGames: string[];
+  handleMiniGameClick: (miniGameType: string) => void;
+};
+
+export const MiniGameSection = ({ selectedMiniGames, handleMiniGameClick }: Props) => {
   const [miniGames, setMiniGames] = useState<MiniGameType[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const handleMiniGameClick = (miniGameType: string) => {
-    setSelectedMiniGame(miniGameType);
-  };
 
   useEffect(() => {
     (async () => {
@@ -46,22 +46,21 @@ export const MiniGameSection = () => {
     })();
   }, []);
 
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div>{error}</div>;
+
   return (
     <>
       <SectionTitle title="미니게임" description="미니게임을 선택해주세요" />
       <S.Wrapper>
-        {loading && <div>로딩 중...</div>}
-        {!loading && error && <div>{error}</div>}
-        {!loading &&
-          !error &&
-          miniGames.map((miniGame) => (
-            <GameActionButton
-              key={miniGame}
-              isSelected={selectedMiniGame === miniGame}
-              gameName={MINI_GAME_NAME_MAP[miniGame]}
-              onClick={() => handleMiniGameClick(miniGame)}
-            />
-          ))}
+        {miniGames.map((miniGame) => (
+          <GameActionButton
+            key={miniGame}
+            isSelected={selectedMiniGames.includes(miniGame)}
+            gameName={MINI_GAME_NAME_MAP[miniGame]}
+            onClick={() => handleMiniGameClick(miniGame)}
+          />
+        ))}
       </S.Wrapper>
     </>
   );

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -64,7 +64,7 @@ const LobbyPage = () => {
     setSelectedMiniGames(updatedMiniGames);
 
     send(
-      `/room/${joinCode}/select-minigames`,
+      `/room/${joinCode}/update-minigames`,
       JSON.stringify({
         hostName: playerType,
         miniGameType: updatedMiniGames,

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -36,7 +36,7 @@ const LobbyPage = () => {
   useWebSocketSubscription<MiniGameResponse>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleClickBackButton = () => {
-    navigate(-1);
+    navigate('/');
   };
 
   const handleClickGameStartButton = () => {

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -22,12 +22,12 @@ type MiniGameResponse = string[];
 
 const LobbyPage = () => {
   const navigate = useNavigate();
+  const { send } = useWebSocket();
   const { openModal } = useModal();
   const { playerType } = usePlayerType();
-  const { joinCode } = useIdentifier();
-  const { send } = useWebSocket();
+  const { joinCode, myName } = useIdentifier();
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
-  const [selectedMiniGames, setSelectedMiniGames] = useState<string[]>([]);
+  const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameResponse>([]);
 
   const handleMiniGameData = useCallback((data: MiniGameResponse) => {
     setSelectedMiniGames(data);
@@ -63,13 +63,10 @@ const LobbyPage = () => {
 
     setSelectedMiniGames(updatedMiniGames);
 
-    send(
-      `/room/${joinCode}/update-minigames`,
-      JSON.stringify({
-        hostName: playerType,
-        miniGameType: updatedMiniGames,
-      })
-    );
+    send(`/room/${joinCode}/update-minigames`, {
+      hostName: myName,
+      miniGameTypes: updatedMiniGames,
+    });
   };
 
   const SECTIONS: SectionComponents = {

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -1,11 +1,14 @@
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
+import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import ShareIcon from '@/assets/share-icon.svg';
 import BackButton from '@/components/@common/BackButton/BackButton';
 import Button from '@/components/@common/Button/Button';
 import useModal from '@/components/@common/Modal/useModal';
 import ToggleButton from '@/components/@common/ToggleButton/ToggleButton';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import Layout from '@/layouts/Layout';
-import { ReactElement, useState } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import JoinCodeModal from '../components/JoinCodeModal/JoinCodeModal';
 import { MiniGameSection } from '../components/MiniGameSection/MiniGameSection';
@@ -13,25 +16,24 @@ import { ParticipantSection } from '../components/ParticipantSection/Participant
 import { RouletteSection } from '../components/RouletteSection/RouletteSection';
 import * as S from './LobbyPage.styled';
 
-type SectionType = '참가자' | '룰렛' | '미니게임';
-type SectionComponents = {
-  [K in SectionType]: ReactElement;
-};
-
-const SECTIONS: SectionComponents = {
-  참가자: <ParticipantSection />,
-  룰렛: <RouletteSection />,
-  미니게임: <MiniGameSection />,
-} as const;
+export type SectionType = '참가자' | '룰렛' | '미니게임';
+type SectionComponents = Record<SectionType, ReactElement>;
+type MiniGameResponse = string[];
 
 const LobbyPage = () => {
   const navigate = useNavigate();
   const { openModal } = useModal();
   const { playerType } = usePlayerType();
+  const { joinCode } = useIdentifier();
+  const { send } = useWebSocket();
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
+  const [selectedMiniGames, setSelectedMiniGames] = useState<string[]>([]);
 
-  //TODO: 다른 에러 처리방식을 찾아보기
-  if (!playerType) return null;
+  const handleMiniGameData = useCallback((data: MiniGameResponse) => {
+    setSelectedMiniGames(data);
+  }, []);
+
+  useWebSocketSubscription<MiniGameResponse>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleClickBackButton = () => {
     navigate(-1);
@@ -51,6 +53,37 @@ const LobbyPage = () => {
       showCloseButton: true,
     });
   };
+
+  const handleMiniGameClick = (miniGameType: string) => {
+    if (playerType === 'GUEST') return;
+
+    const updatedMiniGames = selectedMiniGames.includes(miniGameType)
+      ? selectedMiniGames.filter((game) => game !== miniGameType)
+      : [...selectedMiniGames, miniGameType];
+
+    setSelectedMiniGames(updatedMiniGames);
+
+    send(
+      `/room/${joinCode}/select-minigames`,
+      JSON.stringify({
+        hostName: playerType,
+        miniGameType: updatedMiniGames,
+      })
+    );
+  };
+
+  const SECTIONS: SectionComponents = {
+    참가자: <ParticipantSection />,
+    룰렛: <RouletteSection />,
+    미니게임: (
+      <MiniGameSection
+        selectedMiniGames={selectedMiniGames}
+        handleMiniGameClick={handleMiniGameClick}
+      />
+    ),
+  };
+
+  if (!playerType) return null;
 
   return (
     <Layout>


### PR DESCRIPTION
# 🔥 연관 이슈

- close #297 

# 🚀 작업 내용

## 상태 유지 목적의 상위로직 분리

선택한 미니게임 상태를 MiniGameSection이 아니라 LobbyPage 에서 useState로 관리해서 Props로 내려주었습니다. 왜냐하면, 토글이 계속 이동해도 상태가 유지되기 위함입니다.

## Props 전달을 위한 SECTIONS 이동

넘겨주는 과정에서 Props를 넘겨주기 위해 SECTIONS 객체를 외부에서 컴포넌트 내부로 옮겼습니다.

```tsx
  const SECTIONS: SectionComponents = {
    참가자: <ParticipantSection />,
    룰렛: <RouletteSection />,
    미니게임: (
      <MiniGameSection
        selectedMiniGames={selectedMiniGames}
        handleMiniGameClick={handleMiniGameClick}
      />
    ),
  };
```

## WebSocket 재구독 방지를 위한 콜백 메모이제이션

`useWebSocketSubscription`에서 두 번째 인자로 들어가는 onData를 메모이제이션 해줘야하는데, 해당 훅 내부에서는 안되고, 그 외부에서 감싸서 넘겨줘야 하더라구요.. 왜 안에서 감쌌을때 안되는지 모르겠지만, 일단 외부에서 감싸서 메모이제이션 해줬습니다. 이러면 onData가 실제로 변경될 때만 재생성되게 하여, SEND 할 때 unsubscribe -> subscribe 이렇게 다시 재구독 되는 동작을 막아둘 수 있습니다. 

```tsx
  const handleMiniGameData = useCallback((data: MiniGameResponse) => {
    setSelectedMiniGames(data);
  }, []);

  useWebSocketSubscription<MiniGameResponse>(`/room/${joinCode}/minigame`, handleMiniGameData);
```

## 뒤로가기 대신 루트 경로로 리디렉션

https://github.com/woowacourse-teams/2025-coffee-shout/pull/304/commits/9bdd2aef9749be497b7e8975cae08859551aa025

`handleClickBackButton` 의 라우팅 경로도 변경해주었는데요, 원래는 `-1`이었는데, 이렇게 하니까 계속 뒤로가기 버튼을 누르면 `ParticipantSection`에 계속 머무르더라구요. 그래서 아예 `'/'` 이렇게 메인 화면으로 넘어가도록 수정해줬습니다. 닉네임과 메뉴 페이지로 돌아가진 않아요! 아예 처음부터 입력하도록 완전히 루트 경로로 해놨어요. 추후에 이 부분에 "지금 돌아가시면 방을 다시 만들어야/들어와야 합니다." 뭐 이런 경고 메시지를 띄우고 사용자가 다시 선택할 수 있도록 해줘도 좋을 것 같아요. 


## WebSocket send 요청의 타입 및 필드 정리: Request body가 있는 요청 응답 반환 이슈 해결

https://github.com/woowacourse-teams/2025-coffee-shout/pull/304/commits/f8f269a2ff0440165b06f49c9f9958932b100bd4

request body가 있는 요청(send)에 대한 응답이 제대로 오지 않는 이슈를 해결했습니다.
  - `JSON.stringify` 중복으로 2번 적용되는 문제 해결 (send 사용하는 곳에서 한 번, client.publish 해주는 곳에서 한 번, 총 2번 사용하고 있었음)
  - miniGameType -> miniGameTypes
  - hostName을 playerType이 아니라 myName으로 변경
  - send 메서드 타입을 WebSocketContextType에 있는 send 타입과 동일하게 맞추어주었습니다. (`body?: T` 로 통일)
    - body: T | null = null
    - body?: T
  - 실제로 `client.publish` 할때 쓰는 타입은 `body?: string`이기 때문에 `body?: T`로 하여, T 타입을 각 타입이 뭔지에 따라서 다른 방식으로 문자열(string)으로 변환해주었습니다.


# 참고 사항

**`body == null`** 이 코드는 **`body === null || body === undefined`** 이것과 동일하다고 합니다!

보통은, `==` (느슨한 동등비교)는 암묵적 타입 변환이 일어나기 때문에 예측하기 어렵고 위험해서 피하라고 하잖아요!
하지만, `== null`은 정확히 `null`과 `undefined`만 `true`로 처리해줘서, 이 경우에만 안전하게 사용 가능하다고 합니다.

그래서 **`body == null`** 이걸 사용해줬어요~!

# 제안 사항

1. 저희 useWebSocketSubscription 훅 사용할 때 사용하는 타입명이랑 onData 콜백함수명 컨벤션 정하면 좋을 것 같아요!
2. 저희 웹소켓에서 `client`는 외부에서 직접 사용할 일이 없을 것 같고, 사용하게 되더라도 내부 프로퍼티를 가공해 함수나 변수 형태로 노출하게 될 것 같아요. 그런 점에서 `client` 자체는 아예 외부로 노출하지 않고 은닉화하는 게 더 좋을 것 같다는 생각이 드는데, 다들 어떻게 생각하시나요?!
```tsx
// 해당 상태
client: Client | null;
```