### PR TITLE
[feat] 호스트 퇴장 시, 남은 플레이어 중 랜덤으로 한 명 호스트로 승격하는 로직 구현

### DIFF
--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEvent.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEvent.java
@@ -1,11 +1,7 @@
 package coffeeshout.global.websocket.event;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class RoomStateUpdateEvent {
-    private final String joinCode;
-    private final String reason; // "PLAYER_REMOVED", "PLAYER_RECONNECTED" 등
+/**
+ * @param reason "PLAYER_REMOVED", "PLAYER_RECONNECTED" 등
+ */
+public record RoomStateUpdateEvent(String joinCode, String reason) {
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
@@ -22,15 +22,15 @@ public class RoomStateUpdateEventListener {
     @EventListener
     public void handleRoomStateUpdate(RoomStateUpdateEvent event) {
         try {
-            log.info("방 상태 업데이트 이벤트 처리: joinCode={}, reason={}", event.getJoinCode(), event.getReason());
+            log.info("방 상태 업데이트 이벤트 처리: joinCode={}, reason={}", event.joinCode(), event.reason());
 
-            sendPlayerStatus(event.getJoinCode());
-            sendProbabilitiesStatus(event.getJoinCode());
+            sendPlayerStatus(event.joinCode());
+            sendProbabilitiesStatus(event.joinCode());
 
-            log.info("방 상태 브로드캐스트 완료: joinCode={}", event.getJoinCode());
+            log.info("방 상태 브로드캐스트 완료: joinCode={}", event.joinCode());
 
         } catch (Exception e) {
-            log.error("방 상태 업데이트 이벤트 처리 실패: joinCode={}, reason={}", event.getJoinCode(), event.getReason(), e);
+            log.error("방 상태 업데이트 이벤트 처리 실패: joinCode={}, reason={}", event.joinCode(), event.reason(), e);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -30,11 +30,12 @@ public class Room {
     private static final int MINIMUM_GUEST_COUNT = 2;
 
     private final JoinCode joinCode;
-    private final Player host;
     private final Players players;
     private final Roulette roulette;
     private final Queue<Playable> miniGames;
     private final List<Playable> finishedGames;
+
+    private Player host;
     private RoomState roomState;
 
     public Room(JoinCode joinCode, PlayerName hostName, Menu menu) {
@@ -166,6 +167,12 @@ public class Room {
         if (players.existsByName(playerName)) {
             roulette.removePlayer(playerName);
             players.removePlayer(playerName);
+
+            // 호스트가 나간 경우 새로운 호스트 지정
+            if (host.sameName(playerName) && players.getPlayerCount() > 0) {
+                promoteNewHost();
+            }
+
             return true;
         }
 
@@ -221,5 +228,9 @@ public class Room {
             return Player.createHost(playerName, menu);
         }
         return Player.createGuest(playerName, menu);
+    }
+
+    private void promoteNewHost() {
+        this.host = players.getRandomPlayer();
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/player/Players.java
+++ b/backend/src/main/java/coffeeshout/room/domain/player/Players.java
@@ -3,10 +3,13 @@ package coffeeshout.room.domain.player;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import lombok.Getter;
 
 @Getter
 public class Players {
+
+    private static final Random RANDOM = new Random();
 
     private final List<Player> players;
     private final ColorUsage colorUsage;
@@ -59,5 +62,9 @@ public class Players {
     public boolean existsByName(PlayerName playerName) {
         return players.stream()
                 .anyMatch(player -> player.sameName(playerName));
+    }
+
+    public Player getRandomPlayer() {
+        return players.get(RANDOM.nextInt(players.size()));
     }
 }

--- a/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
@@ -265,4 +265,78 @@ class RoomTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("모든 플레이어가 준비완료해야합니다.");
     }
+
+    @Test
+    void 호스트가_나가면_남은_플레이어_중_랜덤으로_새_호스트가_된다() {
+        // given
+        room.joinGuest(게스트_루키, MenuFixture.아메리카노());
+        room.joinGuest(게스트_꾹이, MenuFixture.아메리카노());
+        room.joinGuest(게스트_엠제이, MenuFixture.아메리카노());
+        
+        Player originalHost = room.getHost();
+        assertThat(originalHost.getName()).isEqualTo(호스트_한스);
+        assertThat(room.getPlayers()).hasSize(4);
+
+        // when
+        boolean removed = room.removePlayer(호스트_한스);
+
+        // then
+        assertThat(removed).isTrue();
+        assertThat(room.getPlayers()).hasSize(3);
+        
+        Player newHost = room.getHost();
+        assertThat(newHost.getName()).isNotEqualTo(호스트_한스);
+        assertThat(newHost.getName()).isIn(게스트_루키, 게스트_꾹이, 게스트_엠제이);
+    }
+
+    @Test
+    void 호스트가_나가고_남은_플레이어가_없으면_호스트_승격이_일어나지_않는다() {
+        // given
+        assertThat(room.getPlayers()).hasSize(1);
+        Player originalHost = room.getHost();
+        assertThat(originalHost.getName()).isEqualTo(호스트_한스);
+
+        // when
+        boolean removed = room.removePlayer(호스트_한스);
+
+        // then
+        assertThat(removed).isTrue();
+        assertThat(room.getPlayers()).hasSize(0);
+        // 원래 호스트 객체는 그대로 유지됨 (빈 방이므로)
+        assertThat(room.getHost()).isEqualTo(originalHost);
+    }
+
+    @Test
+    void 게스트가_나가면_호스트는_그대로다() {
+        // given
+        room.joinGuest(게스트_루키, MenuFixture.아메리카노());
+        room.joinGuest(게스트_꾹이, MenuFixture.아메리카노());
+        
+        Player originalHost = room.getHost();
+        assertThat(originalHost.getName()).isEqualTo(호스트_한스);
+        assertThat(room.getPlayers()).hasSize(3);
+
+        // when
+        boolean removed = room.removePlayer(게스트_루키);
+
+        // then
+        assertThat(removed).isTrue();
+        assertThat(room.getPlayers()).hasSize(2);
+        assertThat(room.getHost()).isEqualTo(originalHost);
+        assertThat(room.getHost().getName()).isEqualTo(호스트_한스);
+    }
+
+    @Test
+    void 존재하지_않는_플레이어_제거시_false_반환() {
+        // given
+        PlayerName 존재하지않는플레이어 = new PlayerName("없는놈");
+
+        // when
+        boolean removed = room.removePlayer(존재하지않는플레이어);
+
+        // then
+        assertThat(removed).isFalse();
+        assertThat(room.getPlayers()).hasSize(1);
+        assertThat(room.getHost().getName()).isEqualTo(호스트_한스);
+    }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [ ] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #526 

# 🚀 작업 내용

1. 호스트 퇴장 시, 남은 플레이어 중 랜덤으로 한 명 호스트로 승격하는 로직 구현
2. 자잘하게 RoomStateUpdateEvent도 recode로 변경했어요

# 💬 리뷰 중점사항

중점사항
