### PR TITLE
[feat] 게임준비 기능 추가 

### DIFF
--- a/frontend/src/components/@common/Button/Button.styled.ts
+++ b/frontend/src/components/@common/Button/Button.styled.ts
@@ -64,7 +64,6 @@ export const Container = styled.button<Props>`
         return `
           background: ${theme.color.point[50]};
           color: ${theme.color.point[400]};
-          /* border: 3px solid ${theme.color.point[300]}; */
         `;
 
       case 'primary':

--- a/frontend/src/components/@common/Button/Button.styled.ts
+++ b/frontend/src/components/@common/Button/Button.styled.ts
@@ -1,7 +1,7 @@
 import { Size } from '@/types/styles';
 import styled from '@emotion/styled';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'loading';
+export type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'loading' | 'ready';
 
 type Props = {
   $height: Size;
@@ -58,6 +58,13 @@ export const Container = styled.button<Props>`
           color: ${theme.color.white};
           cursor: default;
           opacity: 0.7;
+        `;
+
+      case 'ready':
+        return `
+          background: ${theme.color.point[50]};
+          color: ${theme.color.point[400]};
+          /* border: 3px solid ${theme.color.point[300]}; */
         `;
 
       case 'primary':

--- a/frontend/src/features/room/lobby/components/GameReadyButton/GameReadyButton.tsx
+++ b/frontend/src/features/room/lobby/components/GameReadyButton/GameReadyButton.tsx
@@ -1,0 +1,17 @@
+import Button from '@/components/@common/Button/Button';
+import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
+
+type Props = {
+  onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
+  isReady?: boolean;
+} & Omit<ComponentProps<typeof Button>, 'onClick'>;
+
+const GameReadyButton = ({ onClick, isReady = false, ...rest }: Props) => {
+  return (
+    <Button variant={isReady ? 'ready' : 'primary'} onClick={onClick} {...rest}>
+      {isReady ? '준비 완료!' : '준비하기'}
+    </Button>
+  );
+};
+
+export default GameReadyButton;

--- a/frontend/src/features/room/lobby/components/GameReadyButton/GameReadyButton.tsx
+++ b/frontend/src/features/room/lobby/components/GameReadyButton/GameReadyButton.tsx
@@ -2,8 +2,8 @@ import Button from '@/components/@common/Button/Button';
 import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
 
 type Props = {
+  isReady: boolean;
   onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
-  isReady?: boolean;
 } & Omit<ComponentProps<typeof Button>, 'onClick'>;
 
 const GameReadyButton = ({ onClick, isReady = false, ...rest }: Props) => {

--- a/frontend/src/features/room/lobby/components/GameStartButton/GameStartButton.tsx
+++ b/frontend/src/features/room/lobby/components/GameStartButton/GameStartButton.tsx
@@ -3,8 +3,6 @@ import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
 
 type Props = {
   onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
-  canStart?: boolean;
-  participantCount?: number;
 } & Omit<ComponentProps<typeof Button>, 'onClick'>;
 
 const GameStartButton = ({ onClick, ...rest }: Props) => {

--- a/frontend/src/features/room/lobby/components/GameStartButton/GameStartButton.tsx
+++ b/frontend/src/features/room/lobby/components/GameStartButton/GameStartButton.tsx
@@ -1,0 +1,18 @@
+import Button from '@/components/@common/Button/Button';
+import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
+
+type Props = {
+  onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
+  canStart?: boolean;
+  participantCount?: number;
+} & Omit<ComponentProps<typeof Button>, 'onClick'>;
+
+const GameStartButton = ({ onClick, ...rest }: Props) => {
+  return (
+    <Button variant="primary" onClick={onClick} {...rest}>
+      게임 시작
+    </Button>
+  );
+};
+
+export default GameStartButton;

--- a/frontend/src/features/room/lobby/components/HostWaitingButton/HostWaitingButton.tsx
+++ b/frontend/src/features/room/lobby/components/HostWaitingButton/HostWaitingButton.tsx
@@ -1,0 +1,17 @@
+import Button from '@/components/@common/Button/Button';
+import type { ComponentProps } from 'react';
+
+type Props = {
+  isReadyCount?: number;
+  totalParticipantCount?: number;
+} & Omit<ComponentProps<typeof Button>, 'onClick'>;
+
+const HostWaitingButton = ({ isReadyCount = 0, totalParticipantCount = 0, ...rest }: Props) => {
+  return (
+    <Button variant="ready" {...rest}>
+      게임 대기중... {isReadyCount}/{totalParticipantCount}
+    </Button>
+  );
+};
+
+export default HostWaitingButton;

--- a/frontend/src/features/room/lobby/components/HostWaitingButton/HostWaitingButton.tsx
+++ b/frontend/src/features/room/lobby/components/HostWaitingButton/HostWaitingButton.tsx
@@ -2,14 +2,18 @@ import Button from '@/components/@common/Button/Button';
 import type { ComponentProps } from 'react';
 
 type Props = {
-  isReadyCount?: number;
+  currentReadyCount?: number;
   totalParticipantCount?: number;
 } & Omit<ComponentProps<typeof Button>, 'onClick'>;
 
-const HostWaitingButton = ({ isReadyCount = 0, totalParticipantCount = 0, ...rest }: Props) => {
+const HostWaitingButton = ({
+  currentReadyCount = 0,
+  totalParticipantCount = 0,
+  ...rest
+}: Props) => {
   return (
     <Button variant="ready" {...rest}>
-      게임 대기중... {isReadyCount}/{totalParticipantCount}
+      게임 대기중... {currentReadyCount}/{totalParticipantCount}
     </Button>
   );
 };

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -37,7 +37,8 @@ const LobbyPage = () => {
   const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
   const [participants, setParticipants] = useState<ParticipantResponse>([]);
   const isAllReady = participants.every((participant) => participant.isReady);
-  const isReady = participants.find((participant) => participant.playerName === myName)?.isReady;
+  const isReady =
+    participants.find((participant) => participant.playerName === myName)?.isReady ?? false;
 
   const handleParticipant = useCallback((data: ParticipantResponse) => {
     setParticipants(data);

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -124,7 +124,6 @@ const LobbyPage = () => {
   };
 
   const handleGameReadyButtonClick = () => {
-    console.log('isReady', isReady);
     send(`/room/${joinCode}/update-ready`, {
       joinCode,
       playerName: myName,
@@ -139,7 +138,7 @@ const LobbyPage = () => {
       }
       return (
         <HostWaitingButton
-          isReadyCount={participants.filter((participant) => participant.isReady).length}
+          currentReadyCount={participants.filter((participant) => participant.isReady).length}
           totalParticipantCount={participants.length}
         />
       );

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -18,6 +18,9 @@ import JoinCodeModal from '../components/JoinCodeModal/JoinCodeModal';
 import { MiniGameSection } from '../components/MiniGameSection/MiniGameSection';
 import { ParticipantSection } from '../components/ParticipantSection/ParticipantSection';
 import { RouletteSection } from '../components/RouletteSection/RouletteSection';
+import GameStartButton from '../components/GameStartButton/GameStartButton';
+import HostWaitingButton from '../components/HostWaitingButton/HostWaitingButton';
+import GameReadyButton from '../components/GameReadyButton/GameReadyButton';
 import * as S from './LobbyPage.styled';
 
 type SectionType = '참가자' | '룰렛' | '미니게임';
@@ -33,6 +36,8 @@ const LobbyPage = () => {
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
   const [selectedMiniGames, setSelectedMiniGames] = useState<MiniGameType[]>([]);
   const [participants, setParticipants] = useState<ParticipantResponse>([]);
+  const isAllReady = participants.every((participant) => participant.isReady);
+  const isReady = participants.find((participant) => participant.playerName === myName)?.isReady;
 
   const handleParticipant = useCallback((data: ParticipantResponse) => {
     setParticipants(data);
@@ -118,6 +123,31 @@ const LobbyPage = () => {
     });
   };
 
+  const handleGameReadyButtonClick = () => {
+    console.log('isReady', isReady);
+    send(`/room/${joinCode}/update-ready`, {
+      joinCode,
+      playerName: myName,
+      isReady: !isReady,
+    });
+  };
+
+  const renderGameButton = () => {
+    if (playerType === 'HOST') {
+      if (isAllReady) {
+        return <GameStartButton onClick={handleClickGameStartButton} />;
+      }
+      return (
+        <HostWaitingButton
+          isReadyCount={participants.filter((participant) => participant.isReady).length}
+          totalParticipantCount={participants.length}
+        />
+      );
+    }
+
+    return <GameReadyButton isReady={isReady} onClick={handleGameReadyButtonClick} />;
+  };
+
   useEffect(() => {
     if (playerType === 'GUEST' && joinCode) {
       send(`/room/${joinCode}/get-probabilities`);
@@ -161,20 +191,13 @@ const LobbyPage = () => {
           </S.Wrapper>
         </S.Container>
       </Layout.Content>
-      {playerType === 'HOST' ? (
-        <Layout.ButtonBar flexRatios={[5.5, 1]}>
-          <Button variant="primary" onClick={handleClickGameStartButton}>
-            게임 시작
-          </Button>
-          <Button variant="primary" onClick={handleShare}>
-            <img src={ShareIcon} alt="공유" />
-          </Button>
-        </Layout.ButtonBar>
-      ) : (
-        <Layout.ButtonBar flexRatios={[5.5, 1]}>
-          <Button variant="loading">게임 대기중</Button>
-        </Layout.ButtonBar>
-      )}
+
+      <Layout.ButtonBar flexRatios={[5.5, 1]}>
+        {renderGameButton()}
+        <Button variant="primary" onClick={handleShare}>
+          <img src={ShareIcon} alt="공유" />
+        </Button>
+      </Layout.ButtonBar>
     </Layout>
   );
 };


### PR DESCRIPTION
# 🔥 연관 이슈

- close #343 

# 🚀 작업 내용

## 버튼 컴포넌트 렌더링
게임 준비 기능구현에 필요한 버튼들을 아래와 같이 컴포넌트로 분리하였습니다. 
`GameReadyButton` 컴포넌트
 `GameStartButton` 컴포넌트
`HostWaitingButton` 컴포넌트

**분리한 이유:**
LobbyPage에서 조건부 렌더링을 통해 버튼을 표시해야 하는데, 공통 버튼 컴포넌트를 직접 사용하는 방식은 코드가 길어지고 가독성이 떨어진다고 생각해 분리하였습니다. 

또한 Host/Guest 뿐만 아니라 Ready 상태에 따라서도 버튼 렌더링이 달라져서 삼항연산자를 사용하면 가독성이 떨어진다고 느꼈습니다. 따라서 `renderGameButton` 라는 함수를 만들었습니다. 

### guest 일때
- `GameReadyButton` 렌더링
- 플레이어의 준비 상태(isReady)에 따라 버튼 스타일 변경 

### Host 일때
- 모든 참가자가 준비 완료(isAllReady)인 경우: `GameStartButton` 렌더링
- 일부 참가자가 준비되지 않은 경우: `HostWaitingButton` 렌더링
- 준비된 참가자 수와 전체 참가자 수 표시

## 준비 상태 관리
`isReady`, `isAllready` 같은 값들은 이미 participants state에 있기때문에 또 useState로 상태를 만들면 중복 상태라고 생각했습니다. 그래서 해당 값들은 상태가 아닌 변수를 만들어서 처리했습니다. 

## Button 컴포넌트에 ready 스타일 추가
ui적으로 옆에있는 공유버튼과 loading 스타일 버튼이 같이 있으면 어색한데 어떻게 고쳐야 좋을지 잘 모르겠더라고요. 그래서 임시로 ready 스타일도 만들어봤는데 둘중 어떤 스타일이 더 좋은것 같나요? 

<p align="center">
  <img src="https://github.com/user-attachments/assets/a7ce61c0-d7a4-4d84-a065-d0b5f86de469" width="45%" alt="Ready 스타일"/>
  &nbsp;&nbsp;&nbsp;&nbsp;
  <img src="https://github.com/user-attachments/assets/a55ffd3b-56e8-4218-a891-885d500b5cf7" width="45%" alt="Loading 스타일"/>
</p>

<p align="center">
  <b>좌: Ready 스타일 / 우: Loading 스타일</b>
</p>




https://github.com/user-attachments/assets/bf2c48b3-0c96-4ff2-a79d-461b40710dcd




# 💬 리뷰 중점사항
중점사항
