### PR TITLE
[feat] 게임 상태 실시간 업데이트 웹소켓 연동 

### DIFF
--- a/frontend/src/contexts/CardGame/CardGameContext.ts
+++ b/frontend/src/contexts/CardGame/CardGameContext.ts
@@ -1,4 +1,4 @@
-import { CardGameState } from '@/types/miniGame';
+import { CardGameState, CardInfo } from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { createContext, useContext } from 'react';
 
@@ -7,6 +7,7 @@ type CardGameContextType = {
   isTransition: boolean;
   currentRound: RoundKey;
   currentCardGameState: CardGameState;
+  cardInfos: CardInfo[];
 };
 
 export const CardGameContext = createContext<CardGameContextType | null>(null);

--- a/frontend/src/contexts/CardGame/CardGameContext.ts
+++ b/frontend/src/contexts/CardGame/CardGameContext.ts
@@ -1,6 +1,13 @@
+import { CardGameState } from '@/types/miniGame';
+import { RoundKey } from '@/types/round';
 import { createContext, useContext } from 'react';
 
-type CardGameContextType = {};
+type CardGameContextType = {
+  startCardGame: boolean;
+  isTransition: boolean;
+  currentRound: RoundKey;
+  currentCardGameState: CardGameState;
+};
 
 export const CardGameContext = createContext<CardGameContextType | null>(null);
 

--- a/frontend/src/contexts/CardGame/CardGameContext.ts
+++ b/frontend/src/contexts/CardGame/CardGameContext.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+type CardGameContextType = {};
+
+export const CardGameContext = createContext<CardGameContextType | null>(null);
+
+export const useCardGame = () => {
+  const context = useContext(CardGameContext);
+  if (!context) {
+    throw new Error('useCardGame는 CardGameProvider 안에서 사용해야 합니다.');
+  }
+  return context;
+};

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -1,0 +1,12 @@
+import { CardGameContext } from './CardGameContext';
+import { PropsWithChildren } from 'react';
+import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
+import { useIdentifier } from '../Identifier/IdentifierContext';
+
+export const CardGameProvider = ({ children }: PropsWithChildren) => {
+  const { joinCode } = useIdentifier();
+  useWebSocketSubscription(`/room/${joinCode}/gameState`, (data: any) => {
+    console.log(data);
+  });
+  return <CardGameContext.Provider value={{}}>{children}</CardGameContext.Provider>;
+};

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, useCallback, useState } from 'react';
 import { CardGameContext } from './CardGameContext';
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '../Identifier/IdentifierContext';
-import { CardGameState, CardGameStateData } from '@/types/miniGame';
+import { CardGameState, CardGameStateData, CardInfo } from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -14,31 +14,46 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
   const [isTransition, setIsTransition] = useState(false);
   const [currentRound, setCurrentRound] = useState<RoundKey>(1);
   const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
+  const [cardInfos, setCardInfos] = useState<CardInfo[]>([]);
 
