### PR TITLE
[fix] 플레이어의 역할에 따라 재입장시 isReady 다르게 설정

### DIFF
--- a/backend/src/main/java/coffeeshout/global/interceptor/CustomStompChannelInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/CustomStompChannelInterceptor.java
@@ -211,9 +211,9 @@ public class CustomStompChannelInterceptor implements ChannelInterceptor {
             // 1. 방 존재 확인
             final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
 
-            // 2. 플레이어가 방에 있는지 확인
+            // 2. 방에 플레이어 재생성
             final Menu menu = menuQueryService.findById(menuId);
-            room.joinGuest(new PlayerName(playerName), menu);
+            room.reJoin(new PlayerName(playerName), menu);
 
             // 3. 방 상태 확인
             if (room.isPlayingState()) {

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -161,6 +161,31 @@ public class Room {
         return players.hasDuplicateName(guestName);
     }
 
+    public boolean removePlayer(PlayerName playerName) {
+        Player playerToRemove = null;
+        try {
+            playerToRemove = findPlayer(playerName);
+        } catch (Exception e) {
+            // 플레이어가 이미 없으면 false 반환
+            return false;
+        }
+
+        boolean removed = players.removePlayer(playerName);
+        if (removed && playerToRemove != null) {
+            roulette.removePlayer(playerToRemove);
+        }
+        return removed;
+    }
+
+    public void reJoin(PlayerName playerName, Menu menu) {
+        validateRoomReady();
+        validateCanJoin();
+        validatePlayerNameNotDuplicate(playerName);
+
+        final Player player = createPlayerByRole(playerName, menu);
+        join(player);
+    }
+
     private boolean hasEnoughPlayers() {
         return players.hasEnoughPlayers(MINIMUM_GUEST_COUNT, MAXIMUM_GUEST_COUNT);
     }
@@ -196,19 +221,10 @@ public class Room {
         }
     }
 
-    public boolean removePlayer(PlayerName playerName) {
-        Player playerToRemove = null;
-        try {
-            playerToRemove = findPlayer(playerName);
-        } catch (Exception e) {
-            // 플레이어가 이미 없으면 false 반환
-            return false;
+    private Player createPlayerByRole(PlayerName playerName, Menu menu) {
+        if (host.sameName(playerName)) {
+            return Player.createHost(playerName, menu);
         }
-
-        boolean removed = players.removePlayer(playerName);
-        if (removed && playerToRemove != null) {
-            roulette.removePlayer(playerToRemove);
-        }
-        return removed;
+        return Player.createGuest(playerName, menu);
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #494 

# 🚀 작업 내용

- 앱 전환하고 재입장 시에, 플레이어의 역할에 따라 Ready 상태를 다르게 주입하도록 수정했습니다.

# 💬 리뷰 중점사항

중점사항
