### PR TITLE
[fix] 배포 시 환경변수 오류

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Run Build
         id: build
         run: |
+          echo "Loaded ENV:"
+          printenv
           npm run build
           echo "success=true" >> $GITHUB_OUTPUT
 

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -6,7 +6,7 @@ import webpack from 'webpack';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const env = dotenv.config().parsed;
+const env = dotenv.config({ path: path.resolve(__dirname, '.env') }).parsed || {};
 
 const envKeys = Object.keys(env).reduce((acc, key) => {
   acc[`process.env.${key}`] = JSON.stringify(env[key]);


### PR DESCRIPTION
# 🔥 연관 이슈

- close #286

# 📌 문제 상황

배포 했을 때 환경변수를 문자열로 읽지 않아서 화면이 뜨지 않는 현상이 있습니다.
예상하기로는 `.env` 파일에 있는 환경변수를 문자열로 제대로 파싱하지 못해서 `process.env`를 직접 참조하고 있어서 문제가 발생하는 것 같았습니다.

<img width="597" height="92" alt="image" src="https://github.com/user-attachments/assets/874bd3d1-38d3-4541-b475-842b163a7876" />

# 🚀 작업 내용

1. .env 파일 경로가 혹시 프로젝트 루트에 있는 걸로 접근하는 게 문제인가 해서, 직접 path를 명확히 지정해주었어요. 저희는 /frontend/.env 에 존재하므로 현재 webpack 설정 파일과 같은 위치에 있는 .env에 접근할 수 있도록 했습니다. 되는지는 배포 해봐야 확인 가능할 것 같아요! https://github.com/woowacourse-teams/2025-coffee-shout/commit/9f44067cdeb1345705a55ab6aff2a24a417fd609

```ts
// `webpack.common.js`이 위치한 디렉터리의 절대 경로를 가리킴
{ path: path.resolve(__dirname, '.env') }
```

2. `.env` 파일이 잘 읽히는지, `DefinePlugin`이 제대로 동작하는지 확인해보고자 하여, CI 빌드 로그에 디버깅 코드 추가했습니다. 오류 수정되면 삭제할 예정입니다. https://github.com/woowacourse-teams/2025-coffee-shout/commit/02dfdeb873a92b05ef3714356c9649df7495b6a8

