### PR TITLE
[fix] 하나의 플로우가 끝날시 웹소켓 연결 안끊기는 문제 해결

### DIFF
--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -22,13 +22,14 @@ type ParticipantResponse = Player[];
 const OrderPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { send } = useWebSocket();
+  const { send, stopSocket, isConnected } = useWebSocket();
   const { joinCode } = useIdentifier();
   const [viewMode, setViewMode] = useState<'simple' | 'detail'>('simple');
   const [participants, setParticipants] = useState<ParticipantResponse>([]);
 
   const handleOrder = useCallback((data: ParticipantResponse) => {
     setParticipants(data);
+    stopSocket();
   }, []);
 
   useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleOrder);
@@ -37,8 +38,12 @@ const OrderPage = () => {
     setViewMode((prev) => (prev === 'simple' ? 'detail' : 'simple'));
   };
 
+  const handleClickGoMain = () => {
+    navigate('/');
+  };
+
   useEffect(() => {
-    if (joinCode) {
+    if (joinCode && isConnected) {
       send(`/room/${joinCode}/update-players`);
     }
   }, [joinCode, send]);
@@ -65,7 +70,7 @@ const OrderPage = () => {
         )}
       </Layout.Content>
       <Layout.ButtonBar flexRatios={[5.5, 1]}>
-        <Button variant="primary" onClick={() => navigate('/')}>
+        <Button variant="primary" onClick={handleClickGoMain}>
           메인 화면으로 가기
         </Button>
         <Button variant="primary" onClick={() => {}}>

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -27,10 +27,13 @@ const OrderPage = () => {
   const [viewMode, setViewMode] = useState<'simple' | 'detail'>('simple');
   const [participants, setParticipants] = useState<ParticipantResponse>([]);
 
-  const handleOrder = useCallback((data: ParticipantResponse) => {
-    setParticipants(data);
-    stopSocket();
-  }, []);
+  const handleOrder = useCallback(
+    (data: ParticipantResponse) => {
+      setParticipants(data);
+      stopSocket();
+    },
+    [stopSocket]
+  );
 
   useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleOrder);
 
@@ -46,7 +49,7 @@ const OrderPage = () => {
     if (joinCode && isConnected) {
       send(`/room/${joinCode}/update-players`);
     }
-  }, [joinCode, send]);
+  }, [joinCode, send, isConnected]);
 
   return (
     <Layout>


### PR DESCRIPTION
# 🔥 연관 이슈

- close #386 

마지막 OrderPage에서 data를 받고 웹소켓 연결을 끊는 로직을 추가해 주었습니다. 
연결을 끊었을때 send를 보내지 않도록 아래와 같이 isConntectd를 확인하게 조건을 추가하였습니다! 
```js
  useEffect(() => {
    if (joinCode && isConnected) {
      send(`/room/${joinCode}/update-players`);
    }
  }, [joinCode, send]);
```


# 🚀 작업 내용

1.

# 💬 리뷰 중점사항
중점사항
