### PR TITLE
[feat] 카드 선택 웹소켓 연동

### DIFF
--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
@@ -62,13 +62,13 @@ const Round = ({ round, onClickCard, selectedCardInfo, currentTime, cardInfos }:
           )}
         </S.MyCardContainer>
         <S.CardContainer>
-          {cardInfos.map((_, index) => {
-            return selectedCardInfo[round].index === index ? (
+          {cardInfos.map((cardInfo, index) => {
+            return cardInfo.selected || selectedCardInfo[round].index === index ? (
               <CardFront
                 card={
                   {
-                    type: cardInfos[index].cardType as CardType,
-                    value: cardInfos[index].value as CardValue,
+                    type: cardInfo.cardType as CardType,
+                    value: cardInfo.value as CardValue,
                   } as Card
                 }
               />

--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.tsx
@@ -63,7 +63,7 @@ const Round = ({ round, onClickCard, selectedCardInfo, currentTime, cardInfos }:
         </S.MyCardContainer>
         <S.CardContainer>
           {cardInfos.map((cardInfo, index) => {
-            return cardInfo.selected || selectedCardInfo[round].index === index ? (
+            return cardInfo.selected ? (
               <CardFront
                 card={
                   {

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -35,53 +35,26 @@ const CardGamePlayPage = () => {
   });
 
   const handleCardClick = (cardIndex: number) => {
-    if (currentRound === 1) {
-      if (selectedCardInfo[1].index !== -1) {
-        return;
-      }
-
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        1: {
-          index: cardIndex,
-          type: cardInfos[cardIndex].cardType,
-          value: cardInfos[cardIndex].value,
-        },
-      }));
-
-      send(`/room/${joinCode}/minigame/command`, {
-        commandType: 'SELECT_CARD',
-        commandRequest: {
-          playerName: myName,
-          cardIndex,
-        },
-      });
-
+    if (selectedCardInfo[currentRound].index !== -1) {
       return;
     }
 
-    if (currentRound === 2) {
-      if (selectedCardInfo[2].index !== -1) {
-        return;
-      }
+    setSelectedCardInfo((prev) => ({
+      ...prev,
+      1: {
+        index: cardIndex,
+        type: cardInfos[cardIndex].cardType,
+        value: cardInfos[cardIndex].value,
+      },
+    }));
 
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        2: {
-          index: cardIndex,
-          type: cardInfos[cardIndex].cardType,
-          value: cardInfos[cardIndex].value,
-        },
-      }));
-
-      send(`/room/${joinCode}/minigame/command`, {
-        commandType: 'SELECT_CARD',
-        commandRequest: {
-          playerName: myName,
-          cardIndex,
-        },
-      });
-    }
+    send(`/room/${joinCode}/minigame/command`, {
+      commandType: 'SELECT_CARD',
+      commandRequest: {
+        playerName: myName,
+        cardIndex,
+      },
+    });
   };
 
   useEffect(() => {

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -3,6 +3,8 @@ import MiniGameTransition from '@/features/miniGame/components/MiniGameTransitio
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { RoundKey, TOTAL_COUNT } from '@/types/round';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 export type SelectedCardInfo = Record<
   RoundKey,
@@ -14,12 +16,10 @@ export type SelectedCardInfo = Record<
 >;
 
 const CardGamePlayPage = () => {
-  // const navigate = useNavigate();
-
-  // const { miniGameType } = useParams();
-  // const { joinCode } = useIdentifier();
+  const { myName, joinCode } = useIdentifier();
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
+  const { send } = useWebSocket();
 
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
@@ -36,6 +36,10 @@ const CardGamePlayPage = () => {
 
   const handleCardClick = (cardIndex: number) => {
     if (currentRound === 1) {
+      if (selectedCardInfo[1].index !== -1) {
+        return;
+      }
+
       setSelectedCardInfo((prev) => ({
         ...prev,
         1: {
@@ -45,10 +49,22 @@ const CardGamePlayPage = () => {
         },
       }));
 
+      send(`/room/${joinCode}/minigame/command`, {
+        commandType: 'SELECT_CARD',
+        commandRequest: {
+          playerName: myName,
+          cardIndex,
+        },
+      });
+
       return;
     }
 
     if (currentRound === 2) {
+      if (selectedCardInfo[2].index !== -1) {
+        return;
+      }
+
       setSelectedCardInfo((prev) => ({
         ...prev,
         2: {
@@ -58,9 +74,13 @@ const CardGamePlayPage = () => {
         },
       }));
 
-      // setTimeout(() => {
-      //   navigate(`/room/${joinCode}/${miniGameType}/result`);
-      // }, 2000);
+      send(`/room/${joinCode}/minigame/command`, {
+        commandType: 'SELECT_CARD',
+        commandRequest: {
+          playerName: myName,
+          cardIndex,
+        },
+      });
     }
   };
 

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -55,13 +55,6 @@ const LobbyPage = () => {
     setPlayerProbabilities(parsedData);
   }, []);
 
-  useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleParticipant);
-  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
-  useWebSocketSubscription<Probability[]>(
-    `/room/${joinCode}/roulette`,
-    handlePlayerProbabilitiesData
-  );
-
   const handleGameStart = useCallback(
     (data: { miniGameType: MiniGameType }) => {
       const { miniGameType: nextMiniGame } = data;
@@ -71,6 +64,12 @@ const LobbyPage = () => {
     [joinCode, navigate]
   );
 
+  useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleParticipant);
+  useWebSocketSubscription<MiniGameType[]>(`/room/${joinCode}/minigame`, handleMiniGameData);
+  useWebSocketSubscription<Probability[]>(
+    `/room/${joinCode}/roulette`,
+    handlePlayerProbabilitiesData
+  );
   useWebSocketSubscription(`/room/${joinCode}/round`, handleGameStart);
 
   useEffect(() => {
@@ -84,6 +83,8 @@ const LobbyPage = () => {
   };
 
   const handleClickGameStartButton = () => {
+    if (participants.length < 2) return;
+
     send(`/room/${joinCode}/minigame/command`, {
       commandType: 'START_MINI_GAME',
       commandRequest: {


### PR DESCRIPTION
# 🔥 연관 이슈

- close #292 

# 🚀 작업 내용

https://github.com/user-attachments/assets/805c28eb-e643-49b1-9f1f-f504b5818ee1

1. 카드를 선택하면 실시간으로 참여중인 플레이어에게 보여지도록 웹소켓을 연결했습니다.
2. 선택된 카드들을 보여주기 위해 `CardFront` 컴포넌트를 보여주는 조건에 현재 서버에서 받아온 `cardInfo`의 `selected` 필드가 `true`인지를 검사하는 로직을 추가했습니다.

```tsx
cardInfo.selected || selectedCardInfo[round].index === index ?
```

# 💬 리뷰 중점사항
중점사항
