### PR TITLE
[feat] 카드 게임 결과 및 랭킹 카드 웹소켓 연동

### DIFF
--- a/frontend/src/contexts/CardGame/CardGameContext.ts
+++ b/frontend/src/contexts/CardGame/CardGameContext.ts
@@ -1,4 +1,4 @@
-import { CardGameState, CardInfo } from '@/types/miniGame';
+import { CardGameState, CardInfo, PlayerRank, PlayerScore } from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { createContext, useContext } from 'react';
 
@@ -8,6 +8,8 @@ type CardGameContextType = {
   currentRound: RoundKey;
   currentCardGameState: CardGameState;
   cardInfos: CardInfo[];
+  ranks: PlayerRank[];
+  scores: PlayerScore[];
 };
 
 export const CardGameContext = createContext<CardGameContextType | null>(null);

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -75,7 +75,6 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
 
   const handleCardGameRank = useCallback((data: CardGameRanksData) => {
     const { ranks } = data;
-    console.log('ranks', ranks);
     ranks.sort((a, b) => a.rank - b.rank);
     setRanks(ranks);
   }, []);

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -2,9 +2,22 @@ import { PropsWithChildren, useCallback, useState } from 'react';
 import { CardGameContext } from './CardGameContext';
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '../Identifier/IdentifierContext';
-import { CardGameState, CardGameStateData, CardInfo } from '@/types/miniGame';
+import {
+  CardGameState,
+  CardGameStateData,
+  CardInfo,
+  PlayerRank,
+  PlayerScore,
+} from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { useNavigate, useParams } from 'react-router-dom';
+
+export type CardGameScoresData = {
+  scores: PlayerScore[];
+};
+export type CardGameRanksData = {
+  ranks: PlayerRank[];
+};
 
 const CardGameProvider = ({ children }: PropsWithChildren) => {
   const navigate = useNavigate();
@@ -15,6 +28,9 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
   const [currentRound, setCurrentRound] = useState<RoundKey>(1);
   const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
   const [cardInfos, setCardInfos] = useState<CardInfo[]>([]);
+
+  const [scores, setScores] = useState<PlayerScore[]>([]);
+  const [ranks, setRanks] = useState<PlayerRank[]>([]);
 
   const handleCardGameState = useCallback(
     (data: CardGameStateData) => {
@@ -57,11 +73,33 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
     [navigate, joinCode, miniGameType]
   );
 
+  const handleCardGameRank = useCallback((data: CardGameRanksData) => {
+    const { ranks } = data;
+    console.log('ranks', ranks);
+    ranks.sort((a, b) => a.rank - b.rank);
+    setRanks(ranks);
+  }, []);
+
+  const handleCardGameScore = useCallback((data: CardGameScoresData) => {
+    const { scores } = data;
+    setScores(scores);
+  }, []);
+
   useWebSocketSubscription(`/room/${joinCode}/gameState`, handleCardGameState);
+  useWebSocketSubscription(`/room/${joinCode}/rank`, handleCardGameRank);
+  useWebSocketSubscription(`/room/${joinCode}/score`, handleCardGameScore);
 
   return (
     <CardGameContext.Provider
-      value={{ startCardGame, isTransition, currentRound, currentCardGameState, cardInfos }}
+      value={{
+        startCardGame,
+        isTransition,
+        currentRound,
+        currentCardGameState,
+        cardInfos,
+        ranks,
+        scores,
+      }}
     >
       {children}
     </CardGameContext.Provider>

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -3,7 +3,6 @@ import MiniGameTransition from '@/features/miniGame/components/MiniGameTransitio
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey, TOTAL_COUNT } from '@/types/round';
-import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 
 export type SelectedCardInfo = Record<
   RoundKey,

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -16,7 +16,6 @@ export type SelectedCardInfo = Record<
 >;
 
 const CardGamePlayPage = () => {
-
   const { myName, joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -3,7 +3,6 @@ import MiniGameTransition from '@/features/miniGame/components/MiniGameTransitio
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey, TOTAL_COUNT } from '@/types/round';
-import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 
 export type SelectedCardInfo = Record<
@@ -19,7 +18,6 @@ const CardGamePlayPage = () => {
   // const navigate = useNavigate();
 
   // const { miniGameType } = useParams();
-  const { joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
 

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -3,6 +3,8 @@ import MiniGameTransition from '@/features/miniGame/components/MiniGameTransitio
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey, TOTAL_COUNT } from '@/types/round';
+import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 
 export type SelectedCardInfo = Record<
   RoundKey,
@@ -17,7 +19,7 @@ const CardGamePlayPage = () => {
   // const navigate = useNavigate();
 
   // const { miniGameType } = useParams();
-  // const { joinCode } = useIdentifier();
+  const { joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
 

--- a/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
+++ b/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
@@ -6,7 +6,6 @@ import Headline2 from '@/components/@common/Headline2/Headline2';
 import Headline3 from '@/components/@common/Headline3/Headline3';
 import Headline4 from '@/components/@common/Headline4/Headline4';
 import PlayerCard from '@/components/@composition/PlayerCard/PlayerCard';
-import { ColorList } from '@/constants/color';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import Layout from '@/layouts/Layout';
 import { Probability } from '@/types/roulette';

--- a/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
+++ b/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
@@ -14,6 +14,8 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './MiniGameResultPage.styled';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
+import { CardGameStateData } from '@/types/miniGame';
+import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 
 const gameResults = [
   { id: 1, name: '다이앤', score: 20, iconColor: '#FF6B6B' as ColorList, rank: 1 },
@@ -26,8 +28,9 @@ const gameResults = [
 const MiniGameResultPage = () => {
   const navigate = useNavigate();
   const { send } = useWebSocket();
-  const { joinCode } = useIdentifier();
+  const { myName, joinCode } = useIdentifier();
   const { playerType } = usePlayerType();
+  const { ranks, scores } = useCardGame();
 
   const handlePlayerProbabilitiesData = useCallback(
     (data: Probability[]) => {
@@ -67,13 +70,18 @@ const MiniGameResultPage = () => {
       </Layout.Banner>
       <Layout.Content>
         <S.ResultList>
-          {gameResults.map((player) => (
-            <S.PlayerCardWrapper key={player.id} isHighlighted={player.rank === 4}>
+          {ranks.map((playerRank) => (
+            <S.PlayerCardWrapper
+              key={playerRank.playerName}
+              isHighlighted={playerRank.playerName === myName}
+            >
               <Headline3>
-                <S.RankNumber rank={player.rank}>{player.rank}</S.RankNumber>
+                <S.RankNumber rank={playerRank.rank}>{playerRank.rank}</S.RankNumber>
               </Headline3>
-              <PlayerCard name={player.name} iconColor={player.iconColor}>
-                <Headline4>{player.score}점</Headline4>
+              <PlayerCard name={playerRank.playerName} iconColor={'#FF6B6B'}>
+                <Headline4>
+                  {scores.find((score) => score.playerName === playerRank.playerName)?.score}점
+                </Headline4>
               </PlayerCard>
             </S.PlayerCardWrapper>
           ))}

--- a/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
+++ b/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
@@ -14,16 +14,7 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './MiniGameResultPage.styled';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
-import { CardGameStateData } from '@/types/miniGame';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
-
-const gameResults = [
-  { id: 1, name: '다이앤', score: 20, iconColor: '#FF6B6B' as ColorList, rank: 1 },
-  { id: 2, name: '니야', score: 18, iconColor: '#FF6B6B' as ColorList, rank: 2 },
-  { id: 3, name: '메리', score: 15, iconColor: '#FF6B6B' as ColorList, rank: 3 },
-  { id: 4, name: '엠제이', score: 13, iconColor: '#FF6B6B' as ColorList, rank: 4 },
-  { id: 5, name: '루키', score: 10, iconColor: '#FF6B6B' as ColorList, rank: 5 },
-];
 
 const MiniGameResultPage = () => {
   const navigate = useNavigate();

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -9,11 +9,13 @@ import IconButton from '@/components/@common/IconButton/IconButton';
 import Paragraph from '@/components/@common/Paragraph/Paragraph';
 import Layout from '@/layouts/Layout';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './OrderPage.styled';
 
 const OrderPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
   const [viewMode, setViewMode] = useState<'simple' | 'detail'>('simple');
 
   const simpleOrderItems = [
@@ -71,7 +73,7 @@ const OrderPage = () => {
       <Layout.Banner>
         <S.BannerContent>
           <S.Logo src={BreadLogoWhiteIcon} />
-          <Headline1 color="white">다이앤</Headline1>
+          <Headline1 color="white">{location.state?.winner}</Headline1>
           <br />
           <Headline3 color="white">님이 당첨되었습니다!</Headline3>
         </S.BannerContent>

--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
@@ -33,6 +33,7 @@ const RoulettePlayPage = () => {
 
   const handleWinnerData = useCallback((data: Player) => {
     setWinner(data.playerName);
+    setIsSpinning(true);
   }, []);
 
   useWebSocketSubscription<Player>(`/room/${joinCode}/roulette`, handleWinnerData);

--- a/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.tsx
@@ -16,7 +16,9 @@ const RouletteResultPage = () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (joinCode) {
-        navigate(`/room/${joinCode}/order`);
+        navigate(`/room/${joinCode}/order`, {
+          state: { winner },
+        });
       } else {
         navigate('/');
       }

--- a/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.tsx
@@ -25,7 +25,7 @@ const RouletteResultPage = () => {
     }, 3000);
 
     return () => clearTimeout(timer);
-  }, [navigate, joinCode]);
+  }, [navigate, joinCode, winner]);
 
   return (
     <Layout color="point-400">

--- a/frontend/src/types/miniGame.ts
+++ b/frontend/src/types/miniGame.ts
@@ -24,3 +24,13 @@ export type CardGameStateData = {
   cardInfoMessages: CardInfo[];
   allSelected: boolean;
 };
+
+export type PlayerScore = {
+  playerName: string;
+  score: number;
+};
+
+export type PlayerRank = {
+  playerName: string;
+  rank: number;
+};


### PR DESCRIPTION
# 🔥 연관 이슈

- close #302

# 🚀 작업 내용

- 카드 게임 결과 및 랭킹 카드 웹소켓 연동

<img width="995" height="875" alt="image" src="https://github.com/user-attachments/assets/6c1bd948-e4b0-496f-bd54-8e15393705ba" />

-  order 페이지에서 당첨자 연동
-  게스트 화면에서도 룰렛이 돌아가도록 설정

## 미래의 수정사항
- 점수,랭킹은 정적 데이터라 rest api 로 변경하기로 했습니다! 일단 웹소켓으로 구현하였습니다. 

 💬 리뷰 중점사항
중점사항
