### PR TITLE
[fix] RestExceptionHandler에서 HandlerMethod 제거

### DIFF
--- a/backend/src/main/java/coffeeshout/global/exception/RestExceptionHandler.java
+++ b/backend/src/main/java/coffeeshout/global/exception/RestExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.method.HandlerMethod;
 
 @RestControllerAdvice
 @Slf4j
@@ -21,10 +20,9 @@ public class RestExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleException(
             Exception exception,
-            HandlerMethod handler,
             HttpServletRequest request
     ) {
-        logError(exception, handler, request);
+        logError(exception, request);
         return getProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, exception, new ErrorCode() {
             @Override
             public String getCode() {
@@ -41,30 +39,27 @@ public class RestExceptionHandler {
     @ExceptionHandler(InvalidArgumentException.class)
     public ProblemDetail handleInvalidArgumentException(
             InvalidArgumentException exception,
-            HandlerMethod handler,
             HttpServletRequest request
     ) {
-        logWarning(exception, handler, request);
+        logWarning(exception, request);
         return getProblemDetail(HttpStatus.BAD_REQUEST, exception, exception.getErrorCode());
     }
 
     @ExceptionHandler(InvalidStateException.class)
     public ProblemDetail handleInvalidStateException(
             InvalidStateException exception,
-            HandlerMethod handler,
             HttpServletRequest request
     ) {
-        logError(exception, handler, request);
+        logError(exception, request);
         return getProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, exception, exception.getErrorCode());
     }
 
     @ExceptionHandler(NotExistElementException.class)
     public ProblemDetail handleNotExistElementException(
             NotExistElementException exception,
-            HandlerMethod handler,
             HttpServletRequest request
     ) {
-        logWarning(exception, handler, request);
+        logWarning(exception, request);
         return getProblemDetail(HttpStatus.NOT_FOUND, exception, exception.getErrorCode());
     }
 
@@ -80,13 +75,10 @@ public class RestExceptionHandler {
 
     private void logError(
             final Exception e,
-            final HandlerMethod handler,
             final HttpServletRequest request
     ) {
         final String logMessage = String.format(
-                "%s.%s | method=%s uri=%s exception=%s message=%s",
-                handler.getBeanType().getSimpleName(),
-                handler.getMethod().getName(),
+                "method=%s uri=%s exception=%s message=%s",
                 request.getMethod(),
                 request.getRequestURI(),
                 e.getClass().getSimpleName(),
@@ -97,13 +89,10 @@ public class RestExceptionHandler {
 
     private void logWarning(
             final Exception e,
-            final HandlerMethod handler,
             final HttpServletRequest request
     ) {
         final String logMessage = String.format(
-                "%s.%s | method=%s uri=%s exception=%s message=%s",
-                handler.getBeanType().getSimpleName(),
-                handler.getMethod().getName(),
+                "method=%s uri=%s exception=%s message=%s",
                 request.getMethod(),
                 request.getRequestURI(),
                 e.getClass().getSimpleName(),


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #465

# 🚀 작업 내용

- 예외 핸들링 시 필요 없는 HandlerMethod 인수 제거

# 💬 리뷰 중점사항

우선, 당장 에러가 발생하는 걸 해결하고,
추후 nginx에서 하든, 필터에서 하든 부적절한 경로로 요청이 들어오는 걸 막는 게 좋을 것 같아요~
