### PR TITLE
[fix] 카드 선택시 화면에 동기화가 안되는 문제

### DIFF
--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -62,6 +62,18 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         setStartCardGame(true);
         setCurrentCardGameState('PLAYING');
         setCardInfos(cardInfoMessages);
+
+        const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
+        if (!myCardInfo) return;
+
+        setSelectedCardInfo((prev) => ({
+          ...prev,
+          [currentRound]: {
+            isSelected: true,
+            type: myCardInfo.cardType,
+            value: myCardInfo.value,
+          },
+        }));
         return;
       }
 
@@ -81,6 +93,17 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         setIsTransition(false);
         setCardInfos(cardInfoMessages);
         setCurrentCardGameState('PLAYING');
+        const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
+        if (!myCardInfo) return;
+
+        setSelectedCardInfo((prev) => ({
+          ...prev,
+          [currentRound]: {
+            isSelected: true,
+            type: myCardInfo.cardType,
+            value: myCardInfo.value,
+          },
+        }));
         return;
       }
 

--- a/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/cardGame/pages/CardGamePlayPage.tsx
@@ -8,14 +8,8 @@ import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 const CardGamePlayPage = () => {
   const { myName, joinCode } = useIdentifier();
-  const {
-    isTransition,
-    currentRound,
-    currentCardGameState,
-    cardInfos,
-    selectedCardInfo,
-    setSelectedCardInfo,
-  } = useCardGame();
+  const { isTransition, currentRound, currentCardGameState, cardInfos, selectedCardInfo } =
+    useCardGame();
   const [currentTime, setCurrentTime] = useState(TOTAL_COUNT);
   const { send } = useWebSocket();
 
@@ -25,15 +19,6 @@ const CardGamePlayPage = () => {
     if (selectedCardInfo[currentRound].isSelected) {
       return;
     }
-
-    setSelectedCardInfo((prev) => ({
-      ...prev,
-      [currentRound]: {
-        isSelected: true,
-        type: cardInfos[cardIndex].cardType,
-        value: cardInfos[cardIndex].value,
-      },
-    }));
 
     send(`/room/${joinCode}/minigame/command`, {
       commandType: 'SELECT_CARD',


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #495 


# 🚀 작업 내용

### 문제 원인:

- 카드 클릭 시 setSelectedCardInfo 호출로 상태가 변경되어 재렌더링 발생.
- 현재 웹소켓 구독/해제 로직이 useEffect에서 마운트/언마운트 시점에 실행되는데, 재렌더링 시 언마운트 → 구독 해제 발생.
- 하필 이 구독 해제 타이밍에 서버에서 메시지가 도착해 클라이언트가 수신하지 못함.
- setSelectedCardInfo를 Provider로 올려놨지만, 여전히 하위 컴포넌트에서 이를 호출하는 방식을 유지한 것이 원인으로 보임.

### 해결방법:
- setSelectedCardInfo를 아예 서버에서 내려주는 메세지에서 내 카드를 추출해서 하는 방식으로 변경
 - cardGameProvider만 setSelectedCardINfo를 사용하도록 바꿈 

바꾸니까 정상 동작 합니다! 


https://github.com/user-attachments/assets/e1117c1f-bdcd-45af-965d-a06ca121d0f0




# 💬 리뷰 중점사항

중점사항
