### PR TITLE
[feat] 앱 전환 시 웹소켓 세부 로직 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
@@ -6,11 +6,7 @@ import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
-import coffeeshout.room.domain.player.Menu;
-import coffeeshout.room.domain.player.PlayerName;
-import coffeeshout.room.domain.service.MenuQueryService;
 import coffeeshout.room.domain.service.RoomQueryService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -25,7 +21,6 @@ public class ConnectPreSendHandler implements PreSendHandler {
     private final StompSessionManager sessionManager;
     private final WebSocketMetricService webSocketMetricService;
     private final RoomQueryService roomQueryService;
-    private final MenuQueryService menuQueryService;
     private final DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     @Override
@@ -39,20 +34,19 @@ public class ConnectPreSendHandler implements PreSendHandler {
 
         final String joinCode = accessor.getFirstNativeHeader("joinCode");
         final String playerName = accessor.getFirstNativeHeader("playerName");
-        final String menuId = accessor.getFirstNativeHeader("menuId");
 
-        if (joinCode != null && playerName != null && menuId != null) {
-            processPlayerConnection(sessionId, joinCode, playerName, menuId);
+        if (joinCode != null && playerName != null) {
+            processPlayerConnection(sessionId, joinCode, playerName);
         }
 
         webSocketMetricService.startConnection(sessionId);
     }
 
-    private void processPlayerConnection(String sessionId, String joinCode, String playerName, String menuId) {
+    private void processPlayerConnection(String sessionId, String joinCode, String playerName) {
         // 기존 세션 있으면 재연결, 없으면 첫 연결
         if (sessionManager.hasSessionId(joinCode, playerName)) {
             String oldSessionId = sessionManager.getSessionId(joinCode, playerName);
-            processPlayerReconnect(sessionId, joinCode, playerName, menuId, oldSessionId);
+            processPlayerReconnect(sessionId, joinCode, playerName, oldSessionId);
             return;
         }
 
@@ -62,27 +56,19 @@ public class ConnectPreSendHandler implements PreSendHandler {
         handlePlayerFirstConnection(joinCode, playerName);
     }
 
-    private void processPlayerReconnect(String sessionId, String joinCode, String playerName, String menuId,
-                                        String oldSessionId) {
+    private void processPlayerReconnect(String sessionId, String joinCode, String playerName, String oldSessionId) {
         log.info("플레이어 재연결 감지: joinCode={}, playerName={}, oldSessionId={}",
                 joinCode, playerName, oldSessionId);
 
         // 새 세션으로 등록
         sessionManager.registerPlayerSession(joinCode, playerName, sessionId);
-        
+
         // 기존 지연 삭제 취소
         final String playerKey = sessionManager.createPlayerKey(joinCode, playerName);
         delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
         // 재연결 처리
-        parseMenuId(menuId).ifPresentOrElse(
-                parsedMenuId -> handlePlayerReconnection(joinCode, playerName, parsedMenuId, sessionId),
-                () -> {
-                    log.warn("잘못된 menuId 형식으로 재연결 실패: joinCode={}, playerName={}, menuId={}",
-                            joinCode, playerName, menuId);
-                    sessionManager.removeSession(sessionId);
-                }
-        );
+        handlePlayerReconnection(joinCode, playerName, sessionId);
     }
 
     private void handlePlayerFirstConnection(String joinCode, String playerName) {
@@ -91,23 +77,19 @@ public class ConnectPreSendHandler implements PreSendHandler {
         // 현재는 REST API에서 방 참여가 이미 완료되었다고 가정
     }
 
-    private void handlePlayerReconnection(String joinCode, String playerName, Long menuId, String newSessionId) {
+    private void handlePlayerReconnection(String joinCode, String playerName, String newSessionId) {
         try {
             // 1. 방 존재 확인
             final Room room = roomQueryService.findByJoinCode(new JoinCode(joinCode));
 
-            // 2. 플레이어가 방에 있는지 확인
-            final Menu menu = menuQueryService.findById(menuId);
-            room.reJoin(new PlayerName(playerName), menu);
-
-            // 3. 방 상태 확인
+            // 2. 방 상태 확인
             if (room.isPlayingState()) {
                 log.info("게임 중인 방 재연결 거부: joinCode={}, playerName={}", joinCode, playerName);
                 disconnectSession(newSessionId, "GAME_IN_PROGRESS");
                 return;
             }
 
-            // 4. READY 상태면 재연결 허용 + 현재 상태 전송
+            // 3. READY 상태면 재연결 허용 + 현재 상태 전송
             log.info("방 재연결 허용: joinCode={}, playerName={}", joinCode, playerName);
         } catch (Exception e) {
             log.warn("재연결 실패: joinCode={}, playerName={}, error={}", joinCode, playerName, e.getMessage());
@@ -123,17 +105,5 @@ public class ConnectPreSendHandler implements PreSendHandler {
         // TODO: 필요한 경우 실제 세션 강제 종료 로직 구현
         // 현재는 클라이언트가 연결 실패를 감지하여 자동으로 처리한다고 가정
         sessionManager.removeSession(sessionId);
-    }
-
-    private Optional<Long> parseMenuId(String menuId) {
-        if (menuId == null || menuId.trim().isEmpty()) {
-            return Optional.empty();
-        }
-        try {
-            return Optional.of(Long.parseLong(menuId.trim()));
-        } catch (NumberFormatException e) {
-            log.warn("menuId 파싱 실패: {}", menuId);
-            return Optional.empty();
-        }
     }
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
@@ -27,6 +27,9 @@ public class DelayedPlayerRemovalService {
         log.info("플레이어 지연 삭제 스케줄링: playerKey={}, sessionId={}, delay={}초",
                 playerKey, sessionId, REMOVAL_DELAY.getSeconds());
 
+        // disconnect 된 플레이어는 ready 상태 false로 변경
+        playerDisconnectionService.cancelReady(playerKey);
+
         // 새로운 스케줄 등록
         final ScheduledFuture<?> future = taskScheduler.schedule(
                 () -> {

--- a/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
@@ -19,6 +19,13 @@ public class PlayerDisconnectionService {
     private final RoomService roomService;
     private final ApplicationEventPublisher eventPublisher;
 
+    public void cancelReady(String playerKey) {
+        final String joinCode = sessionManager.extractJoinCode(playerKey);
+        final String playerName = sessionManager.extractPlayerName(playerKey);
+
+        roomService.changePlayerReadyState(joinCode, playerName, false);
+    }
+
     /**
      * 플레이어 연결 해제 처리
      */

--- a/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
@@ -30,10 +30,10 @@ public class StompSessionManager {
      * 플레이어 세션 매핑 등록
      */
     public void registerPlayerSession(String joinCode, String playerName, String sessionId) {
-        String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = createPlayerKey(joinCode, playerName);
 
         // 기존 세션이 있으면 정리
-        String oldSessionId = playerSessionMap.get(playerKey);
+        final String oldSessionId = playerSessionMap.get(playerKey);
         if (oldSessionId != null) {
             log.info("기존 플레이어 세션 정리: playerKey={}, oldSessionId={}", playerKey, oldSessionId);
             sessionPlayerMap.remove(oldSessionId);
@@ -48,12 +48,12 @@ public class StompSessionManager {
      * 플레이어의 기존 세션 ID 조회
      */
     public boolean hasSessionId(String joinCode, String playerName) {
-        String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = createPlayerKey(joinCode, playerName);
         return playerSessionMap.containsKey(playerKey);
     }
 
     public String getSessionId(String joinCode, String playerName) {
-        String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = createPlayerKey(joinCode, playerName);
 
         isTrue(playerSessionMap.containsKey(playerKey),
                 "플레이어 세션이 존재하지 않습니다: joinCode=%s, playerName=%s".formatted(joinCode, playerName));
@@ -80,7 +80,7 @@ public class StompSessionManager {
      */
     public String extractJoinCode(String playerKey) {
         validatePlayerKey(playerKey);
-        String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
+        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
         return parts[0];
     }
 
@@ -97,7 +97,7 @@ public class StompSessionManager {
      * 세션 매핑 제거
      */
     public void removeSession(String sessionId) {
-        String playerKey = sessionPlayerMap.remove(sessionId);
+        final String playerKey = sessionPlayerMap.remove(sessionId);
         if (playerKey != null) {
             playerSessionMap.remove(playerKey);
             log.info("세션 매핑 제거: playerKey={}, sessionId={}", playerKey, sessionId);
@@ -140,9 +140,9 @@ public class StompSessionManager {
         if (playerKey == null || !playerKey.contains(PLAYER_KEY_DELIMITER)) {
             return false;
         }
-        String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
+        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
         return parts.length == EXPECTED_PLAYER_KEY_PARTS &&
-               !parts[0].isEmpty() && !parts[1].isEmpty();
+                !parts[0].isEmpty() && !parts[1].isEmpty();
     }
 
     /**
@@ -155,9 +155,10 @@ public class StompSessionManager {
         if (!playerKey.contains(PLAYER_KEY_DELIMITER)) {
             throw new IllegalArgumentException("플레이어 키에 구분자('" + PLAYER_KEY_DELIMITER + "')가 없습니다: " + playerKey);
         }
-        String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
+        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
         if (parts.length != EXPECTED_PLAYER_KEY_PARTS) {
-            throw new IllegalArgumentException("플레이어 키 형식이 잘못되었습니다. 예상: joinCode" + PLAYER_KEY_DELIMITER + "playerName, 실제: " + playerKey);
+            throw new IllegalArgumentException(
+                    "플레이어 키 형식이 잘못되었습니다. 예상: joinCode" + PLAYER_KEY_DELIMITER + "playerName, 실제: " + playerKey);
         }
         if (parts[0].isEmpty() || parts[1].isEmpty()) {
             throw new IllegalArgumentException("joinCode 또는 playerName이 비어있습니다: " + playerKey);

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -179,15 +179,6 @@ public class Room {
         return false;
     }
 
-    public void reJoin(PlayerName playerName, Menu menu) {
-        validateRoomReady();
-        validateCanJoin();
-        validatePlayerNameNotDuplicate(playerName);
-
-        final Player player = createPlayer(playerName, menu);
-        join(player);
-    }
-
     private boolean hasEnoughPlayers() {
         return players.hasEnoughPlayers(MINIMUM_GUEST_COUNT, MAXIMUM_GUEST_COUNT);
     }

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -232,7 +232,7 @@ public class Room {
 
     private void promoteNewHost() {
         final Player newHost = players.getRandomPlayer();
-        newHost.updateReadyState(true);
+        newHost.promote();
         this.host = newHost;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/player/Player.java
+++ b/backend/src/main/java/coffeeshout/room/domain/player/Player.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 public class Player {
 
     private final PlayerName name;
-    private final PlayerType playerType;
+    private PlayerType playerType;
     private Menu menu;
     private Boolean isReady;
     private Integer colorIndex;
@@ -41,6 +41,11 @@ public class Player {
 
     public void updateReadyState(Boolean isReady) {
         this.isReady = isReady;
+    }
+
+    public void promote() {
+        this.playerType = PlayerType.HOST;
+        this.isReady = true;
     }
 
     @Override

--- a/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
@@ -73,7 +73,7 @@ class CustomStompChannelInterceptorTest {
 
         // 핸들러들 생성
         connectPreSendHandler = new ConnectPreSendHandler(sessionManager, webSocketMetricService, roomQueryService,
-                menuQueryService, delayedPlayerRemovalService);
+                delayedPlayerRemovalService);
         connectPostSendHandler = new ConnectPostSendHandler(sessionManager, webSocketMetricService,
                 delayedPlayerRemovalService);
         disconnectPostSendHandler = new DisconnectPostSendHandler(sessionManager, webSocketMetricService,

--- a/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
@@ -14,7 +14,6 @@ import coffeeshout.room.domain.RoomState;
 import coffeeshout.room.domain.player.Menu;
 import coffeeshout.room.domain.player.MenuType;
 import coffeeshout.room.domain.player.PlayerName;
-import coffeeshout.room.domain.service.MenuQueryService;
 import coffeeshout.room.domain.service.RoomQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -36,9 +35,6 @@ class ConnectPreSendHandlerTest {
     private RoomQueryService roomQueryService;
 
     @Mock
-    private MenuQueryService menuQueryService;
-    
-    @Mock
     private DelayedPlayerRemovalService delayedPlayerRemovalService;
 
     private StompSessionManager sessionManager;
@@ -56,7 +52,6 @@ class ConnectPreSendHandlerTest {
                 sessionManager,
                 webSocketMetricService,
                 roomQueryService,
-                menuQueryService,
                 delayedPlayerRemovalService
         );
     }
@@ -134,23 +129,6 @@ class ConnectPreSendHandlerTest {
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
             then(webSocketMetricService).should().startConnection(sessionId);
         }
-
-        @Test
-        void menuId가_없으면_세션_등록하지_않는다() {
-            // given
-            StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
-            accessor.setSessionId(sessionId);
-            accessor.setNativeHeader("joinCode", joinCode);
-            accessor.setNativeHeader("playerName", playerName);
-            // menuId 헤더 누락
-
-            // when
-            connectPreSendHandler.handle(accessor, sessionId);
-
-            // then
-            assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
-        }
     }
 
     @Nested
@@ -168,7 +146,6 @@ class ConnectPreSendHandlerTest {
             Room testRoom = createPlayingRoom(testMenu);
 
             given(roomQueryService.findByJoinCode(any(JoinCode.class))).willReturn(testRoom);
-            given(menuQueryService.findById(1L)).willReturn(testMenu);
 
             // when
             connectPreSendHandler.handle(accessor, sessionId);


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #551 

# 🚀 작업 내용

1. disconnect 감지, 15초 내의 상황에서 앱 전환된 플레이어는 ready false로 처리
2. 웹소켓 연결 시, 헤더에 menuId 필요없도록 수정
3. 게스트가 호스트로 승격시 playerType 변경

# 💬 리뷰 중점사항

중점사항
