### PR TITLE
[refactor] GameActionButton 내부의 도메인 로직 외부로 분리

### DIFF
--- a/frontend/src/components/@common/GameActionButton/GameActionButton.stories.tsx
+++ b/frontend/src/components/@common/GameActionButton/GameActionButton.stories.tsx
@@ -37,3 +37,10 @@ export const Selected: Story = {
     gameName: 'Coffee Shout',
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+    gameName: 'Coffee Shout',
+  },
+};

--- a/frontend/src/components/@common/GameActionButton/GameActionButton.styled.ts
+++ b/frontend/src/components/@common/GameActionButton/GameActionButton.styled.ts
@@ -41,9 +41,12 @@ export const Container = styled.button<Props>`
   padding: ${({ $isSelected }) => getAdjustedPadding($isSelected).vertical}px
     ${({ $isSelected }) => getAdjustedPadding($isSelected).horizontal}px;
 
+  cursor: default;
+
   ${({ $disabled }) =>
     !$disabled &&
     `
+    cursor: pointer;
     transition: transform 0.2s ease;
 
     &:active {

--- a/frontend/src/components/@common/GameActionButton/GameActionButton.tsx
+++ b/frontend/src/components/@common/GameActionButton/GameActionButton.tsx
@@ -3,32 +3,22 @@ import InfoWhiteIcon from '@/assets/white-info.svg';
 import { ComponentProps } from 'react';
 import Headline4 from '../Headline4/Headline4';
 import * as S from './GameActionButton.styled';
-import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 
 type Props = {
   onClick: () => void;
   isSelected: boolean;
+  isDisabled: boolean;
   gameName: string;
 } & Omit<ComponentProps<'button'>, 'onClick'>;
 
-const GameActionButton = ({ onClick, isSelected, gameName, ...rest }: Props) => {
-  const { playerType } = usePlayerType();
-
-  //TODO: 다른 에러 처리방식을 찾아보기
-  if (!playerType) return null;
-
+const GameActionButton = ({ onClick, isSelected, isDisabled, gameName, ...rest }: Props) => {
   const handleClick = () => {
-    if (playerType === 'GUEST') return;
+    if (isDisabled) return;
     onClick();
   };
 
   return (
-    <S.Container
-      onClick={handleClick}
-      $isSelected={isSelected}
-      $disabled={playerType === 'GUEST'}
-      {...rest}
-    >
+    <S.Container onClick={handleClick} $isSelected={isSelected} $disabled={isDisabled} {...rest}>
       <S.GameNameWrapper>
         <Headline4 color={isSelected ? 'white' : 'point-400'}>{gameName}</Headline4>
       </S.GameNameWrapper>

--- a/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
@@ -2,6 +2,7 @@ import { api } from '@/apis/rest/api';
 import { ApiError, NetworkError } from '@/apis/rest/error';
 import GameActionButton from '@/components/@common/GameActionButton/GameActionButton';
 import SectionTitle from '@/components/@composition/SectionTitle/SectionTitle';
+import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import { MINI_GAME_NAME_MAP, MiniGameType } from '@/types/miniGame';
 import { useEffect, useState } from 'react';
 import * as S from './MiniGameSection.styled';
@@ -19,6 +20,7 @@ export const MiniGameSection = ({ selectedMiniGames, handleMiniGameClick }: Prop
   const [miniGames, setMiniGames] = useState<MiniGameType[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { playerType } = usePlayerType();
 
   useEffect(() => {
     (async () => {
@@ -51,6 +53,7 @@ export const MiniGameSection = ({ selectedMiniGames, handleMiniGameClick }: Prop
           <GameActionButton
             key={miniGame}
             isSelected={selectedMiniGames.includes(miniGame)}
+            isDisabled={playerType === 'GUEST'}
             gameName={MINI_GAME_NAME_MAP[miniGame]}
             onClick={() => handleMiniGameClick(miniGame)}
           />


### PR DESCRIPTION
# 🔥 연관 이슈

- close #316 

# 🚀 작업 내용

`GameActionButton` 내부에 도메인 로직이 섞여있어서 이 부분을 외부로 분리해주었습니다.

추가로, `GameActionButton` 이 비활성화 상태일 때 cursor가 default가 되도록 수정했어요.

https://github.com/user-attachments/assets/c81b70ec-25b2-45e0-a9fb-60b40e39683d
