### PR TITLE
[feat] 카드게임 점수 및 등수 Rest API로 전환

### DIFF
--- a/backend/src/main/java/coffeeshout/global/exception/RestExceptionHandler.java
+++ b/backend/src/main/java/coffeeshout/global/exception/RestExceptionHandler.java
@@ -1,5 +1,7 @@
 package coffeeshout.global.exception;
 
+import static coffeeshout.global.log.LogAspect.NOTIFICATION_MARKER;
+
 import coffeeshout.global.exception.custom.InvalidArgumentException;
 import coffeeshout.global.exception.custom.InvalidStateException;
 import coffeeshout.global.exception.custom.NotExistElementException;
@@ -82,7 +84,7 @@ public class RestExceptionHandler {
             final HttpServletRequest request
     ) {
         final String logMessage = String.format(
-                "[ERROR] %s.%s | method=%s uri=%s exception=%s message=%s",
+                "%s.%s | method=%s uri=%s exception=%s message=%s",
                 handler.getBeanType().getSimpleName(),
                 handler.getMethod().getName(),
                 request.getMethod(),
@@ -90,7 +92,7 @@ public class RestExceptionHandler {
                 e.getClass().getSimpleName(),
                 e.getMessage()
         );
-        log.error(logMessage, e);
+        log.error(NOTIFICATION_MARKER, logMessage, e);
     }
 
     private void logWarning(
@@ -99,7 +101,7 @@ public class RestExceptionHandler {
             final HttpServletRequest request
     ) {
         final String logMessage = String.format(
-                "[WARN] %s.%s | method=%s uri=%s exception=%s message=%s",
+                "%s.%s | method=%s uri=%s exception=%s message=%s",
                 handler.getBeanType().getSimpleName(),
                 handler.getMethod().getName(),
                 request.getMethod(),

--- a/backend/src/main/java/coffeeshout/global/log/LogAspect.java
+++ b/backend/src/main/java/coffeeshout/global/log/LogAspect.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,12 +18,14 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class LogAspect {
 
+    public static final Marker NOTIFICATION_MARKER = MarkerFactory.getMarker("[NOTIFICATION]");
+
     @AfterReturning(
             value = "execution(* coffeeshout.room.application.RoomService.createRoom(..))",
             returning = "room"
     )
     public void logRoomCreation(Room room) {
-        log.info("JoinCode[{}] 방 생성 완료 - host: {}, createdAt: {}",
+        log.info(NOTIFICATION_MARKER, "JoinCode[{}] 방 생성 완료 - host: {}, createdAt: {}",
                 room.getJoinCode().value(),
                 room.getHost().getName().value(),
                 LocalDateTime.now());
@@ -41,7 +45,7 @@ public class LogAspect {
             argNames = "joinCode,hostName,player"
     )
     public void logSpinRoulette(String joinCode, String hostName, Player player) {
-        log.info("JoinCode[{}] 룰렛 추첨 완료 - 당첨자: {}",
+        log.info(NOTIFICATION_MARKER, "JoinCode[{}] 룰렛 추첨 완료 - 당첨자: {}",
                 joinCode,
                 player.getName().value());
     }

--- a/backend/src/main/java/coffeeshout/minigame/application/CardGameService.java
+++ b/backend/src/main/java/coffeeshout/minigame/application/CardGameService.java
@@ -103,7 +103,7 @@ public class CardGameService implements MiniGameService {
         final String scoreDestination = String.format(CARD_GAME_SCORE_DESTINATION_FORMAT, joinCode.value());
         final String rankDestination = String.format(CARD_GAME_RESULT_DESTINATION_FORMAT, joinCode.value());
         messagingTemplate.convertAndSend(String.format(scoreDestination, joinCode.value()),
-                WebSocketResponse.success(MiniGameScoresMessage.from(cardGame.calculateScores())));
+                WebSocketResponse.success(MiniGameScoresMessage.from(cardGame.getScores())));
         messagingTemplate.convertAndSend(String.format(rankDestination, joinCode.value()),
                 WebSocketResponse.success(MiniGameRanksMessage.from(cardGame.getResult())));
     }

--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/CardGame.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/CardGame.java
@@ -36,7 +36,7 @@ public class CardGame implements Playable {
 
     @Override
     public MiniGameResult getResult() {
-        return MiniGameResult.from(calculateScores());
+        return MiniGameResult.from(getScores());
     }
 
     @Override
@@ -47,6 +47,11 @@ public class CardGame implements Playable {
     @Override
     public void startGame(List<Player> players) {
         playerHands = new PlayerHands(players);
+    }
+
+    @Override
+    public Map<Player, MiniGameScore> getScores() {
+        return playerHands.scoreByPlayer();
     }
 
     public void startRound() {
@@ -62,10 +67,6 @@ public class CardGame implements Playable {
     public void selectCard(Player player, Integer cardIndex) {
         state(state == CardGameState.PLAYING, "현재 게임이 진행중인 상태가 아닙니다.");
         playerHands.put(player, deck.pick(cardIndex));
-    }
-
-    public Map<Player, MiniGameScore> calculateScores() {
-        return playerHands.scoreByPlayer();
     }
 
     public boolean isFinishedThisRound() {

--- a/backend/src/main/java/coffeeshout/minigame/ui/MiniGameRestController.java
+++ b/backend/src/main/java/coffeeshout/minigame/ui/MiniGameRestController.java
@@ -1,0 +1,44 @@
+package coffeeshout.minigame.ui;
+
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.minigame.ui.response.MiniGameRanksResponse;
+import coffeeshout.minigame.ui.response.MiniGameScoresResponse;
+import coffeeshout.room.application.RoomService;
+import coffeeshout.room.domain.player.Player;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/minigames")
+@RequiredArgsConstructor
+public class MiniGameRestController {
+
+    private final RoomService roomService;
+
+    @GetMapping("/scores")
+    public ResponseEntity<MiniGameScoresResponse> getScores(
+            @RequestParam String joinCode,
+            @RequestParam MiniGameType miniGameType
+    ) {
+        Map<Player, MiniGameScore> result = roomService.getMiniGameScores(joinCode, miniGameType);
+
+        return ResponseEntity.ok(MiniGameScoresResponse.from(result));
+    }
+
+    @GetMapping("/ranks")
+    public ResponseEntity<MiniGameRanksResponse> getRanks(
+            @RequestParam String joinCode,
+            @RequestParam MiniGameType miniGameType
+    ) {
+        final MiniGameResult result = roomService.getMiniGameRanks(joinCode, miniGameType);
+
+        return ResponseEntity.ok(MiniGameRanksResponse.from(result));
+    }
+}

--- a/backend/src/main/java/coffeeshout/minigame/ui/MiniGameWebSocketController.java
+++ b/backend/src/main/java/coffeeshout/minigame/ui/MiniGameWebSocketController.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
-public class MiniGameController {
+public class MiniGameWebSocketController {
 
     private final MiniGameCommandDispatcher miniGameCommandDispatcher;
     private final ObjectMapper objectMapper;

--- a/backend/src/main/java/coffeeshout/minigame/ui/response/MiniGameRanksResponse.java
+++ b/backend/src/main/java/coffeeshout/minigame/ui/response/MiniGameRanksResponse.java
@@ -1,0 +1,28 @@
+package coffeeshout.minigame.ui.response;
+
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.room.domain.player.Player;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+
+public record MiniGameRanksResponse(List<MiniGameRankResponse> ranks) {
+
+    public record MiniGameRankResponse(
+            String playerName,
+            Integer rank
+    ) {
+
+        public static MiniGameRankResponse from(@NonNull Map.Entry<Player, Integer> rankEntry) {
+            return new MiniGameRankResponse(rankEntry.getKey().getName().value(), rankEntry.getValue());
+        }
+    }
+
+    public static MiniGameRanksResponse from(@NonNull MiniGameResult miniGameResult) {
+        final List<MiniGameRankResponse> ranks = miniGameResult.getRank().entrySet()
+                .stream()
+                .map(MiniGameRankResponse::from)
+                .toList();
+        return new MiniGameRanksResponse(ranks);
+    }
+}

--- a/backend/src/main/java/coffeeshout/minigame/ui/response/MiniGameScoresResponse.java
+++ b/backend/src/main/java/coffeeshout/minigame/ui/response/MiniGameScoresResponse.java
@@ -1,0 +1,27 @@
+package coffeeshout.minigame.ui.response;
+
+import coffeeshout.minigame.domain.MiniGameScore;
+import coffeeshout.room.domain.player.Player;
+import java.util.List;
+import java.util.Map;
+import lombok.NonNull;
+
+public record MiniGameScoresResponse(List<MiniGameScoreResponse> scores) {
+
+    public record MiniGameScoreResponse(
+            String playerName,
+            Integer score
+    ) {
+
+        public static MiniGameScoreResponse from(@NonNull Map.Entry<Player, MiniGameScore> scoreEntry) {
+            return new MiniGameScoreResponse(scoreEntry.getKey().getName().value(), scoreEntry.getValue().getValue());
+        }
+    }
+
+    public static MiniGameScoresResponse from(Map<Player, MiniGameScore> miniGameScores) {
+        return new MiniGameScoresResponse(
+                miniGameScores.entrySet().stream()
+                        .map(MiniGameScoreResponse::from)
+                        .toList());
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -1,5 +1,7 @@
 package coffeeshout.room.application;
 
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Playable;
@@ -107,5 +109,24 @@ public class RoomService {
         final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
 
         roomCommandService.delayCleanUp(room, Duration.ofHours(1));
+    }
+
+    public Map<Player, MiniGameScore> getMiniGameScores(String joinCode, MiniGameType miniGameType) {
+        final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
+        final Playable miniGame = room.findMiniGame(miniGameType);
+
+        return miniGame.getScores();
+    }
+
+    public MiniGameResult getMiniGameRanks(String joinCode, MiniGameType miniGameType) {
+        final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
+        final Playable miniGame = room.findMiniGame(miniGameType);
+
+        return miniGame.getResult();
+    }
+
+    public List<MiniGameType> getSelectedMiniGames(String joinCode) {
+        final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
+        return room.getSelectedMiniGameTypes();
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/Playable.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Playable.java
@@ -1,13 +1,17 @@
 package coffeeshout.room.domain;
 
 import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.player.Player;
 import java.util.List;
+import java.util.Map;
 
 public interface Playable {
 
     MiniGameResult getResult();
+
+    Map<Player, MiniGameScore> getScores();
 
     MiniGameType getMiniGameType();
 

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -6,6 +6,7 @@ import static org.springframework.util.Assert.state;
 import coffeeshout.global.exception.custom.InvalidArgumentException;
 import coffeeshout.global.exception.custom.InvalidStateException;
 import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.player.Menu;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
@@ -122,7 +123,13 @@ public class Room {
         return Collections.unmodifiableList(new ArrayList<>(miniGames));
     }
 
-    public Playable findMiniGame(coffeeshout.minigame.domain.MiniGameType miniGameType) {
+    public List<MiniGameType> getSelectedMiniGameTypes(){
+        return getAllMiniGame().stream()
+                .map(Playable::getMiniGameType)
+                .toList();
+    }
+
+    public Playable findMiniGame(MiniGameType miniGameType) {
         return finishedGames.stream()
                 .filter(minigame -> minigame.getMiniGameType() == miniGameType)
                 .findFirst()
@@ -135,11 +142,12 @@ public class Room {
         state(roomState == RoomState.READY, "게임을 시작할 수 있는 상태가 아닙니다.");
 
         Playable currentGame = miniGames.poll();
-        finishedGames.add(currentGame);
 
         currentGame.startGame(players.getPlayers());
 
         roomState = RoomState.PLAYING;
+
+        finishedGames.add(currentGame);
 
         return currentGame;
     }

--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -1,5 +1,6 @@
 package coffeeshout.room.ui;
 
+import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.application.RoomService;
 import coffeeshout.room.domain.Room;
 import coffeeshout.room.ui.request.RoomCreateRequest;
@@ -59,19 +60,15 @@ public class RoomRestController {
     }
 
     @GetMapping("/minigames")
-    public ResponseEntity<List<MiniGameResponse>> getMiniGames() {
-        final List<MiniGameResponse> responses = roomService.getAllMiniGames().stream()
-                .map(MiniGameResponse::from)
-                .toList();
+    public ResponseEntity<List<MiniGameType>> getMiniGames() {
+        final List<MiniGameType> responses = roomService.getAllMiniGames();
 
         return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/minigames/selected")
-    public ResponseEntity<List<MiniGameSelectedResponse>> getSelectedMiniGames(@RequestParam String joinCode){
-        List<MiniGameSelectedResponse> result = roomService.getSelectedMiniGames(joinCode).stream()
-                .map(MiniGameSelectedResponse::from)
-                .toList();
+    public ResponseEntity<List<MiniGameType>> getSelectedMiniGames(@RequestParam String joinCode){
+        List<MiniGameType> result = roomService.getSelectedMiniGames(joinCode);
 
         return ResponseEntity.ok(result);
     }

--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -7,6 +7,7 @@ import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
 import coffeeshout.room.ui.response.MiniGameResponse;
+import coffeeshout.room.ui.response.MiniGameSelectedResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
 import coffeeshout.room.ui.response.RoomEnterResponse;
 import java.util.List;
@@ -64,5 +65,14 @@ public class RoomRestController {
                 .toList();
 
         return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/minigames/selected")
+    public ResponseEntity<List<MiniGameSelectedResponse>> getSelectedMiniGames(@RequestParam String joinCode){
+        List<MiniGameSelectedResponse> result = roomService.getSelectedMiniGames(joinCode).stream()
+                .map(MiniGameSelectedResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/ui/response/MiniGameSelectedResponse.java
+++ b/backend/src/main/java/coffeeshout/room/ui/response/MiniGameSelectedResponse.java
@@ -1,0 +1,10 @@
+package coffeeshout.room.ui.response;
+
+import coffeeshout.minigame.domain.MiniGameType;
+
+public record MiniGameSelectedResponse(MiniGameType miniGameType) {
+
+    public static MiniGameSelectedResponse from(MiniGameType miniGameType) {
+        return new MiniGameSelectedResponse(miniGameType);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,1 +1,8 @@
-spring.application.value=coffee-shout
+spring:
+  application:
+    name:coffee-shout
+
+logging:
+  level:
+    root: info
+

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root"/>
+
+    <property name="CONSOLE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}] [%clr(%-5level)] %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg %clr(%marker)  %n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/backend/src/test/java/coffeeshout/fixture/MiniGameDummy.java
+++ b/backend/src/test/java/coffeeshout/fixture/MiniGameDummy.java
@@ -1,21 +1,32 @@
 package coffeeshout.fixture;
 
 import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.minigame.domain.cardgame.CardGameScore;
 import coffeeshout.room.domain.Playable;
 import coffeeshout.room.domain.player.Player;
 import java.util.List;
+import java.util.Map;
 
 public class MiniGameDummy implements Playable {
 
     @Override
     public MiniGameResult getResult() {
-        return null;
+        return MiniGameResult.from(getScores());
+    }
+
+    @Override
+    public Map<Player, MiniGameScore> getScores() {
+        return Map.of(
+                PlayerFixture.호스트꾹이(), new CardGameScore(20),
+                PlayerFixture.게스트루키(), new CardGameScore(-10)
+        );
     }
 
     @Override
     public MiniGameType getMiniGameType() {
-        return null;
+        return MiniGameType.CARD_GAME;
     }
 
     @Override

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/CardGameTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/CardGameTest.java
@@ -140,7 +140,7 @@ class CardGameTest {
             cardGame.selectCard(player4, 3);
 
             // when
-            Map<Player, MiniGameScore> scores = cardGame.calculateScores();
+            Map<Player, MiniGameScore> scores = cardGame.getScores();
 
             // then - 점수가 계산되는지 확인 (shuffle에 의해 실제 값은 변할 수 있음)
             SoftAssertions.assertSoftly(softly -> {
@@ -171,7 +171,7 @@ class CardGameTest {
             assertThat(cardGame.isFinished(CardGameRound.FIRST)).isTrue();
 
             // then - 점수가 계산되는지 확인
-            Map<Player, MiniGameScore> scores = cardGame.calculateScores();
+            Map<Player, MiniGameScore> scores = cardGame.getScores();
             assertThat(scores).hasSize(4);
         }
     }

--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coffeeshout.fixture.MenuFixture;
+import coffeeshout.fixture.MiniGameDummy;
+import coffeeshout.fixture.PlayerFixture;
 import coffeeshout.fixture.TestDataHelper;
 import coffeeshout.global.exception.custom.InvalidArgumentException;
 import coffeeshout.global.exception.custom.InvalidStateException;
 import coffeeshout.global.exception.custom.NotExistElementException;
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
@@ -17,6 +21,7 @@ import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.roulette.Probability;
 import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -348,5 +353,70 @@ class RoomServiceTest {
         // then
         assertThat(losePlayer).isNotNull();
         assertThat(createdRoom.getPlayers()).contains(losePlayer);
+    }
+
+    @Test
+    void 미니게임의_점수를_반환한다(){
+        // given
+        String hostName = "호스트";
+        Room createdRoom = roomService.createRoom(hostName, 1L);
+        JoinCode joinCode = createdRoom.getJoinCode();
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트1", 2L);
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트2", 3L);
+
+        List<MiniGameDummy> miniGames = List.of(new MiniGameDummy());
+        ReflectionTestUtils.setField(createdRoom, "finishedGames", miniGames);
+
+        // when
+        Map<Player, MiniGameScore> miniGameScores = roomService.getMiniGameScores(
+                joinCode.value(),
+                MiniGameType.CARD_GAME
+        );
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(miniGameScores.get(PlayerFixture.호스트꾹이()).getValue()).isEqualTo(20);
+            softly.assertThat(miniGameScores.get(PlayerFixture.게스트루키()).getValue()).isEqualTo(-10);
+        });
+    }
+
+    @Test
+    void 미니게임의_순위를_반환한다() {
+        // given
+        String hostName = "호스트";
+        Room createdRoom = roomService.createRoom(hostName, 1L);
+        JoinCode joinCode = createdRoom.getJoinCode();
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트1", 2L);
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트2", 3L);
+
+        List<MiniGameDummy> miniGames = List.of(new MiniGameDummy());
+        ReflectionTestUtils.setField(createdRoom, "finishedGames", miniGames);
+
+        // when
+        MiniGameResult miniGameRanks = roomService.getMiniGameRanks(joinCode.value(), MiniGameType.CARD_GAME);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(miniGameRanks.getPlayerRank(PlayerFixture.호스트꾹이())).isEqualTo(1);
+            softly.assertThat(miniGameRanks.getPlayerRank(PlayerFixture.게스트루키())).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 선택된_미니게임의_목록을_반환한다() {
+        // given
+        String hostName = "호스트";
+        Room createdRoom = roomService.createRoom(hostName, 1L);
+        JoinCode joinCode = createdRoom.getJoinCode();
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트1", 2L);
+        roomService.enterRoom(createdRoom.getJoinCode().value(), "게스트2", 3L);
+        roomService.updateMiniGames(createdRoom.getJoinCode().value(), hostName, List.of(MiniGameType.CARD_GAME));
+
+        // when
+        List<MiniGameType> selectedMiniGames = roomService.getSelectedMiniGames(joinCode.value());
+
+        // then
+        assertThat(selectedMiniGames).hasSize(1);
+        assertThat(selectedMiniGames).containsExactly(MiniGameType.CARD_GAME);
     }
 }

--- a/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
@@ -143,8 +143,6 @@ class RoomTest {
     @Test
     void 해당_미니게임이_없을_때_제거하면_예외를_발생한다() {
         // given
-        CardGame cardGame = new CardGame(new CardGameRandomDeckGenerator());
-        room.addMiniGame(호스트_한스, cardGame);
         MiniGameDummy miniGameDummy = new MiniGameDummy();
 
         // when & then


### PR DESCRIPTION
# 🔥 연관 이슈

- close #335 
- close #336 

# 🚀 작업 내용

1. 카드게임 점수 및 등수 Rest API로 전환
2. 선택된 미니게임 목록 반환하는 Rest API 추가
3. 로그 콘솔 출력 형식 변경
4. 관련 테스트 작성

# 💬 리뷰 중점사항
중점사항