-  const handleCardGameState = useCallback((data: CardGameStateData) => {
-    if (data.cardGameState === 'PLAYING' && data.currentRound === 'FIRST') {
-      setStartCardGame(true);
-    }
-    if (data.cardGameState === 'LOADING' && data.currentRound === 'SECOND') {
-      setIsTransition(true);
-      setCurrentRound(2);
-      setCurrentCardGameState('LOADING');
-    }
-    if (data.cardGameState === 'PLAYING' && data.currentRound === 'SECOND') {
-      setIsTransition(false);
-      setCurrentCardGameState('PLAYING');
-    }
-    if (data.cardGameState === 'DONE') {
-      navigate(`/room/${joinCode}/${miniGameType}/result`);
-    }
-    console.log(data);
-  }, []);
+  const handleCardGameState = useCallback(
+    (data: CardGameStateData) => {
+      const { cardGameState, currentRound, cardInfoMessages } = data;
+
+      const isFirstRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'FIRST';
+      const isSecondRoundLoading = cardGameState === 'LOADING' && currentRound === 'SECOND';
+      const isSecondRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'SECOND';
+      const isGameDone = cardGameState === 'DONE';
+
+      if (isFirstRoundPlaying) {
+        setStartCardGame(true);
+        setCardInfos(cardInfoMessages);
+      }
+
+      if (isSecondRoundLoading) {
+        setIsTransition(true);
+        setCurrentRound(2);
+        setCurrentCardGameState('LOADING');
+        setCardInfos(cardInfoMessages);
+      }
+
+      if (isSecondRoundPlaying) {
+        setIsTransition(false);
+        setCurrentCardGameState('PLAYING');
+      }
+
+      if (isGameDone) {
+        navigate(`/room/${joinCode}/${miniGameType}/result`);
+      }
+    },
+    [navigate, joinCode, miniGameType]
+  );
 
   useWebSocketSubscription(`/room/${joinCode}/gameState`, handleCardGameState);
 
   return (
     <CardGameContext.Provider
-      value={{ startCardGame, isTransition, currentRound, currentCardGameState }}
+      value={{ startCardGame, isTransition, currentRound, currentCardGameState, cardInfos }}
     >
       {children}
     </CardGameContext.Provider>

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -23,6 +23,7 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
       const isFirstRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'FIRST';
       const isSecondRoundLoading = cardGameState === 'LOADING' && currentRound === 'SECOND';
       const isSecondRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'SECOND';
+      const isSecondRoundScoreBoard = cardGameState === 'SCORE_BOARD' && currentRound === 'SECOND';
       const isGameDone = cardGameState === 'DONE';
 
       if (isFirstRoundPlaying) {
@@ -41,7 +42,9 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         setCardInfos(cardInfoMessages);
         setCurrentCardGameState('PLAYING');
       }
-
+      if (isSecondRoundScoreBoard) {
+        setCurrentCardGameState('SCORE_BOARD');
+      }
       if (isGameDone) {
         navigate(`/room/${joinCode}/${miniGameType}/result`);
       }

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -29,24 +29,29 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
       if (isFirstRoundPlaying) {
         setStartCardGame(true);
         setCardInfos(cardInfoMessages);
+        return;
       }
 
       if (isSecondRoundLoading) {
         setIsTransition(true);
         setCurrentRound(2);
         setCurrentCardGameState('LOADING');
+        return;
       }
 
       if (isSecondRoundPlaying) {
         setIsTransition(false);
         setCardInfos(cardInfoMessages);
         setCurrentCardGameState('PLAYING');
+        return;
       }
       if (isSecondRoundScoreBoard) {
         setCurrentCardGameState('SCORE_BOARD');
+        return;
       }
       if (isGameDone) {
         navigate(`/room/${joinCode}/${miniGameType}/result`);
+        return;
       }
     },
     [navigate, joinCode, miniGameType]

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -34,11 +34,11 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         setIsTransition(true);
         setCurrentRound(2);
         setCurrentCardGameState('LOADING');
-        setCardInfos(cardInfoMessages);
       }
 
       if (isSecondRoundPlaying) {
         setIsTransition(false);
+        setCardInfos(cardInfoMessages);
         setCurrentCardGameState('PLAYING');
       }
 

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -19,8 +19,7 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
     if (data.cardGameState === 'PLAYING' && data.currentRound === 'FIRST') {
       setStartCardGame(true);
     }
