### PR TITLE
[feat] 참여코드 모달에서 복사하기 기능 구현

### DIFF
--- a/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.tsx
+++ b/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.tsx
@@ -7,7 +7,8 @@ import * as S from './JoinCodeModal.styled';
 const JoinCodeModal = () => {
   const { joinCode } = useIdentifier();
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(joinCode);
     alert('초대 코드가 복사되었습니다.');
   };
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #363

# 🚀 작업 내용
참여코드 모달에서 복사 아이콘을 누르면 클립보드로 복사되는 기능을 구현했습니다.

# 참고 사항
일반적으로 웹에서 클립보드 기능을 구현할 때는 구형 브라우저 호환성을 위해서 `document.execCommand('copy')` 폴백을 함께 구현하는 것이 권장되는데요.

하지만 현재 서비스의 브라우저 지원 범위를 고려하여 폴백 처리를 별도로 진행해 주지는 않았습니다.

**현재 서비스에서의 지원 브라우저**
- Chrome
- Safari  
- 삼성 인터넷

**Clipboard API 지원 현황**
- Chrome for Android: 66+ 지원
- Safari on iOS: 13.4+ (iOS 13.4+) 지원  
- Samsung Internet: 9.2+ 지원

[참고](https://developer.mozilla.org/ko/docs/Web/API/Navigator/clipboard)

위 브라우저들은 모두 `navigator.clipboard` API를 완전히 지원하기 때문에 `navigator.clipboard API`만 사용하기로 결정했습니다.
