### PR TITLE
[feat] 참여코드 존재여부 조회 API 기능 구현

### DIFF
--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -73,9 +73,14 @@ export const apiRequest = async <T, TData>(
 
         try {
           const contentType = response.headers.get('content-type');
-          if (contentType && contentType.includes('application/json')) {
+
+          if (
+            contentType &&
+            (contentType.includes('application/json') ||
+              contentType.includes('application/problem+json'))
+          ) {
             errorData = await response.json();
-            errorMessage = errorData.message || errorData.error || errorMessage;
+            errorMessage = errorData.detail;
           } else {
             const textError = await response.text();
             errorMessage = textError || errorMessage;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #256 

# 🚀 작업 내용

https://github.com/user-attachments/assets/94c9002a-6fd3-41af-832c-87c0c5c7fe7f

1. 참여코드 존재 여부 확인을 위한 `api`를 연동하고 예외 처리를 진행했습니다.
2. 사용자의 불편함을 줄이고자 `toUpperCase()`로 참여 코드를 소문자로 입력해도 대문자로 변환되도록 처리했습니다.
3. 현재 연결을 시도하는 `api` 응답값의 `contentType`이 `application/problem+json`으로 넘어와서 기존 `apiRequest`함수 내부에서 제대로 된 에러 메세지를 처리하지 못하는 문제가 있었습니다. 이를 해결하기 위해 `json`으로 파싱하는 조건문을 수정했습니다.

```javascript
if (contentType && (contentType.includes('application/json') || contentType.includes('application/problem+json'))) {
       errorData = await response.json();
       errorMessage = errorData.detail;
}
```


# 💬 참고 사항
일단은 지금 사용자한테 보여주는 `errorMessage`를 `errorData.detail`의 값을 받아오는걸로 설정이 되어 있는데, 추후 에러 코드로 변환하는 작업이 필요할 것 같아서
이건 따로 이슈 파서 진행하겠습니다 ~

```javascript
errorData = await response.json();
errorMessage = errorData.detail; // 백엔드에서 넘겨받는 에러 메세지 
```
<img width="310" height="153" alt="스크린샷 2025-07-30 오후 9 08 31" src="https://github.com/user-attachments/assets/b1d77c2e-edf6-4420-a5bf-ff930709a490" />