-    // && data.currentRound === 'SECOND' 추가해야함!!
-    if (data.cardGameState === 'LOADING') {
+    if (data.cardGameState === 'LOADING' && data.currentRound === 'SECOND') {
       setIsTransition(true);
       setCurrentRound(2);
       setCurrentCardGameState('LOADING');

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -1,12 +1,49 @@
+import { PropsWithChildren, useCallback, useState } from 'react';
 import { CardGameContext } from './CardGameContext';
-import { PropsWithChildren } from 'react';
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '../Identifier/IdentifierContext';
+import { CardGameState, CardGameStateData } from '@/types/miniGame';
+import { RoundKey } from '@/types/round';
+import { useNavigate, useParams } from 'react-router-dom';
 
-export const CardGameProvider = ({ children }: PropsWithChildren) => {
+const CardGameProvider = ({ children }: PropsWithChildren) => {
+  const navigate = useNavigate();
   const { joinCode } = useIdentifier();
-  useWebSocketSubscription(`/room/${joinCode}/gameState`, (data: any) => {
+  const { miniGameType } = useParams();
+  const [startCardGame, setStartCardGame] = useState<boolean>(false);
+  const [isTransition, setIsTransition] = useState(false);
+  const [currentRound, setCurrentRound] = useState<RoundKey>(1);
+  const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
+
+  const handleCardGameState = useCallback((data: CardGameStateData) => {
+    if (data.cardGameState === 'PLAYING' && data.currentRound === 'FIRST') {
+      setStartCardGame(true);
+    }
+    // && data.currentRound === 'SECOND' 추가해야함!!
+    if (data.cardGameState === 'LOADING') {
+      setIsTransition(true);
+      setCurrentRound(2);
+      setCurrentCardGameState('LOADING');
+    }
+    if (data.cardGameState === 'PLAYING' && data.currentRound === 'SECOND') {
+      setIsTransition(false);
+      setCurrentCardGameState('PLAYING');
+    }
+    if (data.cardGameState === 'DONE') {
+      navigate(`/room/${joinCode}/${miniGameType}/result`);
+    }
     console.log(data);
-  });
-  return <CardGameContext.Provider value={{}}>{children}</CardGameContext.Provider>;
+  }, []);
+
+  useWebSocketSubscription(`/room/${joinCode}/gameState`, handleCardGameState);
+
+  return (
+    <CardGameContext.Provider
+      value={{ startCardGame, isTransition, currentRound, currentCardGameState }}
+    >
+      {children}
+    </CardGameContext.Provider>
+  );
 };
+
+export default CardGameProvider;

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -117,7 +117,7 @@ const EntryMenuPage = () => {
         }
       );
       setJoinCode(_joinCode);
-      navigate(`/room/${_joinCode}/lobby`);
+      startSocket();
     };
 
     try {

--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
@@ -7,11 +7,9 @@ import CircularProgress from '../CircularProgress/CircularProgress';
 import CardBack from '../CardBack/CardBack';
 import { Card, CardType, CardValue } from '../../constants/cards';
 import CardFront from '../CardFront/CardFront';
-import { RoundKey } from '@/types/round';
 import { SelectedCardInfo } from '../../pages/CardGamePlayPage';
+import { RoundKey, TOTAL_COUNT } from '@/types/round';
 import { CardInfo } from '@/types/miniGame';
-
-const TOTAL_COUNT = 10;
 
 type Props = {
   round: RoundKey;

--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
@@ -9,6 +9,7 @@ import { Card, CardType, CardValue } from '../../constants/cards';
 import CardFront from '../CardFront/CardFront';
 import { RoundKey } from '@/types/round';
 import { SelectedCardInfo } from '../../pages/CardGamePlayPage';
+import { CardInfo } from '@/types/miniGame';
 
 const TOTAL_COUNT = 10;
 
@@ -17,9 +18,10 @@ type Props = {
   onClickCard: (cardIndex: number) => void;
   selectedCardInfo: SelectedCardInfo;
   currentTime: number;
+  cardInfos: CardInfo[];
 };
 
-const Round = ({ round, onClickCard, selectedCardInfo, currentTime }: Props) => {
+const Round = ({ round, onClickCard, selectedCardInfo, currentTime, cardInfos }: Props) => {
   return (
     <Layout>
       <Layout.TopBar center={<Headline4>랜덤카드 게임</Headline4>} />
@@ -62,13 +64,13 @@ const Round = ({ round, onClickCard, selectedCardInfo, currentTime }: Props) => 
           )}
         </S.MyCardContainer>
         <S.CardContainer>
-          {mockCardInfoMessages.map((_, index) => {
+          {cardInfos.map((_, index) => {
             return selectedCardInfo[round].index === index ? (
               <CardFront
                 card={
                   {
-                    type: mockCardInfoMessages[index].cardType as CardType,
-                    value: mockCardInfoMessages[index].value as CardValue,
+                    type: cardInfos[index].cardType as CardType,
+                    value: cardInfos[index].value as CardValue,
                   } as Card
                 }
               />
@@ -83,60 +85,3 @@ const Round = ({ round, onClickCard, selectedCardInfo, currentTime }: Props) => 
 };
 
 export default Round;
-
-const mockCardInfoMessages = [
-  {
-    cardType: 'ADDITION',
-    value: 10,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: 30,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -10,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -20,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: 40,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: 2,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: 0,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: -1,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -40,
-    selected: false,
-    playerName: null,
-  },
-];

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -22,7 +22,7 @@ const CardGamePlayPage = () => {
 
   const { miniGameType } = useParams();
   const { joinCode } = useIdentifier();
-  const { isTransition, currentRound, currentCardGameState } = useCardGame();
+  const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
@@ -44,8 +44,8 @@ const CardGamePlayPage = () => {
         ...prev,
         1: {
           index: cardIndex,
-          type: mockCardInfoMessages[cardIndex].cardType,
-          value: mockCardInfoMessages[cardIndex].value,
+          type: cardInfos[cardIndex].cardType,
+          value: cardInfos[cardIndex].value,
         },
       }));
 
@@ -57,31 +57,41 @@ const CardGamePlayPage = () => {
         ...prev,
         2: {
           index: cardIndex,
-          type: mockCardInfoMessages[cardIndex].cardType,
-          value: mockCardInfoMessages[cardIndex].value,
+          type: cardInfos[cardIndex].cardType,
+          value: cardInfos[cardIndex].value,
         },
       }));
 
-      setTimeout(() => {
-        navigate(`/room/${joinCode}/${miniGameType}/result`);
-      }, 2000);
+      // setTimeout(() => {
+      //   navigate(`/room/${joinCode}/${miniGameType}/result`);
+      // }, 2000);
     }
   };
+
+  const shouldResetTimer =
+    currentTime === 0 &&
+    currentRound === 2 &&
+    currentCardGameState === 'PLAYING' &&
+    !hasResetTimerInRound2.current;
 
   useEffect(() => {
     if (currentTime > 0) {
       const timer = setTimeout(() => setCurrentTime(currentTime - 1), 1000);
       return () => clearTimeout(timer);
-    } else if (
-      currentTime === 0 &&
-      currentRound === 2 &&
-      currentCardGameState === 'PLAYING' &&
-      !hasResetTimerInRound2.current
-    ) {
+    } else if (shouldResetTimer) {
       setCurrentTime(TOTAL_COUNT);
       hasResetTimerInRound2.current = true;
     }
-  }, [currentTime, navigate, joinCode, miniGameType, currentRound, currentCardGameState]);
+  }, [
+    currentTime,
+    navigate,
+    joinCode,
+    miniGameType,
+    currentRound,
+    currentCardGameState,
+    cardInfos,
+    shouldResetTimer,
+  ]);
 
   return isTransition ? (
     <MiniGameTransition currentRound={currentRound} />
@@ -92,65 +102,9 @@ const CardGamePlayPage = () => {
       onClickCard={handleCardClick}
       selectedCardInfo={selectedCardInfo}
       currentTime={currentTime}
+      cardInfos={cardInfos}
     />
   );
 };
 
 export default CardGamePlayPage;
-
-const mockCardInfoMessages = [
-  {
-    cardType: 'ADDITION',
-    value: 10,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: 30,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -10,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -20,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: 40,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: 2,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: 0,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'MULTIPLIER',
-    value: -1,
-    selected: false,
-    playerName: null,
-  },
-  {
-    cardType: 'ADDITION',
-    value: -40,
-    selected: false,
-    playerName: null,
-  },
-];

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import MiniGameTransition from '@/features/miniGame/components/MiniGameTransition/MiniGameTransition';
-import { RoundKey } from '@/types/round';
 import { useNavigate, useParams } from 'react-router-dom';
 import Round from '../components/Round/Round';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useCardGame } from '@/contexts/CardGame/CardGameContext';
+import { RoundKey } from '@/types/round';
 
 const TOTAL_COUNT = 10;
 
@@ -18,11 +19,12 @@ export type SelectedCardInfo = Record<
 
 const CardGamePlayPage = () => {
   const navigate = useNavigate();
+
   const { miniGameType } = useParams();
   const { joinCode } = useIdentifier();
+  const { isTransition, currentRound, currentCardGameState } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
-  const [isTransition, setIsTransition] = useState(false);
-  const [currentRound, setCurrentRound] = useState<RoundKey>(1);
+
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
       index: -1,
@@ -47,15 +49,6 @@ const CardGamePlayPage = () => {
         },
       }));
 
