### PR TITLE
[fix] 뒤로가기 시 발생하는 웹소켓 관련 이슈

### DIFF
--- a/frontend/src/components/@common/BackButton/BackButton.tsx
+++ b/frontend/src/components/@common/BackButton/BackButton.tsx
@@ -5,7 +5,6 @@ type Props = {
   onClick: () => void;
 } & ComponentProps<'button'>;
 
-//TODO: 구현 필요
 const BackButton = ({ onClick, ...rest }: Props) => {
   return (
     <button onClick={onClick} {...rest}>

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -1,5 +1,6 @@
 import { api } from '@/apis/rest/api';
 import { ApiError, NetworkError } from '@/apis/rest/error';
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import BackButton from '@/components/@common/BackButton/BackButton';
 import Button from '@/components/@common/Button/Button';
 import Headline3 from '@/components/@common/Headline3/Headline3';
@@ -10,7 +11,6 @@ import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EntryMenuPage.styled';
-import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 // TODO: category 타입 따로 관리 필요 (string이 아니라 유니온 타입으로 지정해서 아이콘 매핑해야함)
 type MenusResponse = {

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -1,15 +1,15 @@
+import { api } from '@/apis/rest/api';
 import BackButton from '@/components/@common/BackButton/BackButton';
 import Button from '@/components/@common/Button/Button';
 import Headline3 from '@/components/@common/Headline3/Headline3';
 import Input from '@/components/@common/Input/Input';
 import ProgressCounter from '@/components/@common/ProgressCounter/ProgressCounter';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import Layout from '@/layouts/Layout';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EntryNamePage.styled';
-import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
-import { api } from '@/apis/rest/api';
-import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 
 const MAX_NAME_LENGTH = 10;
 

--- a/frontend/src/features/home/pages/HomePage.tsx
+++ b/frontend/src/features/home/pages/HomePage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import EnterRoomModal from '../components/EnterRoomModal/EnterRoomModal';
 import Splash from '../components/Splash/Splash';
 import * as S from './HomePage.styled';
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -17,10 +18,14 @@ const HomePage = () => {
   const { openModal, closeModal } = useModal();
   const { setHost, setGuest } = usePlayerType();
   const { clearIdentifier } = useIdentifier();
+  const { isConnected, stopSocket } = useWebSocket();
 
   useEffect(() => {
+    if (isConnected) {
+      stopSocket();
+    }
     clearIdentifier();
-  }, [clearIdentifier]);
+  }, [clearIdentifier, isConnected, stopSocket]);
 
   useEffect(() => {
     const checkFirstVisit = () => {

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -104,7 +104,7 @@ const LobbyPage = () => {
     }
   }, [playerType, joinCode, send]);
 
-  const handleClickBackButton = () => {
+  const handleNavigateToHome = () => {
     navigate('/');
   };
 
@@ -227,7 +227,7 @@ const LobbyPage = () => {
 
   return (
     <Layout>
-      <Layout.TopBar left={<BackButton onClick={handleClickBackButton} />} />
+      <Layout.TopBar left={<BackButton onClick={handleNavigateToHome} />} />
       <Layout.Content>
         <S.Container>
           {SECTIONS[currentSection]}

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -10,32 +10,28 @@ import Headline3 from '@/components/@common/Headline3/Headline3';
 import IconButton from '@/components/@common/IconButton/IconButton';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import Layout from '@/layouts/Layout';
+import { Player } from '@/types/player';
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import * as S from './OrderPage.styled';
 import MenuCount from '../components/MenuCount/MenuCount';
 import PlayerMenu from '../components/PlayerMenu/PlayerMenu';
-import { Player } from '@/types/player';
+import * as S from './OrderPage.styled';
 
 type ParticipantResponse = Player[];
 
 const OrderPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { send, stopSocket, isConnected } = useWebSocket();
+  const { send, isConnected } = useWebSocket();
   const { joinCode } = useIdentifier();
   const [viewMode, setViewMode] = useState<'simple' | 'detail'>('simple');
 
   // TODO: 전역으로 분리
   const [participants, setParticipants] = useState<ParticipantResponse>([]);
 
-  const handleOrder = useCallback(
-    (data: ParticipantResponse) => {
-      setParticipants(data);
-      stopSocket();
-    },
-    [stopSocket]
-  );
+  const handleOrder = useCallback((data: ParticipantResponse) => {
+    setParticipants(data);
+  }, []);
 
   useWebSocketSubscription<ParticipantResponse>(`/room/${joinCode}`, handleOrder);
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #537 

# 🚀 작업 내용

### 문제 상황
메인 페이지로 이동하기 직전에 stopSocket()을 호출해야 하는 위치가 총 3곳이 있었음.

- EntryNamePage: 뒤로가기 버튼 클릭 시
- LobbyPage: 뒤로가기 버튼 클릭 시
- OrderPage: ‘메인 화면으로 가기’ 버튼 클릭 시

이로 인해 동일한 코드가 3번 반복되는 중복 문제가 있었음.
기존에는 OrderPage 에 대해서만 stopSocket()이 호출되고 있었기 때문에 아래 문제 1, 2가 발생했음.

- 문제 1: 방 생성 후 뒤로가기 버튼 눌러서 메인 페이지로 이동한 후에 새로운 초대코드로 방을 참여할 때 해당 사용자가 방에 존재하지 않는 문제
- 문제 2: 방 참가 후 뒤로가기 시 사용자가 방에서 사라지지 않는 문제

### 해결 방안
하지만 각 페이지별로 개별 stopSocket() 호출하는 것이 아니라, stopSocket() 호출을 메인 페이지 진입 시점으로 일원화.
이렇게 하면 EntryNamePage, LobbyPage, OrderPage에서 모두 메인 페이지로 이동하므로, 한 곳에서만 소켓 해제 로직을 관리할 수 있음. 이로써 코드 중복을 제거하고 유지보수하기 쉬워짐.

### 추가 현황
추가로, OrderPage에서 발생하던 사용자별 소켓이 끊기는 시점 차이로 인해 발생하는 사용자 주문 정보 누락 문제도 방지 가능.

하지만, 누군가가 메인 페이지로 이동할 경우에는 소켓이 끊겨서, 다시 브로드캐스트되므로 사용자 정보가 재업데이트되어서 동일하게 사용자 주문 정보가 누락되는 현상이 있음.

고로 Players 정보를 전역으로 분리함으로써, 해당 OrderPage에서는 실시간 웹소켓 정보에 의존하지 않고, 클라이언트에 관리하는 Players 정보를 사용해서 화면에 렌더링 해줄 것.