### PR TITLE
[feat] heart beat 설정 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/WebSocketConfig.java
@@ -1,7 +1,7 @@
 package coffeeshout.global.config;
 
 
-import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.TaskScheduler;
@@ -11,10 +11,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
-@AllArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final TaskScheduler taskScheduler;
+
+    public WebSocketConfig(@Qualifier("webSocketHeartBeatScheduler") TaskScheduler taskScheduler) {
+        this.taskScheduler = taskScheduler;
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {

--- a/backend/src/main/java/coffeeshout/global/config/WebSocketSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/WebSocketSchedulerConfig.java
@@ -9,12 +9,21 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 public class WebSocketSchedulerConfig {
 
-    @Bean
-    @Primary
+    @Bean(name = "webSocketHeartBeatScheduler")
     public TaskScheduler heartBeatMessageBrokerTaskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(1);
         scheduler.setThreadNamePrefix("wss-heartbeat-thread-");
+        scheduler.initialize();
+        return scheduler;
+    }
+
+    @Bean
+    @Primary
+    public TaskScheduler customMessageBrokerTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("default-scheduler-");
         scheduler.initialize();
         return scheduler;
     }


### PR DESCRIPTION
# 🔥 연관 이슈

- close #311 

# 🚀 작업 내용

1. 웹소켓이 연결되었는지 헬스체크를 하기 위해서 heart beat라는 것을 이용합니다.
2. 설정된 시간에 따라 주기적으로 요청을 ping해서 응답(pong)이 오는지 확인해서 연결이 유지되었는지 확인하는 구조입니다.
3. 서버에서 heart beat를 처리할 스케줄러를 만들어줘야 활용할 수 있는 기능이기 때문에 설정을 추가했습니다.
4. heart beat에서 사용하는 스케줄러와 메시지 브로커 스케줄러를 분리

# 💬 리뷰 중점사항
중점사항