-      setTimeout(() => {
-        setIsTransition(true);
-      }, 2000);
-
-      setTimeout(() => {
-        setIsTransition(false);
-        setCurrentRound(2);
-      }, 4000);
-
       return;
     }
 
@@ -79,10 +72,12 @@ const CardGamePlayPage = () => {
     if (currentTime > 0) {
       const timer = setTimeout(() => setCurrentTime(currentTime - 1), 1000);
       return () => clearTimeout(timer);
-    } else if (currentTime === 0) {
-      navigate(`/room/${joinCode}/${miniGameType}/result`);
+    } else if (currentCardGameState === 'LOADING' && currentRound === 2) {
+    } else if (currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING') {
+      setCurrentTime(TOTAL_COUNT);
+      // navigate(`/room/${joinCode}/${miniGameType}/result`);
     }
-  }, [currentTime, navigate, joinCode, miniGameType]);
+  }, [currentTime, navigate, joinCode, miniGameType, currentRound, currentCardGameState]);
 
   return isTransition ? (
     <MiniGameTransition prevRound={currentRound} />

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import MiniGameTransition from '@/features/miniGame/components/MiniGameTransition/MiniGameTransition';
 import { useNavigate, useParams } from 'react-router-dom';
 import Round from '../components/Round/Round';
@@ -24,7 +24,6 @@ const CardGamePlayPage = () => {
   const { joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
-
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
       index: -1,
@@ -37,6 +36,7 @@ const CardGamePlayPage = () => {
       value: null,
     },
   });
+  const hasResetTimerInRound2 = useRef(false);
 
   const handleCardClick = (cardIndex: number) => {
     if (currentRound === 1) {
@@ -72,10 +72,14 @@ const CardGamePlayPage = () => {
     if (currentTime > 0) {
       const timer = setTimeout(() => setCurrentTime(currentTime - 1), 1000);
       return () => clearTimeout(timer);
-    } else if (currentCardGameState === 'LOADING' && currentRound === 2) {
-    } else if (currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING') {
+    } else if (
+      currentTime === 0 &&
+      currentRound === 2 &&
+      currentCardGameState === 'PLAYING' &&
+      !hasResetTimerInRound2.current
+    ) {
       setCurrentTime(TOTAL_COUNT);
-      // navigate(`/room/${joinCode}/${miniGameType}/result`);
+      hasResetTimerInRound2.current = true;
     }
   }, [currentTime, navigate, joinCode, miniGameType, currentRound, currentCardGameState]);
 

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 import MiniGameTransition from '@/features/miniGame/components/MiniGameTransition/MiniGameTransition';
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
-import { RoundKey } from '@/types/round';
-
-const TOTAL_COUNT = 10;
+import { RoundKey, TOTAL_COUNT } from '@/types/round';
 
 export type SelectedCardInfo = Record<
   RoundKey,

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import MiniGameTransition from '@/features/miniGame/components/MiniGameTransition/MiniGameTransition';
-import { useNavigate, useParams } from 'react-router-dom';
 import Round from '../components/Round/Round';
-import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey } from '@/types/round';
 
@@ -18,12 +16,13 @@ export type SelectedCardInfo = Record<
 >;
 
 const CardGamePlayPage = () => {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
-  const { miniGameType } = useParams();
-  const { joinCode } = useIdentifier();
+  // const { miniGameType } = useParams();
+  // const { joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
+
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
       index: -1,
@@ -36,7 +35,6 @@ const CardGamePlayPage = () => {
       value: null,
     },
   });
