### PR TITLE
[feat] 앱 전환 시 웹소켓 재연결 및 해제 로직 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/handler/CustomStompChannelInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/handler/CustomStompChannelInterceptor.java
@@ -153,11 +153,9 @@ public class CustomStompChannelInterceptor implements ChannelInterceptor {
         final String sessionId = accessor.getSessionId();
 
         // STOMP 명령이 아닌 내부 메시지는 무시
-        if (!(commandObj instanceof StompCommand)) {
+        if (!(commandObj instanceof final StompCommand command)) {
             return;
         }
-
-        final StompCommand command = (StompCommand) commandObj;
 
         try {
             if (command == StompCommand.CONNECT && sent) {

--- a/backend/src/main/java/coffeeshout/global/handler/CustomStompChannelInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/handler/CustomStompChannelInterceptor.java
@@ -30,7 +30,6 @@ public class CustomStompChannelInterceptor implements ChannelInterceptor {
     private final RoomService roomService;
     private final RoomQueryService roomQueryService;
     private final ApplicationEventPublisher eventPublisher;
-//    private final LoggingSimpMessagingTemplate messagingTemplate; // 순환 의존성 해결을 위해 제거
 
     // 중복 처리 방지용
     private final Set<String> processedDisconnections = ConcurrentHashMap.newKeySet();

--- a/backend/src/main/java/coffeeshout/global/interceptor/CustomStompChannelInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/CustomStompChannelInterceptor.java
@@ -1,4 +1,4 @@
-package coffeeshout.global.handler;
+package coffeeshout.global.interceptor;
 
 import coffeeshout.global.metric.WebSocketMetricService;
 import coffeeshout.global.websocket.event.RoomStateUpdateEvent;

--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEvent.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEvent.java
@@ -1,0 +1,11 @@
+package coffeeshout.global.websocket.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RoomStateUpdateEvent {
+    private final String joinCode;
+    private final String reason; // "PLAYER_REMOVED", "PLAYER_RECONNECTED" 등
+}

--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
@@ -1,0 +1,40 @@
+package coffeeshout.global.websocket.event;
+
+import coffeeshout.global.ui.WebSocketResponse;
+import coffeeshout.global.websocket.LoggingSimpMessagingTemplate;
+import coffeeshout.room.application.RoomService;
+import coffeeshout.room.ui.response.PlayerResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomStateUpdateEventListener {
+
+    private final RoomService roomService;
+    private final LoggingSimpMessagingTemplate messagingTemplate;
+
+    @EventListener
+    public void handleRoomStateUpdate(RoomStateUpdateEvent event) {
+        try {
+            log.info("방 상태 업데이트 이벤트 처리: joinCode={}, reason={}", event.getJoinCode(), event.getReason());
+            
+            final List<PlayerResponse> responses = roomService.getAllPlayers(event.getJoinCode())
+                    .stream()
+                    .map(PlayerResponse::from)
+                    .toList();
+
+            messagingTemplate.convertAndSend("/topic/room/" + event.getJoinCode(),
+                    WebSocketResponse.success(responses));
+                    
+            log.info("방 상태 브로드캐스트 완료: joinCode={}, playerCount={}", event.getJoinCode(), responses.size());
+            
+        } catch (Exception e) {
+            log.error("방 상태 업데이트 이벤트 처리 실패: joinCode={}, reason={}", event.getJoinCode(), event.getReason(), e);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -138,4 +138,9 @@ public class RoomService {
         final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
         return room.getSelectedMiniGameTypes();
     }
+
+    public boolean removePlayer(String joinCode, String playerName) {
+        final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
+        return room.removePlayer(new PlayerName(playerName));
+    }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -4,7 +4,6 @@ import static org.springframework.util.Assert.isTrue;
 import static org.springframework.util.Assert.state;
 
 import coffeeshout.global.exception.custom.InvalidArgumentException;
-import coffeeshout.global.exception.custom.InvalidStateException;
 import coffeeshout.minigame.domain.MiniGameResult;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.player.Menu;
@@ -123,7 +122,7 @@ public class Room {
         return Collections.unmodifiableList(new ArrayList<>(miniGames));
     }
 
-    public List<MiniGameType> getSelectedMiniGameTypes(){
+    public List<MiniGameType> getSelectedMiniGameTypes() {
         return getAllMiniGame().stream()
                 .map(Playable::getMiniGameType)
                 .toList();
@@ -195,5 +194,21 @@ public class Room {
                     "중복된 닉네임은 들어올 수 없습니다. 닉네임: " + guestName.value()
             );
         }
+    }
+
+    public boolean removePlayer(PlayerName playerName) {
+        Player playerToRemove = null;
+        try {
+            playerToRemove = findPlayer(playerName);
+        } catch (Exception e) {
+            // 플레이어가 이미 없으면 false 반환
+            return false;
+        }
+
+        boolean removed = players.removePlayer(playerName);
+        if (removed && playerToRemove != null) {
+            roulette.removePlayer(playerToRemove);
+        }
+        return removed;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/player/Players.java
+++ b/backend/src/main/java/coffeeshout/room/domain/player/Players.java
@@ -43,4 +43,8 @@ public class Players {
         return players.stream()
                 .allMatch(Player::getIsReady);
     }
+
+    public boolean removePlayer(PlayerName playerName) {
+        return players.removeIf(player -> player.sameName(playerName));
+    }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/roulette/Roulette.java
+++ b/backend/src/main/java/coffeeshout/room/domain/roulette/Roulette.java
@@ -50,4 +50,18 @@ public class Roulette {
     public Map<Player, Probability> getProbabilities() {
         return Map.copyOf(playerProbabilities);
     }
+
+    public boolean removePlayer(Player player) {
+        if (playerProbabilities.remove(player) != null) {
+            // 남은 플레이어들의 확률 재조정
+            if (!playerProbabilities.isEmpty()) {
+                final Probability probability = Probability.TOTAL.divide(getPlayerCount());
+                for (Map.Entry<Player, Probability> entry : playerProbabilities.entrySet()) {
+                    entry.setValue(probability);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
 }

--- a/backend/src/test/java/coffeeshout/minigame/ui/CardGameIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/ui/CardGameIntegrationTest.java
@@ -179,7 +179,6 @@ class CardGameIntegrationTest extends WebSocketIntegrationTestSupport {
         MiniGameStateMessage loadingState = responses.get().data();
         assertThat(loadingState.cardGameState()).isEqualTo(CardGameState.LOADING.name());
 
-
         // PLAYING 상태 확인
         MiniGameStateMessage playingState = responses.get().data();
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #454

# 🚀 작업 내용

- `CustomStompChannelInterceptor`에서 WebSocket 연결 해제, 에러 및 실패 시 플레이어 제거 로직 추가
- `handlePlayerDisconnection` 메서드로 게임 진행 중 연결 해제 시 복구 절차 구현
- 세션 및 플레이어 매핑 관리 로직 개선 (`playerSessionMap`, `sessionPlayerMap`)
- `RoomService`에 플레이어 제거 메서드(`removePlayer`) 추가
- 룰렛에서 플레이어 제거 시 확률 리밸런싱 로직 구현
- `Players` 및 `Roulette` 클래스에 플레이어 삭제 기능 추가

# 💬 리뷰 중점사항

중점사항
