### PR TITLE
[feat] 미니게임 선택 안하면 게임을 시작하지 못하도록 하기

### DIFF
--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -97,7 +97,15 @@ const LobbyPage = () => {
   };
 
   const handleClickGameStartButton = () => {
-    if (participants.length < 2) return;
+    if (participants.length < 2) {
+      alert('참여자가 없어 게임을 진행할 수 없습니다.');
+      return;
+    }
+
+    if (selectedMiniGames.length === 0) {
+      alert('선택된 미니게임이 없어 게임을 진행할 수 없습니다.');
+      return;
+    }
 
     send(`/room/${joinCode}/minigame/command`, {
       commandType: 'START_MINI_GAME',


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #402 

# 🚀 작업 내용

1. 참여자가 나 혼자이거나 미니게임이 선택된게 없을 경우, `alert`를 띄우도록 했습니다.

# 💬 리뷰 중점사항

중점사항
