### PR TITLE
[fix] Sentry DSN 키를 환경 변수에서 하드코딩 값으로 변경

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,9 +6,9 @@ import './styles/global.css';
 import './styles/reset.css';
 import * as Sentry from '@sentry/react';
 
-if (process.env.NODE_ENV === 'production' && process.env.REACT_APP_DSN_KEY) {
+if (process.env.NODE_ENV === 'production') {
   Sentry.init({
-    dsn: process.env.REACT_APP_DSN_KEY,
+    dsn: 'https://b2afc6b0a990c07e81f7458240917d0f@o4509780188987392.ingest.us.sentry.io/4509784133271552',
     release: process.env.REACT_APP_VERSION,
     environment: process.env.NODE_ENV,
     sendDefaultPii: true,


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)


# 🚀 작업 내용

DSN 키는 원래 의도적으로 공개되도록 설정되었더라구요.

배포 환경에서는 Sentry 에러가 안잡히는데, 개발 환경에서는 Sentry 에러가 잘 잡혀서 문제를 찾아보니,
환경변수 이슈인 것 같아서 우선 DSN 키 환경변수를 하드코딩 식으로 바꿔두었습니다.

[My DSN key is publicly visible, is this a security vulnerability?](https://sentry.zendesk.com/hc/en-us/articles/26741783759899-My-DSN-key-is-publicly-visible-is-this-a-security-vulnerability)

자료 출처는 @ExceptAnyone 입니다 :)