-  const hasResetTimerInRound2 = useRef(false);
 
   const handleCardClick = (cardIndex: number) => {
     if (currentRound === 1) {
@@ -68,30 +66,18 @@ const CardGamePlayPage = () => {
     }
   };
 
-  const shouldResetTimer =
-    currentTime === 0 &&
-    currentRound === 2 &&
-    currentCardGameState === 'PLAYING' &&
-    !hasResetTimerInRound2.current;
-
   useEffect(() => {
     if (currentTime > 0) {
-      const timer = setTimeout(() => setCurrentTime(currentTime - 1), 1000);
+      const timer = setTimeout(() => setCurrentTime((prev) => prev - 1), 1000);
       return () => clearTimeout(timer);
-    } else if (shouldResetTimer) {
-      setCurrentTime(TOTAL_COUNT);
-      hasResetTimerInRound2.current = true;
     }
-  }, [
-    currentTime,
-    navigate,
-    joinCode,
-    miniGameType,
-    currentRound,
-    currentCardGameState,
-    cardInfos,
-    shouldResetTimer,
-  ]);
+  }, [currentTime]);
+
+  useEffect(() => {
+    if (currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING') {
+      setCurrentTime(TOTAL_COUNT);
+    }
+  }, [currentTime, currentRound, currentCardGameState]);
 
   return isTransition ? (
     <MiniGameTransition currentRound={currentRound} />

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -80,7 +80,7 @@ const CardGamePlayPage = () => {
   }, [currentTime, navigate, joinCode, miniGameType, currentRound, currentCardGameState]);
 
   return isTransition ? (
-    <MiniGameTransition prevRound={currentRound} />
+    <MiniGameTransition currentRound={currentRound} />
   ) : (
     <Round
       key={currentRound}

--- a/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.stories.tsx
+++ b/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof MiniGameTransition>;
 
 export const Default: Story = {
   args: {
-    prevRound: 2,
+    currentRound: 2,
     children: <img src={CardsStackIcon} alt="cards" />,
   },
   render: (args) => (
@@ -29,7 +29,7 @@ export const Default: Story = {
 
 export const Animated: Story = {
   args: {
-    prevRound: 1,
+    currentRound: 2,
     children: <img src={CardsStackIcon} alt="cards" />,
   },
   render: (args) => (

--- a/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.tsx
+++ b/frontend/src/features/miniGame/components/MiniGameTransition/MiniGameTransition.tsx
@@ -6,16 +6,16 @@ import { PropsWithChildren } from 'react';
 import * as S from './MiniGameTransition.styled';
 
 type Props = {
-  prevRound: RoundKey;
+  currentRound: RoundKey;
 } & PropsWithChildren;
 
-const MiniGameTransition = ({ prevRound, children }: Props) => {
+const MiniGameTransition = ({ currentRound, children }: Props) => {
   return (
     <Layout color="point-400">
       <S.Container>
         <S.Wrapper>
           <S.DescriptionWrapper>
-            <Headline1 color="white">Round {prevRound + 1}</Headline1>
+            <Headline1 color="white">Round {currentRound}</Headline1>
             <Description color="white">다음 라운드로 이동합니다!</Description>
           </S.DescriptionWrapper>
           {children}

--- a/frontend/src/features/miniGame/pages/MiniGameReady/MiniGameReadyPage.tsx
+++ b/frontend/src/features/miniGame/pages/MiniGameReady/MiniGameReadyPage.tsx
@@ -5,18 +5,20 @@ import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import * as S from './MiniGameReadyPage.styled';
+import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 
 const INITIAL_COUNTDOWN_SECONDS = 3;
 const COUNTDOWN_INTERVAL = 1000;
 
 const MiniGameReadyPage = () => {
+  const { startCardGame } = useCardGame();
   const [countdown, setCountdown] = useState(INITIAL_COUNTDOWN_SECONDS);
   const navigate = useNavigate();
   const { miniGameType } = useParams();
   const { joinCode } = useIdentifier();
 
   useEffect(() => {
-    if (countdown <= 0) return;
+    if (countdown <= 1) return;
 
     const timer = setInterval(() => {
       setCountdown((prev) => prev - 1);
@@ -26,10 +28,10 @@ const MiniGameReadyPage = () => {
   }, [countdown]);
 
   useEffect(() => {
-    if (countdown <= 0) {
+    if (startCardGame) {
       navigate(`/room/${joinCode}/${miniGameType}/play`);
     }
-  }, [countdown, navigate, joinCode, miniGameType]);
+  }, [joinCode, miniGameType, startCardGame, navigate]);
 
   return (
     <Layout color="point-400">

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -36,7 +36,8 @@ const LobbyPage = () => {
     [joinCode]
   );
 
-  useWebSocketSubscription(`/room/${joinCode}/round`, (nextMiniGame: MiniGameType) => {
+  useWebSocketSubscription(`/room/${joinCode}/round`, (data: { miniGameType: MiniGameType }) => {
+    const { miniGameType: nextMiniGame } = data;
     handleGameStart(nextMiniGame);
   });
 

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -37,16 +37,14 @@ const LobbyPage = () => {
   useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleGameStart = useCallback(
-    (nextMiniGame: MiniGameType) => {
+    (data: { miniGameType: MiniGameType }) => {
+      const { miniGameType: nextMiniGame } = data;
       navigate(`/room/${joinCode}/${nextMiniGame}/ready`);
     },
     [joinCode]
   );
 
-  useWebSocketSubscription(`/room/${joinCode}/round`, (data: { miniGameType: MiniGameType }) => {
-    const { miniGameType: nextMiniGame } = data;
-    handleGameStart(nextMiniGame);
-  });
+  useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);
 
   const handleClickBackButton = () => {
     navigate('/');

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -28,6 +28,13 @@ const LobbyPage = () => {
   const { openModal } = useModal();
   const { playerType } = usePlayerType();
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
+  const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
+
+  const handleMiniGameData = useCallback((data: MiniGameType[]) => {
+    setSelectedMiniGames(data);
+  }, []);
+
+  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleGameStart = useCallback(
     (nextMiniGame: MiniGameType) => {
@@ -40,14 +47,6 @@ const LobbyPage = () => {
     const { miniGameType: nextMiniGame } = data;
     handleGameStart(nextMiniGame);
   });
-
-  const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
-
-  const handleMiniGameData = useCallback((data: MiniGameType[]) => {
-    setSelectedMiniGames(data);
-  }, []);
-
-  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
 
   const handleClickBackButton = () => {
     navigate('/');

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Outlet } from 'react-router-dom';
 import App from './App';
 import {
   EntryMenuPage,
@@ -13,6 +13,7 @@ import {
   RoulettePage,
   RouletteResultPage,
 } from './pages';
+import { CardGameProvider } from './contexts/CardGame/CardGameProvider';
 
 const router = createBrowserRouter([
   {
@@ -39,6 +40,11 @@ const router = createBrowserRouter([
           { path: 'order', element: <OrderPage /> },
           {
             path: ':miniGameType',
+            element: (
+              <CardGameProvider>
+                <Outlet />
+              </CardGameProvider>
+            ),
             children: [
               { path: 'ready', element: <MiniGameReadyPage /> },
               { path: 'play', element: <MiniGamePlayPage /> },

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,7 +13,7 @@ import {
   RoulettePage,
   RouletteResultPage,
 } from './pages';
-import { CardGameProvider } from './contexts/CardGame/CardGameProvider';
+import CardGameProvider from './contexts/CardGame/CardGameProvider';
 
 const router = createBrowserRouter([
   {

--- a/frontend/src/types/miniGame.ts
+++ b/frontend/src/types/miniGame.ts
@@ -4,3 +4,23 @@ export const MINI_GAME_NAME_MAP = {
 } as const;
 
 export type MiniGameType = keyof typeof MINI_GAME_NAME_MAP;
+
+export type CardGameState = 'READY' | 'LOADING' | 'PLAYING' | 'SCORE_BOARD' | 'DONE';
+
+export type CardGameRound = 'FIRST' | 'SECOND';
+
+export type CardType = 'ADDITION' | 'MULTIPLIER';
+
+export interface CardInfo {
+  cardType: CardType;
+  value: number;
+  selected: boolean;
+  playerName: string | null;
+}
+
+export interface CardGameStateData {
+  cardGameState: CardGameState;
+  currentRound: CardGameRound;
+  cardInfoMessages: CardInfo[];
+  allSelected: boolean;
+}

--- a/frontend/src/types/miniGame.ts
+++ b/frontend/src/types/miniGame.ts
@@ -11,16 +11,16 @@ export type CardGameRound = 'FIRST' | 'SECOND';
 
 export type CardType = 'ADDITION' | 'MULTIPLIER';
 
-export interface CardInfo {
+export type CardInfo = {
   cardType: CardType;
   value: number;
   selected: boolean;
   playerName: string | null;
-}
+};
 
-export interface CardGameStateData {
+export type CardGameStateData = {
   cardGameState: CardGameState;
   currentRound: CardGameRound;
   cardInfoMessages: CardInfo[];
   allSelected: boolean;
-}
+};

--- a/frontend/src/types/round.ts
+++ b/frontend/src/types/round.ts
@@ -1,1 +1,3 @@
 export type RoundKey = 1 | 2;
+
+export const TOTAL_COUNT = 10;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #300 

# 🚀 작업 내용

- CardGameProvider를 만들어 게임 관련 구독과 상태를 여기서 처리했습니다. 

## 전체 플로우 
<img width="1485" height="563" alt="image" src="https://github.com/user-attachments/assets/8816f1e2-81ac-4ecc-9e24-b885790e29cf" />


- 서버에서 내려주는 카드 게임 상태 (CardGameState, CardGameRound) 기반으로 클라이언트 변수를 추가했습니다. 
- 카드 렌더링을 실제 서버에서 내려주는 cardInfoMessages를 사용하여 렌더링 하도록 변경 했습니다. 

## **서버 제공 상태**
```js
export type CardGameState = 'READY' | 'LOADING' | 'PLAYING' | 'SCORE_BOARD' | 'DONE';
export type CardGameRound = 'FIRST' | 'SECOND'
```

READY는 서버에서만 가지고있는 상태여서 클라이언트쪽에는 오지 않습니다

SCORE_BOARD 상태는 카드가 다 선택되거나 10초가 지났을시 바로 화면이 넘어가는 것이 이상해서 1.5초 정도 완충역할로 넣은 상태라고 합니다~

## **클라이언트에서 정의한 시점 변수**
```js
//1라운드 시작
const isFirstRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'FIRST';
//2라운드로 가는 Transition 컴포넌트 나오는 시점
const isSecondRoundLoading = cardGameState === 'LOADING' && currentRound === 'SECOND';
//2라운드 시작
const isSecondRoundPlaying = cardGameState === 'PLAYING' && currentRound === 'SECOND';
//2라운드 스코어보드
const isSecondRoundScoreBoard = cardGameState === 'SCORE_BOARD' && currentRound === 'SECOND';
//게임 끝, 결과 화면으로 넘어감 
const isGameDone = cardGameState === 'DONE';
```

## **게임 navigate 시점**
유저간의 동기화를 맞추기 위해 곧 게임이 시작돼요 321, 이 화면에서 타이머를 1초에 멈춰두고 서버에서 1라운드 시작 신호가 오면 navigate를 실행하도록 변경했습니다. 

## **2라운드에서만  isSecondRoundScoreBoard 처럼 SCORE_BOARD를 체크한 이유**
2라운드 시작 시 타이머(setCurrentTime(TOTAL_COUNT))를 명시적으로 초기화해야 합니다. 타이머 초기화 조건을 아래와 같이 작성했습니다
```JS
currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING'
```
그런데 별도의 상태(SCORE_BOARD)를 두지 않으면 타이머가 0초 → 다시 10초로 초기화되는 문제가 발생했습니다! currentCardGameState === 'PLAYING' 이여서 발생하는 문제라서 2라운드는 currentCardGameState === 'SCORE_BOARD' 도 체크해 주었습니다 .

**타이머 문제 영상**

https://github.com/user-attachments/assets/531b005a-6528-406b-be5c-0ebba77e9d5e

## **Transition 컴포넌트의  prevRound props를 currentRound로 변경**
서버에서 CardGameRound 라는 상태가 옵니다. 게임 상태 업데이트를 고민하다가 분홍색 로딩 화면과 실제 게임을 하는 화면을 하나의 Round로 묶는게 더 편할 것 같아서 백엔드에 수정 요청을 했고 그 결과 `2라운드로 넘어갑니다` 컴포넌트가 렌더링 되는 순간에는  CardGameRound 가 'SECOND'입니다 .따라서 Transition 컴포넌트에 현재 라운드로 props를 넘겨도 되어서 다시 currentRound로 변경 하였습니다. 

## 전체 플로우 영상

https://github.com/user-attachments/assets/a5eab3d8-5e6b-4e26-acad-f531e09b3090




# 💬 리뷰 중점사항
중점사항
