### PR TITLE
[refactor] 카드게임 0점이 많이 나오는 현상 개선

### DIFF
--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/CardGame.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/CardGame.java
@@ -20,8 +20,8 @@ import lombok.NonNull;
 @Getter
 public class CardGame implements Playable {
 
-    private static final int ADDITION_CARD_COUNT = 6;
-    private static final int MULTIPLIER_CARD_COUNT = 3;
+    private static final int ADDITION_CARD_COUNT = 7;
+    private static final int MULTIPLIER_CARD_COUNT = 2;
 
     private final Deck deck;
     private PlayerHands playerHands;

--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/AdditionCard.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/AdditionCard.java
@@ -3,13 +3,21 @@ package coffeeshout.minigame.domain.cardgame.card;
 public class AdditionCard extends Card {
 
     public static final AdditionCard PLUS_40 = new AdditionCard(40);
+    public static final AdditionCard PLUS_35 = new AdditionCard(35);
     public static final AdditionCard PLUS_30 = new AdditionCard(30);
+    public static final AdditionCard PLUS_25 = new AdditionCard(25);
     public static final AdditionCard PLUS_20 = new AdditionCard(20);
+    public static final AdditionCard PLUS_15 = new AdditionCard(15);
     public static final AdditionCard PLUS_10 = new AdditionCard(10);
+    public static final AdditionCard PLUS_5 = new AdditionCard(5);
     public static final AdditionCard ZERO = new AdditionCard(0);
+    public static final AdditionCard MINUS_5 = new AdditionCard(-5);
     public static final AdditionCard MINUS_10 = new AdditionCard(-10);
+    public static final AdditionCard MINUS_15 = new AdditionCard(-15);
     public static final AdditionCard MINUS_20 = new AdditionCard(-20);
+    public static final AdditionCard MINUS_25 = new AdditionCard(-25);
     public static final AdditionCard MINUS_30 = new AdditionCard(-30);
+    public static final AdditionCard MINUS_35 = new AdditionCard(-35);
     public static final AdditionCard MINUS_40 = new AdditionCard(-40);
 
     public AdditionCard(int value) {

--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/AdditionCards.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/AdditionCards.java
@@ -1,13 +1,21 @@
 package coffeeshout.minigame.domain.cardgame.card;
 
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_10;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_15;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_20;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_25;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_30;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_35;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_40;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.MINUS_5;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_10;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_15;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_20;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_25;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_30;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_35;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_40;
+import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.PLUS_5;
 import static coffeeshout.minigame.domain.cardgame.card.AdditionCard.ZERO;
 import static org.springframework.util.Assert.isTrue;
 
@@ -22,13 +30,21 @@ public class AdditionCards {
     public AdditionCards() {
         this.cards = new ArrayList<>();
         this.cards.add(PLUS_40);
+        this.cards.add(PLUS_35);
         this.cards.add(PLUS_30);
+        this.cards.add(PLUS_25);
         this.cards.add(PLUS_20);
+        this.cards.add(PLUS_15);
         this.cards.add(PLUS_10);
+        this.cards.add(PLUS_5);
         this.cards.add(ZERO);
+        this.cards.add(MINUS_5);
         this.cards.add(MINUS_10);
+        this.cards.add(MINUS_15);
         this.cards.add(MINUS_20);
+        this.cards.add(MINUS_25);
         this.cards.add(MINUS_30);
+        this.cards.add(MINUS_35);
         this.cards.add(MINUS_40);
     }
 

--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCard.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCard.java
@@ -4,7 +4,6 @@ public class MultiplierCard extends Card {
 
     public static final MultiplierCard QUADRUPLE = new MultiplierCard(4);
     public static final MultiplierCard DOUBLE = new MultiplierCard(2);
-    public static final MultiplierCard NULLIFY = new MultiplierCard(0);
     public static final MultiplierCard INVERT = new MultiplierCard(-1);
 
     public MultiplierCard(int value) {

--- a/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCards.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCards.java
@@ -2,7 +2,6 @@ package coffeeshout.minigame.domain.cardgame.card;
 
 import static coffeeshout.minigame.domain.cardgame.card.MultiplierCard.DOUBLE;
 import static coffeeshout.minigame.domain.cardgame.card.MultiplierCard.INVERT;
-import static coffeeshout.minigame.domain.cardgame.card.MultiplierCard.NULLIFY;
 import static coffeeshout.minigame.domain.cardgame.card.MultiplierCard.QUADRUPLE;
 import static org.springframework.util.Assert.isTrue;
 
@@ -18,7 +17,6 @@ public class MultiplierCards {
         this.cards = new ArrayList<>();
         this.cards.add(QUADRUPLE);
         this.cards.add(DOUBLE);
-        this.cards.add(NULLIFY);
         this.cards.add(INVERT);
     }
 

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/CardGameScoreTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/CardGameScoreTest.java
@@ -63,22 +63,6 @@ class CardGameScoreTest {
         assertThat(score.getValue()).isEqualTo(20);
     }
 
-
-    @Test
-    void 무효화_카드로_점수를_업데이트한다() {
-        // given
-        CardHand hand = new CardHand();
-        hand.put(AdditionCard.PLUS_40);
-        hand.put(MultiplierCard.NULLIFY);
-
-        // when
-        CardGameScore score = hand.calculateCardGameScore();
-
-        // then
-        assertThat(score.getValue()).isEqualTo(0);
-    }
-
-
     @Test
     void 계산된_점수가_같으면_동일하다() {
         // given

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/PlayerHandsTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/PlayerHandsTest.java
@@ -127,7 +127,7 @@ class PlayerHandsTest {
             // when - 두 번째 라운드
             playerHands.put(players.getPlayer(new PlayerName("꾹이")), MultiplierCard.DOUBLE);
             playerHands.put(players.getPlayer(new PlayerName("루키")), MultiplierCard.QUADRUPLE);
-            playerHands.put(players.getPlayer(new PlayerName("한스")), MultiplierCard.NULLIFY);
+            playerHands.put(players.getPlayer(new PlayerName("한스")), MultiplierCard.INVERT);
             assertThat(playerHands.isRoundFinished()).isFalse();
             playerHands.put(players.getPlayer(new PlayerName("엠제이")), AdditionCard.ZERO);
 
@@ -174,7 +174,7 @@ class PlayerHandsTest {
             playerHands.put(player1, AdditionCard.PLUS_40);
             playerHands.put(player1, MultiplierCard.DOUBLE);
             playerHands.put(player2, AdditionCard.PLUS_30);
-            playerHands.put(player2, MultiplierCard.NULLIFY);
+            playerHands.put(player2, MultiplierCard.INVERT);
 
             // when
             Map<Player, MiniGameScore> scores = playerHands.scoreByPlayer();
@@ -182,7 +182,7 @@ class PlayerHandsTest {
             // then
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(scores.get(player1).getValue()).isEqualTo(80);
-                softly.assertThat(scores.get(player2).getValue()).isEqualTo(0);
+                softly.assertThat(scores.get(player2).getValue()).isEqualTo(-30);
                 softly.assertThat(scores).hasSize(4);
             });
         }

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/AdditionCardsTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/AdditionCardsTest.java
@@ -28,7 +28,7 @@ class AdditionCardsTest {
     void 최대_사용_가능한_카드_수를_초과하면_예외가_발생한다() {
         // given
         AdditionCards additionCards = new AdditionCards();
-        int count = 10;
+        int count = 20;
 
         // when & then
         assertThatThrownBy(() -> additionCards.pickCards(count))

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/DeckTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/DeckTest.java
@@ -25,12 +25,12 @@ class DeckTest {
                 AdditionCard.PLUS_20,
                 AdditionCard.PLUS_10,
                 AdditionCard.ZERO,
-                AdditionCard.MINUS_10
+                AdditionCard.MINUS_10,
+                AdditionCard.MINUS_20
         );
         multiplierCards = List.of(
                 MultiplierCard.QUADRUPLE,
-                MultiplierCard.DOUBLE,
-                MultiplierCard.INVERT
+                MultiplierCard.DOUBLE
         );
         deck = new Deck(additionCards, multiplierCards);
     }

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/DeckTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/DeckTest.java
@@ -30,7 +30,7 @@ class DeckTest {
         multiplierCards = List.of(
                 MultiplierCard.QUADRUPLE,
                 MultiplierCard.DOUBLE,
-                MultiplierCard.NULLIFY
+                MultiplierCard.INVERT
         );
         deck = new Deck(additionCards, multiplierCards);
     }

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCardTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCardTest.java
@@ -64,7 +64,6 @@ class MultiplierCardTest {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(MultiplierCard.QUADRUPLE.getType()).isEqualTo(CardType.MULTIPLIER);
             softly.assertThat(MultiplierCard.DOUBLE.getType()).isEqualTo(CardType.MULTIPLIER);
-            softly.assertThat(MultiplierCard.NULLIFY.getType()).isEqualTo(CardType.MULTIPLIER);
             softly.assertThat(MultiplierCard.INVERT.getType()).isEqualTo(CardType.MULTIPLIER);
         });
     }

--- a/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCardsTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/domain/cardgame/card/MultiplierCardsTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MultiplierCardsTest {
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3, 4})
+    @ValueSource(ints = {1, 2, 3})
     void 요청한_개수만큼_카드를_뽑는다(int count) {
         // given
         MultiplierCards multiplierCards = new MultiplierCards();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #505 

# 🚀 작업 내용

1. 곱하기 카드에서 x 0 제거
2. 카드게임 카드 구성 7, 2로 수정
3. 더하기 카드에서 구성 변경
    - 기존 (+40 ~ -40 까지 10단위)
    - 변경 (+40 ~ -40 까지 5단위)
4. 깨지는 테스트 수정

# 💬 리뷰 중점사항

중점사항
