### PR TITLE
[refactor] 다음 라운드로 넘어갈때 타이머 올바르게 초기화하기

### DIFF
--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -71,7 +71,7 @@ const CardGamePlayPage = () => {
         isTimerReset.current = true;
       }
     }
-  }, [currentTime, currentRound, currentCardGameState]);
+  }, [currentRound, currentCardGameState]);
 
   return isTransition ? (
     <MiniGameTransition currentRound={currentRound} />

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import MiniGameTransition from '@/features/miniGame/components/MiniGameTransition/MiniGameTransition';
 import Round from '../components/Round/Round';
 import { useCardGame } from '@/contexts/CardGame/CardGameContext';
@@ -20,7 +20,6 @@ const CardGamePlayPage = () => {
   const { isTransition, currentRound, currentCardGameState, cardInfos } = useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
   const { send } = useWebSocket();
-
   const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
     1: {
       index: -1,
@@ -33,6 +32,7 @@ const CardGamePlayPage = () => {
       value: null,
     },
   });
+  const isTimerReset = useRef(false);
 
   const handleCardClick = (cardIndex: number) => {
     if (selectedCardInfo[currentRound].index !== -1) {
@@ -65,8 +65,11 @@ const CardGamePlayPage = () => {
   }, [currentTime]);
 
   useEffect(() => {
-    if (currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING') {
-      setCurrentTime(TOTAL_COUNT);
+    if (currentRound === 2 && currentCardGameState === 'PLAYING') {
+      if (!isTimerReset.current) {
+        setCurrentTime(TOTAL_COUNT);
+        isTimerReset.current = true;
+      }
     }
   }, [currentTime, currentRound, currentCardGameState]);
 

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -65,11 +65,9 @@ const CardGamePlayPage = () => {
   }, [currentTime]);
 
   useEffect(() => {
-    if (currentRound === 2 && currentCardGameState === 'PLAYING') {
-      if (!isTimerReset.current) {
-        setCurrentTime(TOTAL_COUNT);
-        isTimerReset.current = true;
-      }
+    if (currentRound === 2 && currentCardGameState === 'PLAYING' && !isTimerReset.current) {
+      setCurrentTime(TOTAL_COUNT);
+      isTimerReset.current = true;
     }
   }, [currentRound, currentCardGameState]);
 


### PR DESCRIPTION
# 🔥 연관 이슈

- close #374 

# 🚀 작업 내용

수정 전 타이머 리셋 조건
```js
if (currentTime === 0 && currentRound === 2 && currentCardGameState === 'PLAYING')
```
**문제 발생 이유** 
카드를 다 클릭하고 넘어갔을 때는 currentTIme 이 0 이 아니여서 해당 조건을 만족하지 못했습니다. 
currentTIme===0 만 제거한 경우 2라운드 타이머가 게속 초기화되는 문제가 발생해서
useRef를 사용해서 타이머 초기화 상태를 저장해서 사용했습니다. 

수정 후 타이머 리셋 조건
```js
  if (currentRound === 2 && currentCardGameState === 'PLAYING') {
      if (!isTimerReset.current) {
        setCurrentTime(TOTAL_COUNT);
        isTimerReset.current = true;
      }
    }
```

수정 전 영상

https://github.com/user-attachments/assets/df1a4da2-b336-46cf-9907-28cc5ef7f5a5



수정 후 영상 


https://github.com/user-attachments/assets/5eca4700-4d2a-4d22-b715-83acc6cc299e


# 💬 리뷰 중점사항
중점사항
