### PR TITLE
[fix]  플레이어 색과 룰렛 색깔 연동되도록 수정

### DIFF
--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
@@ -25,7 +25,11 @@ const RoulettePlaySection = ({ isSpinning }: Props) => {
 
   return (
     <S.Container>
-      <RouletteWheel isSpinning={isSpinning} angles={angles} />
+      <RouletteWheel
+        isSpinning={isSpinning}
+        angles={angles}
+        playerProbabilities={probabilityHistory.current}
+      />
       <S.ProbabilityText>
         <Headline4>
           당첨 확률 {myProbabilityChange >= 0 ? '+' : ''}

--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
@@ -81,7 +81,7 @@ const RoulettePlayPage = () => {
           {isRouletteView ? (
             <RoulettePlaySection isSpinning={isSpinning} />
           ) : (
-            <ProbabilityList playerProbabilities={probabilityHistory.prev} />
+            <ProbabilityList playerProbabilities={probabilityHistory.current} />
           )}
           <S.IconButtonWrapper>
             <IconButton

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
@@ -3,14 +3,11 @@ import { describeArc } from '../../utils/describeArc';
 import { getPlayersWithAngles } from '../../utils/getPlayerWithAngles.ts';
 import { polarToCartesian } from '../../utils/polarToCartesian';
 import { PlayerProbability } from '@/types/roulette';
-import { colorList } from '@/constants/color';
 import * as S from './RouletteWheel.styled';
 
 type Angle = { playerName: string; startAngle: number; endAngle: number };
 
-type Props =
-  | { angles: Angle[]; playerProbabilities?: never; isSpinning?: boolean }
-  | { playerProbabilities: PlayerProbability[]; angles?: never; isSpinning?: boolean };
+type Props = { angles?: Angle[]; playerProbabilities: PlayerProbability[]; isSpinning?: boolean };
 
 const getCenterAngle = (startAngle: number, endAngle: number) => {
   return (startAngle + endAngle) / 2;
@@ -42,7 +39,7 @@ const RouletteWheel = ({ angles, playerProbabilities, isSpinning = false }: Prop
                       startAngle: player.startAngle,
                       endAngle: player.endAngle,
                     })}
-                    fill={colorList[index % colorList.length]}
+                    fill={playerProbabilities[index].playerColor}
                     stroke={theme.color.point[100]}
                     strokeWidth="1"
                   />
@@ -74,7 +71,7 @@ const RouletteWheel = ({ angles, playerProbabilities, isSpinning = false }: Prop
       <S.Container>
         <S.Wrapper $isSpinning={isSpinning}>
           <svg width={300} height={300} viewBox="0 0 300 300">
-            {playersWithAngles.map((player, index) => {
+            {playersWithAngles.map((player) => {
               const centerAngle = getCenterAngle(player.startAngle, player.endAngle);
               const textPosition = getTextPosition(centerAngle);
 
@@ -88,7 +85,7 @@ const RouletteWheel = ({ angles, playerProbabilities, isSpinning = false }: Prop
                       startAngle: player.startAngle,
                       endAngle: player.endAngle,
                     })}
-                    fill={colorList[index % colorList.length]}
+                    fill={player.playerColor}
                     stroke={theme.color.point[100]}
                   />
                   <S.PlayerNameText


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용


https://github.com/user-attachments/assets/5fd8e9c5-28e9-43ae-94a5-f0e838268220



# 💬 리뷰 중점사항

중점사항
