### PR TITLE
[refactor] Selectbox 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/@common/SelectBox/SelectBox.stories.tsx
+++ b/frontend/src/components/@common/SelectBox/SelectBox.stories.tsx
@@ -22,10 +22,6 @@ const meta = {
       control: 'text',
       description: '선택되지 않았을 때 표시되는 텍스트',
     },
-    disabled: {
-      control: 'boolean',
-      description: '비활성화 상태',
-    },
     onChange: {
       action: 'changed',
       description: '옵션 선택 시 실행되는 함수',
@@ -67,14 +63,6 @@ export const WithValue: Story = {
   },
 };
 
-export const Disabled: Story = {
-  args: {
-    options: basicOptions,
-    disabled: true,
-    placeholder: '비활성화된 SelectBox',
-  },
-};
-
 export const Interactive = () => {
   const [selectedValue, setSelectedValue] = useState<Option>({
     id: -1,
@@ -87,7 +75,7 @@ export const Interactive = () => {
     { id: 3, name: '카푸치노' },
     { id: 4, name: '마끼아또' },
     { id: 5, name: '카페 모카' },
-    { id: 6, name: '에스프레소', disabled: true },
+    { id: 6, name: '에스프레소' },
   ];
 
   return (

--- a/frontend/src/components/@common/SelectBox/SelectBox.styled.ts
+++ b/frontend/src/components/@common/SelectBox/SelectBox.styled.ts
@@ -6,18 +6,15 @@ export type ContainerProps = {
 };
 
 export type TriggerProps = {
-  $disabled?: boolean;
   $isOpen: boolean;
 };
 
 export type SelectTextProps = {
   $hasValue: boolean;
-  $disabled?: boolean;
 };
 
 export type ArrowIconProps = {
   $isOpen: boolean;
-  $disabled?: boolean;
 };
 
 export type ContentProps = {
@@ -25,7 +22,6 @@ export type ContentProps = {
 };
 
 export type ItemProps = {
-  $disabled?: boolean;
   $selected?: boolean;
 };
 
@@ -40,7 +36,7 @@ export const Trigger = styled.div<TriggerProps>`
   align-items: center;
   justify-content: space-between;
   padding: 8px 0;
-  background-color: ${({ $disabled, theme }) => ($disabled ? theme.color.gray[50] : 'white')};
+  background-color: 'white';
 
   border-bottom: 2px solid
     ${({ theme, $isOpen }) => {
@@ -48,23 +44,17 @@ export const Trigger = styled.div<TriggerProps>`
       return theme.color.gray[200];
     }};
 
-  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+  cursor: pointer;
   user-select: none;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover:not(:disabled) {
-      border-bottom-color: ${({ theme, $disabled }) => {
-        if ($disabled) return theme.color.gray[200];
-        return theme.color.gray[400];
-      }};
+      border-bottom-color: ${({ theme }) => theme.color.gray[400]};
     }
   }
   @media (hover: none) {
     &:active:not(:disabled) {
-      border-bottom-color: ${({ theme, $disabled }) => {
-        if ($disabled) return theme.color.gray[200];
-        return theme.color.gray[400];
-      }};
+      border-bottom-color: ${({ theme }) => theme.color.gray[400]};
     }
   }
 
@@ -75,8 +65,7 @@ export const Trigger = styled.div<TriggerProps>`
 `;
 
 export const SelectText = styled.span<SelectTextProps>`
-  color: ${({ theme, $hasValue, $disabled }) => {
-    if ($disabled) return theme.color.gray[400];
+  color: ${({ theme, $hasValue }) => {
     if ($hasValue) return theme.color.gray[700];
     return theme.color.gray[300];
   }};
@@ -93,8 +82,7 @@ export const ArrowIcon = styled.div<ArrowIconProps>`
   height: 0;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-top: 6px solid
-    ${({ theme, $disabled }) => ($disabled ? theme.color.gray[300] : theme.color.gray[400])};
+  border-top: 6px solid ${({ theme }) => theme.color.gray[400]};
 
   transform: ${({ $isOpen }) => ($isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
   transition: transform 0.2s ease;
@@ -128,13 +116,12 @@ export const Content = styled.ul<ContentProps>`
 
 export const Item = styled.li<ItemProps>`
   padding: 8px 12px;
-  cursor: ${({ $disabled }) => ($disabled ? 'default' : 'pointer')};
+  cursor: pointer;
 
   background-color: ${({ $selected, theme }) =>
     $selected ? theme.color.gray[100] : 'transparent'};
 
-  color: ${({ theme, $disabled, $selected }) => {
-    if ($disabled) return theme.color.gray[300];
+  color: ${({ theme, $selected }) => {
     if ($selected) return theme.color.gray[900];
     return theme.color.gray[700];
   }};

--- a/frontend/src/components/@common/SelectBox/SelectBox.tsx
+++ b/frontend/src/components/@common/SelectBox/SelectBox.tsx
@@ -1,123 +1,69 @@
-import { ComponentProps, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { ComponentProps } from 'react';
 import * as S from './SelectBox.styled';
+import useSelectBox from './hooks/useSelectBox';
+import useClickOutside from './hooks/useClickOutside';
 
 export type Option = {
   id: number;
   name: string;
-  disabled?: boolean;
 };
 
 export type Props = Omit<ComponentProps<'div'>, 'onChange'> & {
   options: Option[];
-  value?: string;
+  value: string;
   placeholder?: string;
-  disabled?: boolean;
   width?: string;
   height?: string;
   onChange?: (value: Option) => void;
-  onFocus?: () => void;
-  onBlur?: () => void;
 };
 
 const SelectBox = ({
   options,
   value,
   placeholder = '선택하세요',
-  disabled = false,
   width = '100%',
   height = '32px',
   onChange,
-  onFocus,
-  onBlur,
   ...rest
 }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const {
+    isOpen,
+    setIsOpen,
+    containerRef,
+    triggerRef,
+    selectedOption,
+    handleOptionClick,
+    handleTriggerClick,
+    handleKeyDown,
+  } = useSelectBox(options, value, onChange);
 
-  const selectedOption = options.find((option) => option.name === value);
-
-  const handleOptionClick = (optionId: Option) => {
-    if (disabled) return;
-
-    onChange?.(optionId);
-    setIsOpen(false);
-    triggerRef.current?.focus();
-  };
-
-  const handleTriggerClick = () => {
-    if (disabled) return;
-
-    setIsOpen(!isOpen);
-    if (!isOpen) onFocus?.();
-  };
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (disabled) return;
-
-    switch (e.key) {
-      case 'Enter':
-      case ' ': {
-        e.preventDefault();
-        setIsOpen(!isOpen);
-        break;
-      }
-      case 'Escape': {
-        setIsOpen(false);
-        triggerRef.current?.focus();
-        break;
-      }
-      case 'ArrowDown': {
-        e.preventDefault();
-        if (!isOpen) setIsOpen(true);
-        break;
-      }
-      case 'ArrowUp': {
-        e.preventDefault();
-        break;
-      }
-    }
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-        onBlur?.();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [onBlur]);
+  useClickOutside(containerRef, () => setIsOpen(false));
 
   return (
     <S.Container ref={containerRef} $width={width} $height={height} {...rest}>
       <S.Trigger
         ref={triggerRef}
-        $disabled={disabled}
         $isOpen={isOpen}
         onClick={handleTriggerClick}
         onKeyDown={handleKeyDown}
-        tabIndex={disabled ? -1 : 0}
+        tabIndex={0}
         role="combobox"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-label={selectedOption ? selectedOption.name : placeholder}
       >
-        <S.SelectText $hasValue={!!selectedOption} $disabled={disabled}>
+        <S.SelectText $hasValue={!!selectedOption}>
           {selectedOption ? selectedOption.name : placeholder}
         </S.SelectText>
-        <S.ArrowIcon $isOpen={isOpen} $disabled={disabled} />
+        <S.ArrowIcon $isOpen={isOpen} />
       </S.Trigger>
 
       <S.Content $isOpen={isOpen} role="listbox">
         {options.map((option) => (
           <S.Item
             key={option.id}
-            $disabled={option.disabled}
             $selected={option.name === value}
-            onClick={() => !option.disabled && handleOptionClick(option)}
+            onClick={() => handleOptionClick(option)}
             role="option"
             aria-selected={String(option.id) === value}
           >

--- a/frontend/src/components/@common/SelectBox/hooks/useClickOutside.ts
+++ b/frontend/src/components/@common/SelectBox/hooks/useClickOutside.ts
@@ -1,0 +1,16 @@
+import { RefObject, useEffect } from 'react';
+
+const useClickOutside = (ref: RefObject<HTMLElement | null>, callback: () => void) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [ref, callback]);
+};
+
+export default useClickOutside;

--- a/frontend/src/components/@common/SelectBox/hooks/useSelectBox.ts
+++ b/frontend/src/components/@common/SelectBox/hooks/useSelectBox.ts
@@ -1,0 +1,59 @@
+import { useRef, useState, KeyboardEvent } from 'react';
+import { Option } from '../SelectBox';
+
+const useSelectBox = (options: Option[], value: string, onChange?: (value: Option) => void) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find((option) => option.name === value);
+
+  const handleOptionClick = (option: Option) => {
+    onChange?.(option);
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleTriggerClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case 'Enter':
+      case ' ': {
+        e.preventDefault();
+        setIsOpen(!isOpen);
+        break;
+      }
+      case 'Escape': {
+        setIsOpen(false);
+        triggerRef.current?.focus();
+        break;
+      }
+      case 'ArrowDown': {
+        e.preventDefault();
+        if (!isOpen) setIsOpen(true);
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        if (isOpen) setIsOpen(false);
+        break;
+      }
+    }
+  };
+
+  return {
+    isOpen,
+    setIsOpen,
+    containerRef,
+    triggerRef,
+    selectedOption,
+    handleOptionClick,
+    handleTriggerClick,
+    handleKeyDown,
+  };
+};
+
+export default useSelectBox;


### PR DESCRIPTION
# 🔥 연관 이슈

- close #83

# 🚀 작업 내용

1. 기존에 쓰이지 않는 속성인 `disabled` 속성을 삭제했습니다.
2. 기존 select 컴포넌트의 관심사 분리를 위해 아래의 커스텀 훅으로 분리해주었습니다.

`useSelectBox`: `selectBox` 내부의 상태 관리 로직을 처리하는 커스텀 훅
`useClickOutside`: 외부 클릭을 감지하는 커스텀 훅

# 💬 논의 사항
컴포넌트 내부에 `hooks` 폴더를 만들어 `SelectBox` 컴포넌트 안에 넣었는데, 생각해보니 훅의 성격에 따라 위치를 구분해야 할 것 같습니다.
`useSelectBox` 같은 경우는 해당 컴포넌트에만 특화된 로직이라 현재 위치가 적절하다고 생각하는데, `useClickOutside` 훅은 모달, 드롭다운, 툴팁 등 다른 컴포넌트에서도 재사용 가능할 것 같습니다.
이런 경우 `useClickOutside`는 전역 `hooks` 폴더로 옮기는 것이 더 나은 구조라고 생각하는데, 어떻게 생각하시나용 ?.?
