### PR TITLE
[feat] player의 Disconnect 감지 시, 15초 뒤에 삭제되는 로직 구현

### DIFF
--- a/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
@@ -17,7 +17,7 @@ public class DelayRemovalSchedulerConfig {
         final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 
         // 스레드 풀 크기 (동시 실행되는 스케줄 작업 수에 따라 조정)
-        scheduler.setPoolSize(2);
+        scheduler.setPoolSize(1);
 
         // 스레드 이름 접두사
         scheduler.setThreadNamePrefix("delay-removal-task");

--- a/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
@@ -1,0 +1,40 @@
+package coffeeshout.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+@Slf4j
+public class DelayRemovalSchedulerConfig {
+
+    @Bean(name = "delayRemovalScheduler")
+    public TaskScheduler delayRemovalTaskScheduler() {
+        final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+        // 스레드 풀 크기 (동시 실행되는 스케줄 작업 수에 따라 조정)
+        scheduler.setPoolSize(2);
+
+        // 스레드 이름 접두사
+        scheduler.setThreadNamePrefix("delay-removal-task");
+
+        // 스레드가 데몬 스레드로 동작할지 여부
+        scheduler.setDaemon(false);
+
+        // 에러 핸들러 (스케줄 실행 중 예외 로깅)
+        scheduler.setErrorHandler(t ->
+                log.error("스케줄 실행 중 예외가 발생했습니다.")
+        );
+
+        // 종료 시 현재 실행 중인 작업 완료 대기
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/postsend/ConnectPostSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/postsend/ConnectPostSendHandler.java
@@ -2,7 +2,7 @@ package coffeeshout.global.interceptor.handler.postsend;
 
 import coffeeshout.global.interceptor.handler.PostSendHandler;
 import coffeeshout.global.metric.WebSocketMetricService;
-import coffeeshout.global.websocket.PlayerDisconnectionService;
+import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +17,7 @@ public class ConnectPostSendHandler implements PostSendHandler {
 
     private final StompSessionManager sessionManager;
     private final WebSocketMetricService webSocketMetricService;
-    private final PlayerDisconnectionService playerDisconnectionService;
+    private final DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     @Override
     public StompCommand getCommand() {
@@ -39,7 +39,7 @@ public class ConnectPostSendHandler implements PostSendHandler {
         if (sessionManager.hasPlayerKey(sessionId)) {
             final String failedPlayerKey = sessionManager.getPlayerKey(sessionId);
             sessionManager.removeSession(sessionId);
-            playerDisconnectionService.handlePlayerDisconnection(failedPlayerKey, sessionId, "CONNECTION_FAILED");
+            delayedPlayerRemovalService.schedulePlayerRemoval(failedPlayerKey, sessionId, "CONNECTION_FAILED");
         }
 
         webSocketMetricService.failConnection(sessionId, "connection_response_failed");

--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
@@ -2,6 +2,7 @@ package coffeeshout.global.interceptor.handler.presend;
 
 import coffeeshout.global.interceptor.handler.PreSendHandler;
 import coffeeshout.global.metric.WebSocketMetricService;
+import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
@@ -25,6 +26,7 @@ public class ConnectPreSendHandler implements PreSendHandler {
     private final WebSocketMetricService webSocketMetricService;
     private final RoomQueryService roomQueryService;
     private final MenuQueryService menuQueryService;
+    private final DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     @Override
     public StompCommand getCommand() {
@@ -67,6 +69,10 @@ public class ConnectPreSendHandler implements PreSendHandler {
 
         // 새 세션으로 등록
         sessionManager.registerPlayerSession(joinCode, playerName, sessionId);
+        
+        // 기존 지연 삭제 취소
+        final String playerKey = sessionManager.createPlayerKey(joinCode, playerName);
+        delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
         // 재연결 처리
         parseMenuId(menuId).ifPresentOrElse(

--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ErrorPreSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ErrorPreSendHandler.java
@@ -33,7 +33,6 @@ public class ErrorPreSendHandler implements PreSendHandler {
         if (sessionManager.hasPlayerKey(sessionId)) {
             final String errorPlayerKey = sessionManager.getPlayerKey(sessionId);
 
-            sessionManager.removeSession(sessionId);
             delayedPlayerRemovalService.schedulePlayerRemoval(errorPlayerKey, sessionId, "STOMP_ERROR");
         }
 

--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ErrorPreSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ErrorPreSendHandler.java
@@ -2,7 +2,7 @@ package coffeeshout.global.interceptor.handler.presend;
 
 import coffeeshout.global.interceptor.handler.PreSendHandler;
 import coffeeshout.global.metric.WebSocketMetricService;
-import coffeeshout.global.websocket.PlayerDisconnectionService;
+import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +17,7 @@ public class ErrorPreSendHandler implements PreSendHandler {
 
     private final StompSessionManager sessionManager;
     private final WebSocketMetricService webSocketMetricService;
-    private final PlayerDisconnectionService playerDisconnectionService;
+    private final DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     @Override
     public StompCommand getCommand() {
@@ -34,7 +34,7 @@ public class ErrorPreSendHandler implements PreSendHandler {
             final String errorPlayerKey = sessionManager.getPlayerKey(sessionId);
 
             sessionManager.removeSession(sessionId);
-            playerDisconnectionService.handlePlayerDisconnection(errorPlayerKey, sessionId, "STOMP_ERROR");
+            delayedPlayerRemovalService.schedulePlayerRemoval(errorPlayerKey, sessionId, "STOMP_ERROR");
         }
 
         webSocketMetricService.recordDisconnection(sessionId, "stomp_error", false);

--- a/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
@@ -25,10 +25,7 @@ public class DelayedPlayerRemovalService {
     public void schedulePlayerRemoval(String playerKey, String sessionId, String reason) {
         log.info("플레이어 지연 삭제 스케줄링: playerKey={}, sessionId={}, delay={}초",
                 playerKey, sessionId, REMOVAL_DELAY.getSeconds());
-
-        // 기존 스케줄 있으면 취소
-        // cancelScheduledRemoval(playerKey);
-
+        
         // 새로운 스케줄 등록
         final ScheduledFuture<?> future = taskScheduler.schedule(
                 () -> executePlayerRemoval(playerKey, sessionId, reason),
@@ -60,8 +57,5 @@ public class DelayedPlayerRemovalService {
         }
     }
 
-    public boolean hasScheduledRemoval(String playerKey) {
-        ScheduledFuture<?> future = scheduledTasks.get(playerKey);
-        return future != null && !future.isDone();
-    }
+
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
@@ -27,10 +27,10 @@ public class DelayedPlayerRemovalService {
                 playerKey, sessionId, REMOVAL_DELAY.getSeconds());
 
         // 기존 스케줄 있으면 취소
-        cancelScheduledRemoval(playerKey);
+        // cancelScheduledRemoval(playerKey);
 
         // 새로운 스케줄 등록
-        ScheduledFuture<?> future = taskScheduler.schedule(
+        final ScheduledFuture<?> future = taskScheduler.schedule(
                 () -> executePlayerRemoval(playerKey, sessionId, reason),
                 Instant.now().plus(REMOVAL_DELAY)
         );
@@ -39,7 +39,7 @@ public class DelayedPlayerRemovalService {
     }
 
     public void cancelScheduledRemoval(String playerKey) {
-        ScheduledFuture<?> future = scheduledTasks.remove(playerKey);
+        final ScheduledFuture<?> future = scheduledTasks.remove(playerKey);
         if (future != null && !future.isDone()) {
             future.cancel(false);
             log.info("플레이어 지연 삭제 취소됨: playerKey={}", playerKey);

--- a/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
@@ -1,0 +1,67 @@
+package coffeeshout.global.websocket;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DelayedPlayerRemovalService {
+
+    private static final Duration REMOVAL_DELAY = Duration.ofSeconds(15);
+
+    @Qualifier("delayRemovalScheduler")
+    private final TaskScheduler taskScheduler;
+    private final PlayerDisconnectionService playerDisconnectionService;
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    public void schedulePlayerRemoval(String playerKey, String sessionId, String reason) {
+        log.info("플레이어 지연 삭제 스케줄링: playerKey={}, sessionId={}, delay={}초",
+                playerKey, sessionId, REMOVAL_DELAY.getSeconds());
+
+        // 기존 스케줄 있으면 취소
+        cancelScheduledRemoval(playerKey);
+
+        // 새로운 스케줄 등록
+        ScheduledFuture<?> future = taskScheduler.schedule(
+                () -> executePlayerRemoval(playerKey, sessionId, reason),
+                Instant.now().plus(REMOVAL_DELAY)
+        );
+
+        scheduledTasks.put(playerKey, future);
+    }
+
+    public void cancelScheduledRemoval(String playerKey) {
+        ScheduledFuture<?> future = scheduledTasks.remove(playerKey);
+        if (future != null && !future.isDone()) {
+            future.cancel(false);
+            log.info("플레이어 지연 삭제 취소됨: playerKey={}", playerKey);
+        }
+    }
+
+    private void executePlayerRemoval(String playerKey, String sessionId, String reason) {
+        try {
+            log.info("플레이어 지연 삭제 실행: playerKey={}, sessionId={}, reason={}",
+                    playerKey, sessionId, reason);
+
+            playerDisconnectionService.handlePlayerDisconnection(playerKey, sessionId, reason);
+            scheduledTasks.remove(playerKey);
+
+        } catch (Exception e) {
+            log.error("플레이어 지연 삭제 실행 중 오류 발생: playerKey={}, error={}",
+                    playerKey, e.getMessage(), e);
+        }
+    }
+
+    public boolean hasScheduledRemoval(String playerKey) {
+        ScheduledFuture<?> future = scheduledTasks.get(playerKey);
+        return future != null && !future.isDone();
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
@@ -13,9 +13,8 @@ import coffeeshout.global.interceptor.handler.postsend.DisconnectPostSendHandler
 import coffeeshout.global.interceptor.handler.presend.ConnectPreSendHandler;
 import coffeeshout.global.interceptor.handler.presend.ErrorPreSendHandler;
 import coffeeshout.global.metric.WebSocketMetricService;
-import coffeeshout.global.websocket.PlayerDisconnectionService;
+import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
-import coffeeshout.room.application.RoomService;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.player.Menu;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -53,9 +51,9 @@ class CustomStompChannelInterceptorTest {
 
     @Mock
     private MessageChannel channel;
-
+    
     @Mock
-    private ApplicationEventPublisher eventPublisher;
+    private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     private StompSessionManager sessionManager;
     private CustomStompChannelInterceptor interceptor;
@@ -73,24 +71,16 @@ class CustomStompChannelInterceptorTest {
     void setUp() {
         // 실제 구현체 생성
         sessionManager = new StompSessionManager();
-        final RoomService roomService = mock(RoomService.class);
-        final PlayerDisconnectionService playerDisconnectionService = new PlayerDisconnectionService(sessionManager,
-                roomService);
-        eventPublisher = new ApplicationEventPublisher() {
-            @Override
-            public void publishEvent(Object event) {
-            }
-        };
 
         // 핸들러들 생성
         connectPreSendHandler = new ConnectPreSendHandler(sessionManager, webSocketMetricService, roomQueryService,
-                menuQueryService);
+                menuQueryService, delayedPlayerRemovalService);
         connectPostSendHandler = new ConnectPostSendHandler(sessionManager, webSocketMetricService,
-                playerDisconnectionService);
+                delayedPlayerRemovalService);
         disconnectPostSendHandler = new DisconnectPostSendHandler(sessionManager, webSocketMetricService,
-                playerDisconnectionService, eventPublisher);
+                delayedPlayerRemovalService);
         errorPreSendHandler = new ErrorPreSendHandler(sessionManager, webSocketMetricService,
-                playerDisconnectionService);
+                delayedPlayerRemovalService);
 
         // 핸들러 레지스트리 생성
         final StompHandlerRegistry handlerRegistry = new StompHandlerRegistry(

--- a/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 import coffeeshout.global.interceptor.handler.StompHandlerRegistry;
@@ -51,7 +50,7 @@ class CustomStompChannelInterceptorTest {
 
     @Mock
     private MessageChannel channel;
-    
+
     @Mock
     private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
@@ -329,7 +328,6 @@ class CustomStompChannelInterceptorTest {
             errorPreSendHandler.handle(accessor, sessionId);
 
             // then - 세션이 제거되었는지 확인
-            assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
             then(webSocketMetricService).should().recordDisconnection(sessionId, "stomp_error", false);
         }
 

--- a/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import coffeeshout.global.metric.WebSocketMetricService;
+import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
@@ -36,6 +37,9 @@ class ConnectPreSendHandlerTest {
 
     @Mock
     private MenuQueryService menuQueryService;
+    
+    @Mock
+    private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     private StompSessionManager sessionManager;
     private ConnectPreSendHandler connectPreSendHandler;
@@ -52,7 +56,8 @@ class ConnectPreSendHandlerTest {
                 sessionManager,
                 webSocketMetricService,
                 roomQueryService,
-                menuQueryService
+                menuQueryService,
+                delayedPlayerRemovalService
         );
     }
 

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package coffeeshout.global.websocket;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -51,8 +50,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
 
             // then - 15초 후 실행을 기다림 (테스트에서는 짧게 조정할 수 없어서 긴 시간이 필요)
             // 실제 운영에서는 15초지만, 테스트에서는 적절한 시간으로 조정 필요
-            await()
-                    .atMost(20, TimeUnit.SECONDS)
+            await().atMost(20, TimeUnit.SECONDS)
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
@@ -68,8 +66,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
             // then - 15초 기다려도 실행되지 않음
-            await()
-                    .during(Duration.ofSeconds(2)) // 2초 동안 호출되지 않음을 확인
+            await().during(Duration.ofSeconds(2)) // 2초 동안 호출되지 않음을 확인
                     .atMost(Duration.ofSeconds(3))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should(never())
@@ -94,8 +91,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.schedulePlayerRemoval(player3, "session-3", reason);
 
             // then - 모든 플레이어가 독립적으로 처리됨
-            await()
-                    .atMost(20, TimeUnit.SECONDS)
+            await().atMost(20, TimeUnit.SECONDS)
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(player1, "session-1", reason);
@@ -116,8 +112,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
 
             // then - 실행 완료 후 PlayerDisconnectionService 호출됨을 확인
-            await()
-                    .atMost(20, TimeUnit.SECONDS)
+            await().atMost(20, TimeUnit.SECONDS)
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
@@ -133,8 +128,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
             // then - 취소 후 일정 시간이 지나도 호출되지 않음
-            await()
-                    .during(Duration.ofSeconds(2))
+            await().during(Duration.ofSeconds(2))
                     .atMost(Duration.ofSeconds(3))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should(never())
@@ -157,18 +151,5 @@ class DelayedPlayerRemovalServiceIntegrationTest {
         // 테스트에서는 더 짧은 지연시간 사용하고 싶다면 이런 식으로 오버라이드 가능
         // 하지만 현재 구조상 REMOVAL_DELAY가 private static final이라 어렵다
         // 실제로는 설정으로 빼거나 생성자 주입으로 받는 게 좋을 듯
-    }
-
-    @Nested
-    class 빠른_테스트_시나리오 {
-        // 실제 15초 기다리기 어려우면 이런 식으로 더 짧은 지연시간으로 테스트
-        // 단, DelayedPlayerRemovalService 구조 변경 필요
-
-        @Test
-        void 설정으로_지연시간을_조정할_수_있다면_더_빠른_테스트가_가능하다() {
-            // 현재는 하드코딩되어 있어서 불가능
-            // Duration REMOVAL_DELAY를 생성자나 설정으로 주입받도록 리팩토링하면
-            // 테스트에서는 짧은 시간으로 설정 가능
-        }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
@@ -16,8 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
- * DelayedPlayerRemovalService의 실제 타이밍 기반 통합 테스트
- * 실제 TaskScheduler를 사용하여 지연 실행을 테스트한다.
+ * DelayedPlayerRemovalService의 실제 타이밍 기반 통합 테스트 실제 TaskScheduler를 사용하여 지연 실행을 테스트한다.
  */
 @ExtendWith(MockitoExtension.class)
 class DelayedPlayerRemovalServiceIntegrationTest {
@@ -28,7 +27,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
     private ThreadPoolTaskScheduler taskScheduler;
     private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
-    private final String playerKey = "ABC123:김철수";
+    private final String playerKey = "ABC23:김철수";
     private final String sessionId = "session-123";
     private final String reason = "CLIENT_DISCONNECT";
 
@@ -91,7 +90,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
 
             // when
             delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, firstSessionId, reason);
-            
+
             // 잠시 후 재스케줄링
             await().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> true);
             delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, secondSessionId, reason);
@@ -114,9 +113,9 @@ class DelayedPlayerRemovalServiceIntegrationTest {
         @Test
         void 여러_플레이어가_동시에_스케줄링되어도_안전하게_처리된다() {
             // given
-            String player1 = "ABC123:김철수";
-            String player2 = "DEF456:박영희";
-            String player3 = "GHI789:이민수";
+            String player1 = "ABC23:김철수";
+            String player2 = "DEF56:박영희";
+            String player3 = "GHI89:이민수";
 
             // when - 동시에 여러 플레이어 스케줄링
             delayedPlayerRemovalService.schedulePlayerRemoval(player1, "session-1", reason);
@@ -201,14 +200,13 @@ class DelayedPlayerRemovalServiceIntegrationTest {
     }
 
     /**
-     * 테스트용 DelayedPlayerRemovalService
-     * 실제 15초 대신 짧은 시간으로 테스트할 수 있도록 오버라이드
+     * 테스트용 DelayedPlayerRemovalService 실제 15초 대신 짧은 시간으로 테스트할 수 있도록 오버라이드
      */
     private static class TestDelayedPlayerRemovalService extends DelayedPlayerRemovalService {
         private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(500); // 500ms로 단축
 
-        public TestDelayedPlayerRemovalService(ThreadPoolTaskScheduler taskScheduler, 
-                                             PlayerDisconnectionService playerDisconnectionService) {
+        public TestDelayedPlayerRemovalService(ThreadPoolTaskScheduler taskScheduler,
+                                               PlayerDisconnectionService playerDisconnectionService) {
             super(taskScheduler, playerDisconnectionService);
         }
 
@@ -221,7 +219,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
     class 빠른_테스트_시나리오 {
         // 실제 15초 기다리기 어려우면 이런 식으로 더 짧은 지연시간으로 테스트
         // 단, DelayedPlayerRemovalService 구조 변경 필요
-        
+
         @Test
         void 설정으로_지연시간을_조정할_수_있다면_더_빠른_테스트가_가능하다() {
             // 현재는 하드코딩되어 있어서 불가능

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
@@ -25,6 +25,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
 
     private ThreadPoolTaskScheduler taskScheduler;
     private DelayedPlayerRemovalService delayedPlayerRemovalService;
+    private StompSessionManager stompSessionManager;
 
     private final String playerKey = "ABC23:김철수";
     private final String sessionId = "session-123";
@@ -36,8 +37,10 @@ class DelayedPlayerRemovalServiceIntegrationTest {
         taskScheduler.setPoolSize(5);
         taskScheduler.setThreadNamePrefix("test-scheduler-");
         taskScheduler.initialize();
+        stompSessionManager = new StompSessionManager();
 
-        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService);
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService,
+                stompSessionManager);
     }
 
     @Nested
@@ -144,8 +147,9 @@ class DelayedPlayerRemovalServiceIntegrationTest {
         private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(500); // 500ms로 단축
 
         public TestDelayedPlayerRemovalService(ThreadPoolTaskScheduler taskScheduler,
-                                               PlayerDisconnectionService playerDisconnectionService) {
-            super(taskScheduler, playerDisconnectionService);
+                                               PlayerDisconnectionService playerDisconnectionService,
+                                               StompSessionManager stompSessionManager) {
+            super(taskScheduler, playerDisconnectionService, stompSessionManager);
         }
 
         // 테스트에서는 더 짧은 지연시간 사용하고 싶다면 이런 식으로 오버라이드 가능

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
@@ -1,0 +1,232 @@
+package coffeeshout.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * DelayedPlayerRemovalService의 실제 타이밍 기반 통합 테스트
+ * 실제 TaskScheduler를 사용하여 지연 실행을 테스트한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class DelayedPlayerRemovalServiceIntegrationTest {
+
+    @Mock
+    private PlayerDisconnectionService playerDisconnectionService;
+
+    private ThreadPoolTaskScheduler taskScheduler;
+    private DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    private final String playerKey = "ABC123:김철수";
+    private final String sessionId = "session-123";
+    private final String reason = "CLIENT_DISCONNECT";
+
+    @BeforeEach
+    void setUp() {
+        taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(5);
+        taskScheduler.setThreadNamePrefix("test-scheduler-");
+        taskScheduler.initialize();
+
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService);
+    }
+
+    @Nested
+    class 실제_지연_실행_테스트 {
+
+        @Test
+        void 지연시간_후_실제로_PlayerDisconnectionService가_호출된다() {
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // then - 15초 후 실행을 기다림 (테스트에서는 짧게 조정할 수 없어서 긴 시간이 필요)
+            // 실제 운영에서는 15초지만, 테스트에서는 적절한 시간으로 조정 필요
+            await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(playerKey, sessionId, reason);
+                    });
+
+            // 실행 후에는 스케줄이 제거됨
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+
+        @Test
+        void 지연시간_내에_취소하면_실행되지_않는다() {
+            // given
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when - 즉시 취소
+            delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
+
+            // then - 15초 기다려도 실행되지 않음
+            await()
+                    .during(Duration.ofSeconds(2)) // 2초 동안 호출되지 않음을 확인
+                    .atMost(Duration.ofSeconds(3))
+                    .untilAsserted(() -> {
+                        then(playerDisconnectionService).should(never())
+                                .handlePlayerDisconnection(playerKey, sessionId, reason);
+                    });
+
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+
+        @Test
+        void 재스케줄링하면_첫번째는_취소되고_두번째만_실행된다() {
+            // given
+            String firstSessionId = "session-1";
+            String secondSessionId = "session-2";
+
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, firstSessionId, reason);
+            
+            // 잠시 후 재스케줄링
+            await().pollDelay(100, TimeUnit.MILLISECONDS).until(() -> true);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, secondSessionId, reason);
+
+            // then - 두 번째 세션ID로만 호출됨
+            await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(playerKey, secondSessionId, reason);
+                        then(playerDisconnectionService).should(never())
+                                .handlePlayerDisconnection(playerKey, firstSessionId, reason);
+                    });
+        }
+    }
+
+    @Nested
+    class 동시성_실제_테스트 {
+
+        @Test
+        void 여러_플레이어가_동시에_스케줄링되어도_안전하게_처리된다() {
+            // given
+            String player1 = "ABC123:김철수";
+            String player2 = "DEF456:박영희";
+            String player3 = "GHI789:이민수";
+
+            // when - 동시에 여러 플레이어 스케줄링
+            delayedPlayerRemovalService.schedulePlayerRemoval(player1, "session-1", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(player2, "session-2", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(player3, "session-3", reason);
+
+            // then - 모든 플레이어가 독립적으로 처리됨
+            await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(player1, "session-1", reason);
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(player2, "session-2", reason);
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(player3, "session-3", reason);
+                    });
+
+            // 모든 스케줄이 완료됨
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(player1)).isFalse();
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(player2)).isFalse();
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(player3)).isFalse();
+        }
+
+        @Test
+        void 한_플레이어를_빠르게_여러번_스케줄링해도_마지막_것만_실행된다() {
+            // when - 빠르게 여러 번 스케줄링
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "session-1", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "session-2", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "session-3", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "session-final", reason);
+
+            // then - 마지막 세션만 실행됨
+            await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        then(playerDisconnectionService).should()
+                                .handlePlayerDisconnection(playerKey, "session-final", reason);
+                    });
+
+            // 이전 세션들은 호출되지 않음
+            then(playerDisconnectionService).should(never())
+                    .handlePlayerDisconnection(playerKey, "session-1", reason);
+            then(playerDisconnectionService).should(never())
+                    .handlePlayerDisconnection(playerKey, "session-2", reason);
+            then(playerDisconnectionService).should(never())
+                    .handlePlayerDisconnection(playerKey, "session-3", reason);
+        }
+    }
+
+    @Nested
+    class 리소스_정리_테스트 {
+
+        @Test
+        void 실행_완료된_태스크는_맵에서_자동_제거된다() {
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // 실행 전에는 존재
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+
+            // then - 실행 후에는 제거됨
+            await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+                    });
+        }
+
+        @Test
+        void 취소된_태스크도_맵에서_즉시_제거된다() {
+            // given
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+
+            // when
+            delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
+
+            // then - 즉시 제거됨
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+    }
+
+    /**
+     * 테스트용 DelayedPlayerRemovalService
+     * 실제 15초 대신 짧은 시간으로 테스트할 수 있도록 오버라이드
+     */
+    private static class TestDelayedPlayerRemovalService extends DelayedPlayerRemovalService {
+        private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(500); // 500ms로 단축
+
+        public TestDelayedPlayerRemovalService(ThreadPoolTaskScheduler taskScheduler, 
+                                             PlayerDisconnectionService playerDisconnectionService) {
+            super(taskScheduler, playerDisconnectionService);
+        }
+
+        // 테스트에서는 더 짧은 지연시간 사용하고 싶다면 이런 식으로 오버라이드 가능
+        // 하지만 현재 구조상 REMOVAL_DELAY가 private static final이라 어렵다
+        // 실제로는 설정으로 빼거나 생성자 주입으로 받는 게 좋을 듯
+    }
+
+    @Nested
+    class 빠른_테스트_시나리오 {
+        // 실제 15초 기다리기 어려우면 이런 식으로 더 짧은 지연시간으로 테스트
+        // 단, DelayedPlayerRemovalService 구조 변경 필요
+        
+        @Test
+        void 설정으로_지연시간을_조정할_수_있다면_더_빠른_테스트가_가능하다() {
+            // 현재는 하드코딩되어 있어서 불가능
+            // Duration REMOVAL_DELAY를 생성자나 설정으로 주입받도록 리팩토링하면
+            // 테스트에서는 짧은 시간으로 설정 가능
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -1,6 +1,5 @@
 package coffeeshout.global.websocket;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -28,6 +27,9 @@ class DelayedPlayerRemovalServiceTest {
     private PlayerDisconnectionService playerDisconnectionService;
 
     @Mock
+    private StompSessionManager sessionManager;
+
+    @Mock
     @SuppressWarnings("rawtypes")
     private ScheduledFuture scheduledFuture;
 
@@ -39,7 +41,8 @@ class DelayedPlayerRemovalServiceTest {
 
     @BeforeEach
     void setUp() {
-        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService);
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService,
+                sessionManager);
     }
 
     @Nested
@@ -122,7 +125,6 @@ class DelayedPlayerRemovalServiceTest {
             then(scheduledFuture).should(never()).cancel(false);
         }
     }
-
 
 
     @Nested

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -1,0 +1,272 @@
+package coffeeshout.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedPlayerRemovalServiceTest {
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private PlayerDisconnectionService playerDisconnectionService;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    private ScheduledFuture scheduledFuture;
+
+    private DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    private final String playerKey = "ABC123:김철수";
+    private final String sessionId = "session-123";
+    private final String reason = "CLIENT_DISCONNECT";
+
+    @BeforeEach
+    void setUp() {
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService);
+    }
+
+    @Nested
+    class 플레이어_지연_삭제_스케줄링 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 정상적으로_지연_삭제를_스케줄링한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // then
+            then(taskScheduler).should().schedule(any(Runnable.class), any(Instant.class));
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 동일한_플레이어의_기존_스케줄을_취소하고_새로_등록한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            // 첫 번째 스케줄 등록
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when - 같은 플레이어 다시 스케줄링
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "new-session", "SERVER_ERROR");
+
+            // then
+            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+            then(scheduledFuture).should().cancel(false);
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 서로_다른_플레이어는_독립적으로_스케줄링된다() {
+            // given
+            String anotherPlayerKey = "DEF456:박영희";
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(anotherPlayerKey, "session-456", reason);
+
+            // then
+            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(anotherPlayerKey)).isTrue();
+        }
+    }
+
+    @Nested
+    class 지연_삭제_취소 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 스케줄된_삭제를_정상적으로_취소한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+            given(scheduledFuture.isDone()).willReturn(false);
+
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when
+            delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
+
+            // then
+            then(scheduledFuture).should().cancel(false);
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 이미_완료된_스케줄은_취소하지_않는다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+            given(scheduledFuture.isDone()).willReturn(true);
+
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when
+            delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
+
+            // then
+            then(scheduledFuture).should(never()).cancel(false);
+        }
+
+        @Test
+        void 존재하지_않는_플레이어의_취소_요청은_무시한다() {
+            // when
+            delayedPlayerRemovalService.cancelScheduledRemoval("없는플레이어");
+
+            // then - 예외 발생하지 않고 정상 처리
+            then(scheduledFuture).should(never()).cancel(false);
+        }
+    }
+
+    @Nested
+    class 스케줄_상태_확인 {
+
+        @Test
+        void 스케줄이_없으면_false를_반환한다() {
+            // when & then
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 스케줄이_있고_완료되지_않았으면_true를_반환한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+            given(scheduledFuture.isDone()).willReturn(false);
+
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when & then
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 스케줄이_완료되었으면_false를_반환한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+            given(scheduledFuture.isDone()).willReturn(true);
+
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // when & then
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+        }
+    }
+
+    @Nested
+    class 실제_삭제_실행_시뮬레이션 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void PlayerDisconnectionService가_정상_호출된다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willAnswer(invocation -> {
+                        Runnable task = invocation.getArgument(0);
+                        // 스케줄링된 태스크를 바로 실행
+                        task.run();
+                        return scheduledFuture;
+                    });
+
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            // then
+            then(playerDisconnectionService).should()
+                    .handlePlayerDisconnection(playerKey, sessionId, reason);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void PlayerDisconnectionService에서_예외_발생해도_안전하게_처리한다() {
+            // given
+            willThrow(new RuntimeException("플레이어 삭제 실패"))
+                    .given(playerDisconnectionService)
+                    .handlePlayerDisconnection(any(), any(), any());
+
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willAnswer(invocation -> {
+                        Runnable task = invocation.getArgument(0);
+                        // 스케줄링된 태스크를 바로 실행
+                        task.run();
+                        return scheduledFuture;
+                    });
+
+            // when & then - 예외가 터져도 프로그램이 죽지 않음
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+
+            then(playerDisconnectionService).should()
+                    .handlePlayerDisconnection(playerKey, sessionId, reason);
+        }
+    }
+
+    @Nested
+    class 동시성_시나리오 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 같은_플레이어의_동시_스케줄링_요청을_안전하게_처리한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            // when - 동시에 여러 번 호출
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId + "2", reason);
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId + "3", reason);
+
+            // then - 마지막 스케줄만 유효
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
+            then(taskScheduler).should(times(3)).schedule(any(Runnable.class), any(Instant.class));
+            then(scheduledFuture).should(times(2)).cancel(false); // 첫 번째, 두 번째 취소됨
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 스케줄링_중_취소_요청이_와도_안전하게_처리한다() {
+            // given
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+            given(scheduledFuture.isDone()).willReturn(false);
+
+            // when
+            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
+            delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
+
+            // then
+            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
+            then(scheduledFuture).should().cancel(false);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -62,25 +62,6 @@ class DelayedPlayerRemovalServiceTest {
 
         @Test
         @SuppressWarnings("unchecked")
-        void 동일한_플레이어의_기존_스케줄을_취소하고_새로_등록한다() {
-            // given
-            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
-                    .willReturn(scheduledFuture);
-
-            // 첫 번째 스케줄 등록
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
-
-            // when - 같은 플레이어 다시 스케줄링
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, "new-session", "SERVER_ERROR");
-
-            // then
-            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
-            then(scheduledFuture).should().cancel(false);
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
-        }
-
-        @Test
-        @SuppressWarnings("unchecked")
         void 서로_다른_플레이어는_독립적으로_스케줄링된다() {
             // given
             String anotherPlayerKey = "DEF456:박영희";
@@ -233,24 +214,6 @@ class DelayedPlayerRemovalServiceTest {
 
     @Nested
     class 동시성_시나리오 {
-
-        @Test
-        @SuppressWarnings("unchecked")
-        void 같은_플레이어의_동시_스케줄링_요청을_안전하게_처리한다() {
-            // given
-            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
-                    .willReturn(scheduledFuture);
-
-            // when - 동시에 여러 번 호출
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId + "2", reason);
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId + "3", reason);
-
-            // then - 마지막 스케줄만 유효
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
-            then(taskScheduler).should(times(3)).schedule(any(Runnable.class), any(Instant.class));
-            then(scheduledFuture).should(times(2)).cancel(false); // 첫 번째, 두 번째 취소됨
-        }
 
         @Test
         @SuppressWarnings("unchecked")

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -33,7 +33,7 @@ class DelayedPlayerRemovalServiceTest {
 
     private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
-    private final String playerKey = "ABC123:김철수";
+    private final String playerKey = "ABC23:김철수";
     private final String sessionId = "session-123";
     private final String reason = "CLIENT_DISCONNECT";
 

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -57,7 +57,6 @@ class DelayedPlayerRemovalServiceTest {
 
             // then
             then(taskScheduler).should().schedule(any(Runnable.class), any(Instant.class));
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
         }
 
         @Test
@@ -74,8 +73,6 @@ class DelayedPlayerRemovalServiceTest {
 
             // then
             then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(anotherPlayerKey)).isTrue();
         }
     }
 
@@ -97,7 +94,6 @@ class DelayedPlayerRemovalServiceTest {
 
             // then
             then(scheduledFuture).should().cancel(false);
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
         }
 
         @Test
@@ -127,43 +123,7 @@ class DelayedPlayerRemovalServiceTest {
         }
     }
 
-    @Nested
-    class 스케줄_상태_확인 {
 
-        @Test
-        void 스케줄이_없으면_false를_반환한다() {
-            // when & then
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
-        }
-
-        @Test
-        @SuppressWarnings("unchecked")
-        void 스케줄이_있고_완료되지_않았으면_true를_반환한다() {
-            // given
-            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
-                    .willReturn(scheduledFuture);
-            given(scheduledFuture.isDone()).willReturn(false);
-
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
-
-            // when & then
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isTrue();
-        }
-
-        @Test
-        @SuppressWarnings("unchecked")
-        void 스케줄이_완료되었으면_false를_반환한다() {
-            // given
-            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
-                    .willReturn(scheduledFuture);
-            given(scheduledFuture.isDone()).willReturn(true);
-
-            delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
-
-            // when & then
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
-        }
-    }
 
     @Nested
     class 실제_삭제_실행_시뮬레이션 {
@@ -228,7 +188,6 @@ class DelayedPlayerRemovalServiceTest {
             delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
             // then
-            assertThat(delayedPlayerRemovalService.hasScheduledRemoval(playerKey)).isFalse();
             then(scheduledFuture).should().cancel(false);
         }
     }

--- a/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
@@ -1,10 +1,11 @@
 package coffeeshout.global.websocket;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.*;
 
 class StompSessionManagerTest {
 
@@ -19,14 +20,14 @@ class StompSessionManagerTest {
     @DisplayName("정상적인 플레이어 키 생성")
     void createPlayerKey_Success() {
         // given
-        String joinCode = "ABC123";
+        String joinCode = "ABC23";
         String playerName = "player1";
 
         // when
         String playerKey = sessionManager.createPlayerKey(joinCode, playerName);
 
         // then
-        assertThat(playerKey).isEqualTo("ABC123:player1");
+        assertThat(playerKey).isEqualTo("ABC23:player1");
     }
 
     @Test
@@ -42,7 +43,7 @@ class StompSessionManagerTest {
     @DisplayName("playerName이 null인 경우 예외 발생")
     void createPlayerKey_NullPlayerName_ThrowsException() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC123", null))
+        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("joinCode와 playerName은 null일 수 없습니다");
     }
@@ -51,7 +52,7 @@ class StompSessionManagerTest {
     @DisplayName("joinCode에 구분자가 포함된 경우 예외 발생")
     void createPlayerKey_JoinCodeContainsDelimiter_ThrowsException() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC:123", "player1"))
+        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC:23", "player1"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("joinCode와 playerName에 구분자(':')가 포함될 수 없습니다");
     }
@@ -60,7 +61,7 @@ class StompSessionManagerTest {
     @DisplayName("playerName에 구분자가 포함된 경우 예외 발생")
     void createPlayerKey_PlayerNameContainsDelimiter_ThrowsException() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC123", "play:er1"))
+        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", "play:er1"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("joinCode와 playerName에 구분자(':')가 포함될 수 없습니다");
     }
@@ -69,20 +70,20 @@ class StompSessionManagerTest {
     @DisplayName("정상적인 joinCode 추출")
     void extractJoinCode_Success() {
         // given
-        String playerKey = "ABC123:player1";
+        String playerKey = "ABC23:player1";
 
         // when
         String joinCode = sessionManager.extractJoinCode(playerKey);
 
         // then
-        assertThat(joinCode).isEqualTo("ABC123");
+        assertThat(joinCode).isEqualTo("ABC23");
     }
 
     @Test
     @DisplayName("정상적인 playerName 추출")
     void extractPlayerName_Success() {
         // given
-        String playerKey = "ABC123:player1";
+        String playerKey = "ABC23:player1";
 
         // when
         String playerName = sessionManager.extractPlayerName(playerKey);
@@ -104,18 +105,18 @@ class StompSessionManagerTest {
     @DisplayName("구분자가 없는 플레이어 키로 joinCode 추출 시 예외 발생")
     void extractJoinCode_NoDelimiter_ThrowsException() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractJoinCode("ABC123player1"))
+        assertThatThrownBy(() -> sessionManager.extractJoinCode("ABC23player1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("플레이어 키에 구분자(':')가 없습니다: ABC123player1");
+                .hasMessage("플레이어 키에 구분자(':')가 없습니다: ABC23player1");
     }
 
     @Test
     @DisplayName("잘못된 형식의 플레이어 키로 playerName 추출 시 예외 발생")
     void extractPlayerName_InvalidFormat_ThrowsException() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractPlayerName("ABC123:player1:extra"))
+        assertThatThrownBy(() -> sessionManager.extractPlayerName("ABC23:player1:extra"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("플레이어 키 형식이 잘못되었습니다. 예상: joinCode:playerName, 실제: ABC123:player1:extra");
+                .hasMessage("플레이어 키 형식이 잘못되었습니다. 예상: joinCode:playerName, 실제: ABC23:player1:extra");
     }
 
     @Test
@@ -131,7 +132,7 @@ class StompSessionManagerTest {
     @DisplayName("플레이어 키 유효성 검증 - 정상")
     void isValidPlayerKey_ValidKey_ReturnsTrue() {
         // given
-        String validPlayerKey = "ABC123:player1";
+        String validPlayerKey = "ABC23:player1";
 
         // when & then
         assertThat(sessionManager.isValidPlayerKey(validPlayerKey)).isTrue();
@@ -148,7 +149,7 @@ class StompSessionManagerTest {
     @DisplayName("플레이어 키 유효성 검증 - 구분자 없음")
     void isValidPlayerKey_NoDelimiter_ReturnsFalse() {
         // when & then
-        assertThat(sessionManager.isValidPlayerKey("ABC123player1")).isFalse();
+        assertThat(sessionManager.isValidPlayerKey("ABC23player1")).isFalse();
     }
 
     @Test
@@ -162,7 +163,7 @@ class StompSessionManagerTest {
     @DisplayName("플레이어 세션 등록 및 조회")
     void registerAndGetPlayerSession() {
         // given
-        String joinCode = "ABC123";
+        String joinCode = "ABC23";
         String playerName = "player1";
         String sessionId = "session123";
 
@@ -171,14 +172,14 @@ class StompSessionManagerTest {
 
         // then
         assertThat(sessionManager.getSessionId(joinCode, playerName)).isEqualTo(sessionId);
-        assertThat(sessionManager.getPlayerKey(sessionId)).isEqualTo("ABC123:player1");
+        assertThat(sessionManager.getPlayerKey(sessionId)).isEqualTo("ABC23:player1");
     }
 
     @Test
     @DisplayName("특정 방의 연결된 플레이어 수 조회")
     void getConnectedPlayerCountByJoinCode() {
         // given
-        String joinCode = "ABC123";
+        String joinCode = "ABC23";
         sessionManager.registerPlayerSession(joinCode, "player1", "session1");
         sessionManager.registerPlayerSession(joinCode, "player2", "session2");
         sessionManager.registerPlayerSession("XYZ789", "player3", "session3");

--- a/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
@@ -17,8 +17,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("정상적인 플레이어 키 생성")
-    void createPlayerKey_Success() {
+    void 정상적인_플레이어_키_생성() {
         // given
         String joinCode = "ABC23";
         String playerName = "player1";
@@ -31,8 +30,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("joinCode가 null인 경우 예외 발생")
-    void createPlayerKey_NullJoinCode_ThrowsException() {
+    void joinCode가_null인_경우_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.createPlayerKey(null, "player1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -40,8 +38,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("playerName이 null인 경우 예외 발생")
-    void createPlayerKey_NullPlayerName_ThrowsException() {
+    void playerName이_null인_경우_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", null))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -49,8 +46,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("joinCode에 구분자가 포함된 경우 예외 발생")
-    void createPlayerKey_JoinCodeContainsDelimiter_ThrowsException() {
+    void joinCode에_구분자가_포함된_경우_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC:23", "player1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -58,8 +54,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("playerName에 구분자가 포함된 경우 예외 발생")
-    void createPlayerKey_PlayerNameContainsDelimiter_ThrowsException() {
+    void playerName에_구분자가_포함된_경우_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", "play:er1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -67,8 +62,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("정상적인 joinCode 추출")
-    void extractJoinCode_Success() {
+    void 정상적인_joinCode_추출() {
         // given
         String playerKey = "ABC23:player1";
 
@@ -80,8 +74,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("정상적인 playerName 추출")
-    void extractPlayerName_Success() {
+    void 정상적인_playerName_추출() {
         // given
         String playerKey = "ABC23:player1";
 
@@ -93,8 +86,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("null 플레이어 키로 joinCode 추출 시 예외 발생")
-    void extractJoinCode_NullPlayerKey_ThrowsException() {
+    void null_플레이어_키로_joinCode_추출_시_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.extractJoinCode(null))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -102,8 +94,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("구분자가 없는 플레이어 키로 joinCode 추출 시 예외 발생")
-    void extractJoinCode_NoDelimiter_ThrowsException() {
+    void 구분자가_없는_플레이어_키로_joinCode_추출_시_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.extractJoinCode("ABC23player1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -111,8 +102,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("잘못된 형식의 플레이어 키로 playerName 추출 시 예외 발생")
-    void extractPlayerName_InvalidFormat_ThrowsException() {
+    void 잘못된_형식의_플레이어_키로_playerName_추출_시_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.extractPlayerName("ABC23:player1:extra"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -120,8 +110,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("빈 joinCode가 있는 플레이어 키 검증 시 예외 발생")
-    void extractJoinCode_EmptyJoinCode_ThrowsException() {
+    void 빈_joinCode가_있는_플레이어_키_검증_시_예외_발생() {
         // when & then
         assertThatThrownBy(() -> sessionManager.extractJoinCode(":player1"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -129,8 +118,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("플레이어 키 유효성 검증 - 정상")
-    void isValidPlayerKey_ValidKey_ReturnsTrue() {
+    void 플레이어_키_유효성_검증_정상() {
         // given
         String validPlayerKey = "ABC23:player1";
 
@@ -139,29 +127,25 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("플레이어 키 유효성 검증 - null")
-    void isValidPlayerKey_NullKey_ReturnsFalse() {
+    void 플레이어_키_유효성_검증_null() {
         // when & then
         assertThat(sessionManager.isValidPlayerKey(null)).isFalse();
     }
 
     @Test
-    @DisplayName("플레이어 키 유효성 검증 - 구분자 없음")
-    void isValidPlayerKey_NoDelimiter_ReturnsFalse() {
+    void 플레이어_키_유효성_검증_구분자_없음() {
         // when & then
         assertThat(sessionManager.isValidPlayerKey("ABC23player1")).isFalse();
     }
 
     @Test
-    @DisplayName("플레이어 키 유효성 검증 - 빈 joinCode")
-    void isValidPlayerKey_EmptyJoinCode_ReturnsFalse() {
+    void 플레이어_키_유효성_검증_빈_joinCode() {
         // when & then
         assertThat(sessionManager.isValidPlayerKey(":player1")).isFalse();
     }
 
     @Test
-    @DisplayName("플레이어 세션 등록 및 조회")
-    void registerAndGetPlayerSession() {
+    void 플레이어_세션_등록_및_조회() {
         // given
         String joinCode = "ABC23";
         String playerName = "player1";
@@ -176,8 +160,7 @@ class StompSessionManagerTest {
     }
 
     @Test
-    @DisplayName("특정 방의 연결된 플레이어 수 조회")
-    void getConnectedPlayerCountByJoinCode() {
+    void 특정_방의_연결된_플레이어_수_조회() {
         // given
         String joinCode = "ABC23";
         sessionManager.registerPlayerSession(joinCode, "player1", "session1");

--- a/backend/src/test/java/coffeeshout/websocket/WebSocketConnectionTest.java
+++ b/backend/src/test/java/coffeeshout/websocket/WebSocketConnectionTest.java
@@ -27,7 +27,6 @@ class WebSocketConnectionTest {
     private int port;
 
     @Test
-    @DisplayName("순수 WebSocket STOMP 연결 테스트")
     void 순수_WebSocket_STOMP_연결_테스트() throws Exception {
         // given
         WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(List.of(
@@ -50,7 +49,6 @@ class WebSocketConnectionTest {
     }
 
     @Test
-    @DisplayName("토픽 구독 테스트")
     void 토픽_구독_테스트() throws Exception {
         // given
         WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(List.of(
@@ -76,7 +74,6 @@ class WebSocketConnectionTest {
     }
 
     @Test
-    @DisplayName("메시지 전송 테스트")
     void 메시지_전송_테스트() throws Exception {
         // given
         WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(List.of(

--- a/backend/src/test/java/coffeeshout/websocket/WebSocketSimpleTest.java
+++ b/backend/src/test/java/coffeeshout/websocket/WebSocketSimpleTest.java
@@ -33,7 +33,6 @@ class WebSocketSimpleTest {
     private int port;
 
     @Test
-    @DisplayName("SockJS STOMP 엔드포인트 연결 테스트")
     void SockJS_STOMP_엔드포인트_연결_테스트() throws Exception {
         // given
         List<Transport> transports = List.of(
@@ -59,7 +58,6 @@ class WebSocketSimpleTest {
     }
 
     @Test
-    @DisplayName("방 토픽 구독 테스트")
     void 방_토픽_구독_테스트() throws Exception {
         // given
         List<Transport> transports = List.of(
@@ -88,7 +86,6 @@ class WebSocketSimpleTest {
     }
 
     @Test
-    @DisplayName("플레이어 목록 요청 메시지 전송 테스트")
     void 플레이어_목록_요청_메시지_전송_테스트() throws Exception {
         // given
         List<Transport> transports = List.of(
@@ -120,7 +117,6 @@ class WebSocketSimpleTest {
     }
 
     @Test
-    @DisplayName("여러 토픽 동시 구독 테스트")
     void 여러_토픽_동시_구독_테스트() throws Exception {
         // given
         List<Transport> transports = List.of(


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #503 

# 🚀 작업 내용

1. TaskScheduler를 사용해서 player의 Disconnect 감지 시, 15초 뒤에 삭제되는 로직 구현했습니다.

# 💬 리뷰 중점사항

1. 현재 DelayedPlayerRemovalServiceIntegrationTest에는 실제로 15초를 기다려야하는 테스트가 존재합니다.
우선 배포되었을 때 정상 작동하는지 보고 싶어서 지금은 이대로 올리지만, 정상 작동 확인이 되면 disable 처리하고 동일 로직을 검사하는 테스트를 CountdownLatch로 재구현해놓을게요~
