### PR TITLE
[refacotr] 게임 결과  웹소켓 -> REST API 로 변경

### DIFF
--- a/frontend/src/contexts/CardGame/CardGameContext.ts
+++ b/frontend/src/contexts/CardGame/CardGameContext.ts
@@ -1,4 +1,4 @@
-import { CardGameState, CardInfo, PlayerRank, PlayerScore } from '@/types/miniGame';
+import { CardGameState, CardInfo } from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { createContext, useContext } from 'react';
 
@@ -8,8 +8,6 @@ type CardGameContextType = {
   currentRound: RoundKey;
   currentCardGameState: CardGameState;
   cardInfos: CardInfo[];
-  ranks: PlayerRank[];
-  scores: PlayerScore[];
 };
 
 export const CardGameContext = createContext<CardGameContextType | null>(null);

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -2,22 +2,9 @@ import { PropsWithChildren, useCallback, useState } from 'react';
 import { CardGameContext } from './CardGameContext';
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '../Identifier/IdentifierContext';
-import {
-  CardGameState,
-  CardGameStateData,
-  CardInfo,
-  PlayerRank,
-  PlayerScore,
-} from '@/types/miniGame';
+import { CardGameState, CardGameStateData, CardInfo } from '@/types/miniGame';
 import { RoundKey } from '@/types/round';
 import { useNavigate, useParams } from 'react-router-dom';
-
-export type CardGameScoresData = {
-  scores: PlayerScore[];
-};
-export type CardGameRanksData = {
-  ranks: PlayerRank[];
-};
 
 const CardGameProvider = ({ children }: PropsWithChildren) => {
   const navigate = useNavigate();
@@ -28,9 +15,6 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
   const [currentRound, setCurrentRound] = useState<RoundKey>(1);
   const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
   const [cardInfos, setCardInfos] = useState<CardInfo[]>([]);
-
-  const [scores, setScores] = useState<PlayerScore[]>([]);
-  const [ranks, setRanks] = useState<PlayerRank[]>([]);
 
   const handleCardGameState = useCallback(
     (data: CardGameStateData) => {
@@ -73,20 +57,7 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
     [navigate, joinCode, miniGameType]
   );
 
-  const handleCardGameRank = useCallback((data: CardGameRanksData) => {
-    const { ranks } = data;
-    ranks.sort((a, b) => a.rank - b.rank);
-    setRanks(ranks);
-  }, []);
-
-  const handleCardGameScore = useCallback((data: CardGameScoresData) => {
-    const { scores } = data;
-    setScores(scores);
-  }, []);
-
   useWebSocketSubscription(`/room/${joinCode}/gameState`, handleCardGameState);
-  useWebSocketSubscription(`/room/${joinCode}/rank`, handleCardGameRank);
-  useWebSocketSubscription(`/room/${joinCode}/score`, handleCardGameScore);
 
   return (
     <CardGameContext.Provider
@@ -96,8 +67,6 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         currentRound,
         currentCardGameState,
         cardInfos,
-        ranks,
-        scores,
       }}
     >
       {children}

--- a/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
+++ b/frontend/src/features/miniGame/pages/MiniGameResultPage/MiniGameResultPage.tsx
@@ -9,19 +9,32 @@ import PlayerCard from '@/components/@composition/PlayerCard/PlayerCard';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import Layout from '@/layouts/Layout';
 import { Probability } from '@/types/roulette';
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import * as S from './MiniGameResultPage.styled';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
-import { useCardGame } from '@/contexts/CardGame/CardGameContext';
 import { colorList } from '@/constants/color';
+import { MiniGameType, PlayerRank, PlayerScore } from '@/types/miniGame';
+import { api } from '@/apis/rest/api';
+import { ApiError, NetworkError } from '@/apis/rest/error';
+
+type RankResponse = {
+  ranks: PlayerRank[];
+};
+type ScoreResponse = {
+  scores: PlayerScore[];
+};
 
 const MiniGameResultPage = () => {
   const navigate = useNavigate();
+  const miniGameType = useParams<{ miniGameType: MiniGameType }>().miniGameType;
   const { send } = useWebSocket();
   const { myName, joinCode } = useIdentifier();
   const { playerType } = usePlayerType();
-  const { ranks, scores } = useCardGame();
+  const [ranks, setRanks] = useState<PlayerRank[] | null>(null);
+  const [scores, setScores] = useState<PlayerScore[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const handlePlayerProbabilitiesData = useCallback(
     (data: Probability[]) => {
@@ -49,6 +62,34 @@ const MiniGameResultPage = () => {
     send(`/room/${joinCode}/get-probabilities`);
   };
 
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+
+        const { ranks } = await api.get<RankResponse>(
+          `/minigames/ranks?joinCode=${joinCode}&miniGameType=${miniGameType}`
+        );
+        const { scores } = await api.get<ScoreResponse>(
+          `/minigames/scores?joinCode=${joinCode}&miniGameType=${miniGameType}`
+        );
+        ranks.sort((a, b) => a.rank - b.rank);
+        setRanks(ranks);
+        setScores(scores);
+      } catch (error) {
+        if (error instanceof ApiError) {
+          setError(error.message);
+        } else if (error instanceof NetworkError) {
+          setError('네트워크 연결을 확인해주세요');
+        } else {
+          setError('알 수 없는 오류가 발생했습니다');
+        }
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [joinCode, miniGameType]);
+
   return (
     <Layout>
       <Layout.Banner height="30%">
@@ -61,23 +102,29 @@ const MiniGameResultPage = () => {
         </S.Banner>
       </Layout.Banner>
       <Layout.Content>
-        <S.ResultList>
-          {ranks.map((playerRank) => (
-            <S.PlayerCardWrapper
-              key={playerRank.playerName}
-              isHighlighted={playerRank.playerName === myName}
-            >
-              <Headline3>
-                <S.RankNumber rank={playerRank.rank}>{playerRank.rank}</S.RankNumber>
-              </Headline3>
-              <PlayerCard name={playerRank.playerName} playerColor={'#FF6B6B'}>
-                <Headline4>
-                  {scores.find((score) => score.playerName === playerRank.playerName)?.score}점
-                </Headline4>
-              </PlayerCard>
-            </S.PlayerCardWrapper>
-          ))}
-        </S.ResultList>
+        {loading ? (
+          <div>로딩 중...</div>
+        ) : error ? (
+          <div>{error}</div>
+        ) : ranks && scores ? (
+          <S.ResultList>
+            {ranks.map((playerRank) => (
+              <S.PlayerCardWrapper
+                key={playerRank.playerName}
+                isHighlighted={playerRank.playerName === myName}
+              >
+                <Headline3>
+                  <S.RankNumber rank={playerRank.rank}>{playerRank.rank}</S.RankNumber>
+                </Headline3>
+                <PlayerCard name={playerRank.playerName} playerColor={'#FF6B6B'}>
+                  <Headline4>
+                    {scores.find((score) => score.playerName === playerRank.playerName)?.score}점
+                  </Headline4>
+                </PlayerCard>
+              </S.PlayerCardWrapper>
+            ))}
+          </S.ResultList>
+        ) : null}
       </Layout.Content>
       <Layout.ButtonBar>
         {playerType === 'HOST' ? (


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #382 

# 🚀 작업 내용

게임 결과 웹소켓 -> REST API 로 변경했습니다. 
변경하는 과정에서 minigameContext에 있던 점수/랭킹 관련 로직과 점수/랭킹 웹소켓 연결을 삭제하였습니다. 
미니게임 결과 페이지에서 api를 호출하도록 하였습니다. 

# 💬 리뷰 중점사항

중점사항
