### PR TITLE
[fix] 룰렛 play페이지 상세 통계에서 현재 확률 보여주도록 수정

### DIFF
--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
@@ -81,7 +81,7 @@ const RoulettePlayPage = () => {
           {isRouletteView ? (
             <RoulettePlaySection isSpinning={isSpinning} />
           ) : (
-            <ProbabilityList playerProbabilities={probabilityHistory.prev} />
+            <ProbabilityList playerProbabilities={probabilityHistory.current} />
           )}
           <S.IconButtonWrapper>
             <IconButton


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

룰렛 상세 페이지에서 이전 확률이 나오고 있는 오류 수정

<img width="540" height="486" alt="image" src="https://github.com/user-attachments/assets/a0feb5b2-bdd6-49ee-8e53-1c826d1b3785" />



# 🚀 작업 내용

1.

# 💬 리뷰 중점사항

중점사항
