### PR TITLE
[feat] 메뉴 웹소켓 연동

### DIFF
--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
@@ -62,13 +62,13 @@ const Round = ({ round, onClickCard, selectedCardInfo, currentTime, cardInfos }:
           )}
         </S.MyCardContainer>
         <S.CardContainer>
-          {cardInfos.map((_, index) => {
-            return selectedCardInfo[round].index === index ? (
+          {cardInfos.map((cardInfo, index) => {
+            return cardInfo.selected ? (
               <CardFront
                 card={
                   {
-                    type: cardInfos[index].cardType as CardType,
-                    value: cardInfos[index].value as CardValue,
+                    type: cardInfo.cardType as CardType,
+                    value: cardInfo.value as CardValue,
                   } as Card
                 }
               />

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -3,6 +3,8 @@ import MiniGameTransition from '@/features/miniGame/components/MiniGameTransitio
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey, TOTAL_COUNT } from '@/types/round';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 export type SelectedCardInfo = Record<
   RoundKey,
@@ -14,12 +16,10 @@ export type SelectedCardInfo = Record<
 >;
 
 const CardGamePlayPage = () => {
-  // const navigate = useNavigate();
-
-  // const { miniGameType } = useParams();
-  // const { joinCode } = useIdentifier();
+  const { myName, joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
+  const { send } = useWebSocket();
 
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
@@ -35,33 +35,26 @@ const CardGamePlayPage = () => {
   });
 
   const handleCardClick = (cardIndex: number) => {
-    if (currentRound === 1) {
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        1: {
-          index: cardIndex,
-          type: cardInfos[cardIndex].cardType,
-          value: cardInfos[cardIndex].value,
-        },
-      }));
-
+    if (selectedCardInfo[currentRound].index !== -1) {
       return;
     }
 
-    if (currentRound === 2) {
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        2: {
-          index: cardIndex,
-          type: cardInfos[cardIndex].cardType,
-          value: cardInfos[cardIndex].value,
-        },
-      }));
+    setSelectedCardInfo((prev) => ({
+      ...prev,
+      1: {
+        index: cardIndex,
+        type: cardInfos[cardIndex].cardType,
+        value: cardInfos[cardIndex].value,
+      },
+    }));
 
-      // setTimeout(() => {
-      //   navigate(`/room/${joinCode}/${miniGameType}/result`);
-      // }, 2000);
-    }
+    send(`/room/${joinCode}/minigame/command`, {
+      commandType: 'SELECT_CARD',
+      commandRequest: {
+        playerName: myName,
+        cardIndex,
+      },
+    });
   };
 
   useEffect(() => {

--- a/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
+++ b/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
@@ -10,14 +10,14 @@ import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 
 type Props = {
+  myMenu: string;
   onClose: () => void;
 };
 
-const MenuModifyModal = ({ onClose }: Props) => {
-  // TODO: 현재 메뉴를 초깃값으로 설정 (웹소켓: 현재 본인 메뉴)
+const MenuModifyModal = ({ myMenu, onClose }: Props) => {
   const [modifiedMenu, setModifiedMenu] = useState<Option>({
     id: -1,
-    name: '',
+    name: myMenu,
   });
   const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
+++ b/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
@@ -6,9 +6,8 @@ import SelectBox, { Option } from '@/components/@common/SelectBox/SelectBox';
 import { useEffect, useState } from 'react';
 import * as S from './MenuModifyModal.styled';
 import { Menu } from '@/types/menu';
-
-// TODO: category 타입 따로 관리 필요 (string이 아니라 유니온 타입으로 지정해서 아이콘 매핑해야함)
-type MenusResponse = Menu[];
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 
 type Props = {
   onClose: () => void;
@@ -23,13 +22,15 @@ const MenuModifyModal = ({ onClose }: Props) => {
   const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { send } = useWebSocket();
+  const { myName, joinCode } = useIdentifier();
 
   useEffect(() => {
     (async () => {
       try {
         setLoading(true);
 
-        const menus = await api.get<MenusResponse>('/menus');
+        const menus = await api.get<Menu[]>('/menus');
         const options = menus.map((menu) => ({
           id: menu.id,
           name: menu.name,
@@ -55,7 +56,11 @@ const MenuModifyModal = ({ onClose }: Props) => {
       return;
     }
 
-    // TODO 메뉴 변경 api 호출
+    send(`/room/${joinCode}/update-menus`, {
+      playerName: myName,
+      menuId: modifiedMenu.id,
+    });
+
     onClose();
   };
 

--- a/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
+++ b/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
@@ -53,10 +53,7 @@ export const ParticipantSection = ({ participants }: Props) => {
               name={participant.playerName}
               iconColor="#FF6B6B"
             >
-              <S.Menu
-                src={getMenuIcon(participant.menuResponse.menuType)}
-                onClick={handleModifyMenu}
-              />
+              <S.Menu src={getMenuIcon(participant.menuResponse.menuType)} />
             </PlayerCard>
           ))
         )}

--- a/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
+++ b/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
@@ -18,7 +18,7 @@ export const ParticipantSection = ({ participants }: Props) => {
   const { openModal, closeModal } = useModal();
 
   const handleModifyMenu = () => {
-    openModal(<MenuModifyModal onClose={closeModal} />, {
+    openModal(<MenuModifyModal myMenu={mySelect.menuResponse.name} onClose={closeModal} />, {
       title: '음료 변경',
       showCloseButton: true,
     });

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -55,13 +55,6 @@ const LobbyPage = () => {
     setPlayerProbabilities(parsedData);
   }, []);
 
-  useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleParticipant);
-  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
-  useWebSocketSubscription<Probability[]>(
-    `/room/${joinCode}/roulette`,
-    handlePlayerProbabilitiesData
-  );
-
   const handleGameStart = useCallback(
     (data: { miniGameType: MiniGameType }) => {
       const { miniGameType: nextMiniGame } = data;
@@ -71,6 +64,12 @@ const LobbyPage = () => {
     [joinCode, navigate]
   );
 
+  useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleParticipant);
+  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
+  useWebSocketSubscription<Probability[]>(
+    `/room/${joinCode}/roulette`,
+    handlePlayerProbabilitiesData
+  );
   useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);
 
   useEffect(() => {
@@ -84,6 +83,8 @@ const LobbyPage = () => {
   };
 
   const handleClickGameStartButton = () => {
+    if (participants.length < 2) return;
+
     send(`/room/${joinCode}/minigame/command`, {
       commandType: 'START_MINI_GAME',
       commandRequest: {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #291 

# 🚀 작업 내용

1. 메뉴를 수정하는 웹소켓을 연결했습니다.
2. `LobbyPage`에서 이미 `/room/{joinCode}`에 대한 `Subscribe`를 처리한 상태였기 때문에, `MenuModifyModal`에서 `send` 요청을 보내는 로직만 추가해 주었습니다!
3. 본인이 아닌 다른 참가자의 아이콘에서는 메뉴 수정 모달이 클릭되지 않도록 핸들러를 제거했습니다.

# 💬 리뷰 중점사항
아직 메뉴 아이콘을 넣지 않아서 시각적으로 테스트는 못하지만, `participants`를 출력해보면 메뉴 모달에서 메뉴를 변경한 이후에 변경된 내용을 확인할 수 있습니당