### PR TITLE
[feat] 미니게임 시작 웹소켓 연동 

### DIFF
--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -117,7 +117,7 @@ const EntryMenuPage = () => {
         }
       );
       setJoinCode(_joinCode);
-      navigate(`/room/${_joinCode}/lobby`);
+      startSocket();
     };
 
     try {

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -36,7 +36,8 @@ const LobbyPage = () => {
     [joinCode]
   );
 
-  useWebSocketSubscription(`/room/${joinCode}/round`, (nextMiniGame: MiniGameType) => {
+  useWebSocketSubscription(`/room/${joinCode}/round`, (data: { miniGameType: MiniGameType }) => {
+    const { miniGameType: nextMiniGame } = data;
     handleGameStart(nextMiniGame);
   });
 

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -41,7 +41,7 @@ const LobbyPage = () => {
       const { miniGameType: nextMiniGame } = data;
       navigate(`/room/${joinCode}/${nextMiniGame}/ready`);
     },
-    [joinCode]
+    [joinCode, navigate]
   );
 
   useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -37,16 +37,14 @@ const LobbyPage = () => {
   useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleGameStart = useCallback(
-    (nextMiniGame: MiniGameType) => {
+    (data: { miniGameType: MiniGameType }) => {
+      const { miniGameType: nextMiniGame } = data;
       navigate(`/room/${joinCode}/${nextMiniGame}/ready`);
     },
     [joinCode]
   );
 
-  useWebSocketSubscription(`/room/${joinCode}/round`, (data: { miniGameType: MiniGameType }) => {
-    const { miniGameType: nextMiniGame } = data;
-    handleGameStart(nextMiniGame);
-  });
+  useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);
 
   const handleClickBackButton = () => {
     navigate('/');

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -28,6 +28,13 @@ const LobbyPage = () => {
   const { openModal } = useModal();
   const { playerType } = usePlayerType();
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
+  const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
+
+  const handleMiniGameData = useCallback((data: MiniGameType[]) => {
+    setSelectedMiniGames(data);
+  }, []);
+
+  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleGameStart = useCallback(
     (nextMiniGame: MiniGameType) => {
@@ -40,14 +47,6 @@ const LobbyPage = () => {
     const { miniGameType: nextMiniGame } = data;
     handleGameStart(nextMiniGame);
   });
-
-  const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
-
-  const handleMiniGameData = useCallback((data: MiniGameType[]) => {
-    setSelectedMiniGames(data);
-  }, []);
-
-  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleClickBackButton = () => {
     navigate('/');


### PR DESCRIPTION
# 🔥 연관 이슈

- close #301 

# 🚀 작업 내용


시작 버튼을 누르면 send가 보내지고 
```js
  const handleClickGameStartButton = () => {
    send(`/room/${joinCode}/minigame/command`, {
      commandType: 'START_MINI_GAME',
      commandRequest: {
        hostName: myName,
      },
    });
  };
```
메세지가 오면 game ready 페이지로 이동하도록 구현했습니다.
기존에 seletecedMinigames[0] 으로 설정되어있던 경로를 서버에서 받아온 MiniGameType 데이터로 변경했습니다 
```js
  const handleGameStart = useCallback(
    (data: { miniGameType: MiniGameType }) => {
      const { miniGameType: nextMiniGame } = data;
      navigate(`/room/${joinCode}/${nextMiniGame}/ready`);
    },
    [joinCode]
  );

  useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);


```


# 💬 리뷰 중점사항
중점사항
