### PR TITLE
[design] 전체 반응형 스타일 통일

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -14,17 +14,17 @@ const preview: Preview = {
   decorators: [
     (Story) => (
       <ThemeProvider theme={theme}>
-        <WebSocketProvider>
-          <MemoryRouter>
-            <IdentifierProvider>
+        <MemoryRouter>
+          <IdentifierProvider>
+            <WebSocketProvider>
               <CardGameProvider>
                 <ModalProvider>
                   <Story />
                 </ModalProvider>
               </CardGameProvider>
-            </IdentifierProvider>
-          </MemoryRouter>
-        </WebSocketProvider>
+            </WebSocketProvider>
+          </IdentifierProvider>
+        </MemoryRouter>
       </ThemeProvider>
     ),
   ],

--- a/frontend/src/components/@common/Button/Button.styled.ts
+++ b/frontend/src/components/@common/Button/Button.styled.ts
@@ -1,3 +1,4 @@
+import { Size } from '@/types/styles';
 import styled from '@emotion/styled';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'loading' | 'ready';
@@ -5,12 +6,23 @@ export type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'loading' | '
 type Props = {
   $variant: ButtonVariant;
   $width: string;
-  $height: string;
+  $height: Size;
 };
 
 export const Container = styled.button<Props>`
   width: ${({ $width }) => $width};
-  height: ${({ $height }) => $height};
+  height: ${({ $height }) => {
+    switch ($height) {
+      case 'small':
+        return '40px';
+      case 'medium':
+        return '45px';
+      case 'large':
+        return '50px';
+      default:
+        return '50px';
+    }
+  }};
   ${({ theme }) => theme.typography.h4}
   display: flex;
   align-items: center;

--- a/frontend/src/components/@common/Button/Button.styled.ts
+++ b/frontend/src/components/@common/Button/Button.styled.ts
@@ -1,28 +1,16 @@
-import { Size } from '@/types/styles';
 import styled from '@emotion/styled';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'disabled' | 'loading' | 'ready';
 
 type Props = {
-  $height: Size;
   $variant: ButtonVariant;
   $width: string;
+  $height: string;
 };
 
 export const Container = styled.button<Props>`
   width: ${({ $width }) => $width};
-  height: ${({ $height }) => {
-    switch ($height) {
-      case 'small':
-        return '40px';
-      case 'medium':
-        return '45px';
-      case 'large':
-        return '50px';
-      default:
-        return '50px';
-    }
-  }};
+  height: ${({ $height }) => $height};
   ${({ theme }) => theme.typography.h4}
   display: flex;
   align-items: center;

--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -1,4 +1,3 @@
-import { Size } from '@/types/styles';
 import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
 import * as S from './Button.styled';
 import { isTouchDevice } from '@/utils/isTouchDevice';
@@ -7,13 +6,13 @@ type Props = {
   onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
   variant?: S.ButtonVariant;
   width?: string;
-  height?: Size;
+  height?: string;
 } & Omit<ComponentProps<'button'>, 'disabled'>;
 
 const Button = ({
   variant = 'primary',
   width = '100%',
-  height = 'large',
+  height = '45px',
   children,
   onClick,
   ...rest

--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -1,18 +1,19 @@
 import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
 import * as S from './Button.styled';
 import { isTouchDevice } from '@/utils/isTouchDevice';
+import { Size } from '@/types/styles';
 
 type Props = {
   onClick?: (e: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
   variant?: S.ButtonVariant;
   width?: string;
-  height?: string;
+  height?: Size;
 } & Omit<ComponentProps<'button'>, 'disabled'>;
 
 const Button = ({
   variant = 'primary',
   width = '100%',
-  height = '45px',
+  height = 'medium',
   children,
   onClick,
   ...rest

--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -13,7 +13,7 @@ type Props = {
 const Button = ({
   variant = 'primary',
   width = '100%',
-  height = 'medium',
+  height = 'large',
   children,
   onClick,
   ...rest

--- a/frontend/src/components/@common/Input/Input.styled.ts
+++ b/frontend/src/components/@common/Input/Input.styled.ts
@@ -1,3 +1,4 @@
+import { DESIGN_TOKENS } from '@/constants/design';
 import styled from '@emotion/styled';
 
 type ContainerProps = { $height: string; $hasValue: boolean };
@@ -44,7 +45,7 @@ export const Input = styled.input`
 
 export const ClearButton = styled.button<ClearButtonProps>`
   background-color: white;
-  font-size: 20px;
+  font-size: ${DESIGN_TOKENS.typography.h2};
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/components/@common/RoomActionButton/RoomActionButton.styled.ts
+++ b/frontend/src/components/@common/RoomActionButton/RoomActionButton.styled.ts
@@ -8,8 +8,7 @@ export const Container = styled.button`
   gap: 20px;
 
   width: 100%;
-  min-width: 310px;
-  height: 135px;
+  height: 130px;
   background-color: ${({ theme }) => theme.color.gray[50]};
   border-radius: 12px;
   padding: 28px 20px;

--- a/frontend/src/constants/design.ts
+++ b/frontend/src/constants/design.ts
@@ -1,0 +1,36 @@
+import { clampByWidth, clampByHeight } from '@/utils/responsive';
+
+export const DESIGN_TOKENS = {
+  // 타이포그래피
+  typography: {
+    h1: clampByWidth(24, 30),
+    h2: clampByWidth(20, 24),
+    h3: clampByWidth(18, 20),
+    h4: clampByWidth(14, 16),
+    paragraph: clampByWidth(14, 16),
+    small: clampByWidth(12, 14),
+  },
+
+  // 카드
+  card: {
+    small: {
+      width: clampByWidth(40, 48),
+      height: clampByHeight(45, 61),
+    },
+    medium: {
+      width: clampByWidth(54, 64),
+      height: clampByHeight(60, 82),
+    },
+    large: {
+      width: clampByWidth(80, 96),
+      height: clampByHeight(95, 123),
+    },
+  },
+
+  // 원형
+  circle: {
+    small: clampByWidth(29, 34),
+    medium: clampByWidth(38, 46),
+    large: clampByWidth(57, 69),
+  },
+} as const;

--- a/frontend/src/constants/design.ts
+++ b/frontend/src/constants/design.ts
@@ -1,36 +1,36 @@
-import { clampByWidth, clampByHeight } from '@/utils/responsive';
+import { responsiveWidth, responsiveHeight } from '@/utils/responsive';
 
 export const DESIGN_TOKENS = {
   // 타이포그래피
   typography: {
-    h1: clampByWidth(24, 30),
-    h2: clampByWidth(20, 24),
-    h3: clampByWidth(18, 20),
-    h4: clampByWidth(14, 16),
-    paragraph: clampByWidth(14, 16),
-    small: clampByWidth(12, 14),
+    h1: responsiveWidth(24, 30),
+    h2: responsiveWidth(20, 24),
+    h3: responsiveWidth(18, 20),
+    h4: responsiveWidth(14, 16),
+    paragraph: responsiveWidth(14, 16),
+    small: responsiveWidth(12, 14),
   },
 
   // 카드
   card: {
     small: {
-      width: clampByWidth(40, 48),
-      height: clampByHeight(45, 61),
+      width: responsiveWidth(40, 48),
+      height: responsiveHeight(45, 61),
     },
     medium: {
-      width: clampByWidth(54, 64),
-      height: clampByHeight(60, 82),
+      width: responsiveWidth(54, 64),
+      height: responsiveHeight(60, 82),
     },
     large: {
-      width: clampByWidth(80, 96),
-      height: clampByHeight(95, 123),
+      width: responsiveWidth(80, 96),
+      height: responsiveHeight(95, 123),
     },
   },
 
   // 원형
   circle: {
-    small: clampByWidth(29, 34),
-    medium: clampByWidth(38, 46),
-    large: clampByWidth(57, 69),
+    small: responsiveWidth(29, 34),
+    medium: responsiveWidth(38, 46),
+    large: responsiveWidth(57, 69),
   },
 } as const;

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -164,7 +164,7 @@ const EntryMenuPage = () => {
         <Button
           variant={isButtonDisabled ? 'disabled' : 'primary'}
           onClick={handleNavigateToLobby}
-          height="50px"
+          height="large"
         >
           {isHost ? '방 만들러 가기' : '방 참가하기'}
         </Button>

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -161,7 +161,11 @@ const EntryMenuPage = () => {
         </S.Container>
       </Layout.Content>
       <Layout.ButtonBar>
-        <Button variant={isButtonDisabled ? 'disabled' : 'primary'} onClick={handleNavigateToLobby}>
+        <Button
+          variant={isButtonDisabled ? 'disabled' : 'primary'}
+          onClick={handleNavigateToLobby}
+          height="50px"
+        >
           {isHost ? '방 만들러 가기' : '방 참가하기'}
         </Button>
       </Layout.ButtonBar>

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -66,7 +66,11 @@ const EntryNamePage = () => {
         </S.Container>
       </Layout.Content>
       <Layout.ButtonBar>
-        <Button variant={isButtonDisabled ? 'disabled' : 'primary'} onClick={handleNavigateToMenu}>
+        <Button
+          variant={isButtonDisabled ? 'disabled' : 'primary'}
+          onClick={handleNavigateToMenu}
+          height="50px"
+        >
           메뉴 선택하러 가기
         </Button>
       </Layout.ButtonBar>

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -69,7 +69,7 @@ const EntryNamePage = () => {
         <Button
           variant={isButtonDisabled ? 'disabled' : 'primary'}
           onClick={handleNavigateToMenu}
-          height="50px"
+          height="large"
         >
           메뉴 선택하러 가기
         </Button>

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.styled.ts
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.styled.ts
@@ -4,7 +4,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0;
 `;
 
 export const ButtonContainer = styled.div`

--- a/frontend/src/features/home/pages/HomePage.styled.ts
+++ b/frontend/src/features/home/pages/HomePage.styled.ts
@@ -13,6 +13,10 @@ export const Logo = styled.img`
   right: 20px;
   -webkit-user-drag: none;
   user-select: none;
+
+  @media (max-height: 675px) {
+    display: none;
+  }
 `;
 
 export const ButtonContainer = styled.div`

--- a/frontend/src/features/miniGame/cardGame/components/CardFront/CardFront.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/CardFront/CardFront.styled.ts
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Card } from '../../constants/cards';
 import { cardVariants, circleVariants } from '../../constants/variants';
+import { DESIGN_TOKENS } from '@/constants/design';
 
 type Props = {
   $size?: Size;
@@ -36,9 +37,9 @@ const getCardTextColor = ($card?: Card) => {
 };
 
 const cardTextFontSize = {
-  small: '0.75rem', // ~12px
-  medium: '1rem', // ~16px
-  large: '1.25rem', // ~20px
+  small: DESIGN_TOKENS.typography.small, // ~12px
+  medium: DESIGN_TOKENS.typography.h4, // ~16px
+  large: DESIGN_TOKENS.typography.h3, // ~20px
 };
 
 export const Container = styled.div<Props>`

--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.styled.ts
@@ -1,3 +1,4 @@
+import { DESIGN_TOKENS } from '@/constants/design';
 import styled from '@emotion/styled';
 
 type Props = {
@@ -36,7 +37,7 @@ export const ProgressCircle = styled.circle<Props>`
 
 export const CountText = styled.span`
   color: ${({ theme }) => theme.color.gray[700]};
-  font-size: 0.75rem; // ~12px
+  font-size: ${DESIGN_TOKENS.typography.small};
   font-weight: 700;
   text-align: center;
 `;

--- a/frontend/src/features/miniGame/cardGame/components/Round/Round.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/Round/Round.styled.ts
@@ -34,6 +34,5 @@ export const CardContainer = styled.div`
   grid-template-columns: repeat(3, 1fr);
   place-items: center;
   margin: 0 auto;
-  width: 20.25rem;
   gap: 0.625rem;
 `;

--- a/frontend/src/features/miniGame/cardGame/constants/variants.ts
+++ b/frontend/src/features/miniGame/cardGame/constants/variants.ts
@@ -1,21 +1,22 @@
+import { DESIGN_TOKENS } from '@/constants/design';
+
 export const cardVariants = {
-  // 1.28 비율
   small: {
-    width: '3rem', // ~48px
-    height: '3.84rem', // ~61.4px
+    width: DESIGN_TOKENS.card.small.width,
+    height: DESIGN_TOKENS.card.small.height,
   },
   medium: {
-    width: '4rem', // ~64px
-    height: '5.12rem', // ~81.9px
+    width: DESIGN_TOKENS.card.medium.width,
+    height: DESIGN_TOKENS.card.medium.height,
   },
   large: {
-    width: '6rem', // ~96px
-    height: '7.68rem', // ~122.9px
+    width: DESIGN_TOKENS.card.large.width,
+    height: DESIGN_TOKENS.card.large.height,
   },
 };
 
 export const circleVariants = {
-  small: '2.15rem', // ~34.4px
-  medium: '2.875rem', // ~46px
-  large: '4.325rem', // ~69.2px
+  small: DESIGN_TOKENS.circle.small,
+  medium: DESIGN_TOKENS.circle.medium,
+  large: DESIGN_TOKENS.circle.large,
 };

--- a/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.styled.ts
+++ b/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.styled.ts
@@ -4,7 +4,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0;
 `;
 
 export const Wrapper = styled.div`

--- a/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.tsx
+++ b/frontend/src/features/room/lobby/components/JoinCodeModal/JoinCodeModal.tsx
@@ -4,12 +4,17 @@ import Paragraph from '@/components/@common/Paragraph/Paragraph';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import * as S from './JoinCodeModal.styled';
 
-const JoinCodeModal = () => {
+type props = {
+  onClose: () => void;
+};
+
+const JoinCodeModal = ({ onClose }: props) => {
   const { joinCode } = useIdentifier();
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(joinCode);
     alert('초대 코드가 복사되었습니다.');
+    onClose();
   };
 
   return (

--- a/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.styled.ts
+++ b/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.styled.ts
@@ -4,7 +4,6 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0;
 `;
 
 export const ButtonContainer = styled.div`

--- a/frontend/src/features/room/lobby/pages/LobbyPage.styled.ts
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.styled.ts
@@ -9,7 +9,7 @@ export const Container = styled.div`
 
 export const Wrapper = styled.div`
   position: absolute;
-  bottom: 2rem;
+  bottom: 1rem;
   left: 2rem;
   right: 2rem;
 `;

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -132,7 +132,7 @@ const LobbyPage = () => {
   };
 
   const handleShare = () => {
-    openModal(<JoinCodeModal />, {
+    openModal(<JoinCodeModal onClose={closeModal} />, {
       title: '초대 코드',
       showCloseButton: true,
     });
@@ -223,7 +223,15 @@ const LobbyPage = () => {
     ),
   };
 
-  if (!playerType) return null;
+  useEffect(() => {
+    if (!playerType) {
+      navigate('/', { replace: true });
+    }
+  }, [playerType, navigate]);
+
+  if (!playerType) {
+    return null;
+  }
 
   return (
     <Layout>

--- a/frontend/src/features/roulette/components/RouletteSlice/RouletteSlice.styled.ts
+++ b/frontend/src/features/roulette/components/RouletteSlice/RouletteSlice.styled.ts
@@ -1,7 +1,8 @@
+import { DESIGN_TOKENS } from '@/constants/design';
 import styled from '@emotion/styled';
 
 export const PlayerNameText = styled.text`
   fill: ${({ theme }) => theme.color.point[100]};
-  font-size: 12px;
+  font-size: ${DESIGN_TOKENS.typography.small};
   font-weight: bold;
 `;

--- a/frontend/src/layouts/ButtonBar/ButtonBar.styled.ts
+++ b/frontend/src/layouts/ButtonBar/ButtonBar.styled.ts
@@ -13,6 +13,7 @@ export const Container = styled.div<ContainerProps>`
   height: ${({ $height }) => $height};
   display: flex;
   gap: 1.5rem;
+  padding-top: 8px;
 `;
 
 export const Wrapper = styled.div<WrapperProps>`

--- a/frontend/src/layouts/ButtonBar/ButtonBar.tsx
+++ b/frontend/src/layouts/ButtonBar/ButtonBar.tsx
@@ -7,7 +7,7 @@ type ButtonBarProps = {
   children: ReactElement | ReactElement[];
 };
 
-const ButtonBar = ({ height = '4rem', flexRatios, children }: ButtonBarProps) => {
+const ButtonBar = ({ height = '3rem', flexRatios, children }: ButtonBarProps) => {
   if (flexRatios?.some((ratio) => ratio <= 0)) {
     throw new Error('flexRatio는 0보다 큰 양수여야 합니다');
   }

--- a/frontend/src/layouts/ButtonBar/ButtonBar.tsx
+++ b/frontend/src/layouts/ButtonBar/ButtonBar.tsx
@@ -7,7 +7,7 @@ type ButtonBarProps = {
   children: ReactElement | ReactElement[];
 };
 
-const ButtonBar = ({ height = '3rem', flexRatios, children }: ButtonBarProps) => {
+const ButtonBar = ({ height = 'auto', flexRatios, children }: ButtonBarProps) => {
   if (flexRatios?.some((ratio) => ratio <= 0)) {
     throw new Error('flexRatio는 0보다 큰 양수여야 합니다');
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -27,6 +27,7 @@ body {
 }
 
 #root {
+  min-width: 320px;
   max-width: 430px;
   width: 100%;
   height: 100dvh;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import { DESIGN_TOKENS } from '@/constants/design';
+
 const color = {
   point: {
     50: '#FEF2F2',
@@ -28,39 +30,39 @@ const color = {
 
 const typography = {
   h1: {
-    fontSize: '30px',
+    fontSize: DESIGN_TOKENS.typography.h1,
     fontWeight: 700,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
   h2: {
-    fontSize: '24px',
+    fontSize: DESIGN_TOKENS.typography.h2,
     fontWeight: 600,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
   h3: {
-    fontSize: '20px',
+    fontSize: DESIGN_TOKENS.typography.h3,
     fontWeight: 600,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
   h4: {
-    fontSize: '16px',
+    fontSize: DESIGN_TOKENS.typography.h4,
     fontWeight: 600,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
 
   paragraph: {
-    fontSize: '16px',
+    fontSize: DESIGN_TOKENS.typography.paragraph,
     fontWeight: 500,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",
   },
 
   small: {
-    fontSize: '14px',
+    fontSize: DESIGN_TOKENS.typography.small,
     fontWeight: 400,
     fontFamily:
       "'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif",

--- a/frontend/src/utils/responsive.ts
+++ b/frontend/src/utils/responsive.ts
@@ -3,13 +3,13 @@ const MAX_WIDTH = 430;
 const MIN_HEIGHT = 568;
 const MAX_HEIGHT = 932;
 
-export const clampByWidth = (min: number, max: number): string => {
+export const responsiveWidth = (min: number, max: number): string => {
   const vw = ((max - min) / (MAX_WIDTH - MIN_WIDTH)) * 100;
   const offset = min - (MIN_WIDTH * vw) / 100;
   return `clamp(${min}px, ${vw}vw + ${offset}px, ${max}px)`;
 };
 
-export const clampByHeight = (min: number, max: number): string => {
+export const responsiveHeight = (min: number, max: number): string => {
   const slope = (max - min) / (MAX_HEIGHT - MIN_HEIGHT);
   const vhValue = slope * 100;
   const offset = min - slope * MIN_HEIGHT;

--- a/frontend/src/utils/responsive.ts
+++ b/frontend/src/utils/responsive.ts
@@ -3,17 +3,16 @@ const MAX_WIDTH = 430;
 const MIN_HEIGHT = 568;
 const MAX_HEIGHT = 932;
 
-export const responsiveWidth = (min: number, max: number): string => {
-  const vw = ((max - min) / (MAX_WIDTH - MIN_WIDTH)) * 100;
-  const offset = min - (MIN_WIDTH * vw) / 100;
-  return `clamp(${min}px, ${vw}vw + ${offset}px, ${max}px)`;
+const createResponsiveClamp = (minViewport: number, maxViewport: number, unit: 'vw' | 'vh') => {
+  return (min: number, max: number): string => {
+    const slope = (max - min) / (maxViewport - minViewport);
+    const unitValue = slope * 100;
+    const offset = min - slope * minViewport;
+
+    const offsetStr = offset >= 0 ? `+ ${offset}px` : `- ${Math.abs(offset)}px`;
+    return `clamp(${min}px, ${unitValue}${unit} ${offsetStr}, ${max}px)`;
+  };
 };
 
-export const responsiveHeight = (min: number, max: number): string => {
-  const slope = (max - min) / (MAX_HEIGHT - MIN_HEIGHT);
-  const vhValue = slope * 100;
-  const offset = min - slope * MIN_HEIGHT;
-
-  const offsetStr = offset >= 0 ? `+ ${offset}px` : `- ${Math.abs(offset)}px`;
-  return `clamp(${min}px, ${vhValue}vh ${offsetStr}, ${max}px)`;
-};
+export const responsiveWidth = createResponsiveClamp(MIN_WIDTH, MAX_WIDTH, 'vw');
+export const responsiveHeight = createResponsiveClamp(MIN_HEIGHT, MAX_HEIGHT, 'vh');

--- a/frontend/src/utils/responsive.ts
+++ b/frontend/src/utils/responsive.ts
@@ -1,0 +1,19 @@
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 430;
+const MIN_HEIGHT = 568;
+const MAX_HEIGHT = 932;
+
+export const clampByWidth = (min: number, max: number): string => {
+  const vw = ((max - min) / (MAX_WIDTH - MIN_WIDTH)) * 100;
+  const offset = min - (MIN_WIDTH * vw) / 100;
+  return `clamp(${min}px, ${vw}vw + ${offset}px, ${max}px)`;
+};
+
+export const clampByHeight = (min: number, max: number): string => {
+  const slope = (max - min) / (MAX_HEIGHT - MIN_HEIGHT);
+  const vhValue = slope * 100;
+  const offset = min - slope * MIN_HEIGHT;
+
+  const offsetStr = offset >= 0 ? `+ ${offset}px` : `- ${Math.abs(offset)}px`;
+  return `clamp(${min}px, ${vhValue}vh ${offsetStr}, ${max}px)`;
+};


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #145


# 🚀 작업 내용

### 1. `root` 태그의 최소 넓이를 320px로 고정
모든 모바일 기기에서 잘 보이도록 처리하기 위해 가장 작은 화면 넓이인 iPhone SE를 기준으로 320px을 최소 넓이로 설정해주었습니다.

현재 커버하고 있는 최소/최대 넓이는 아래와 같습니다.

```tsx
const MIN_WIDTH = 320;
const MAX_WIDTH = 430;
const MIN_HEIGHT = 568; 
const MAX_HEIGHT = 932;
```
 
### 2. `clamp` 함수를 사용하여 반응형 유틸함수 구현

`media-query`로 모든 분기점에 대해 처리하는 것은 처리하기 복잡하다고 생각하여 `clamp` 함수를 사용하여 반응형을 처리해 주었습니다.
`clamp` 함수는 아래와 같이 사용하며 의미는 다음과 같습니다.

```tsx
font-size: clamp(14px, 4vw, 18px); // 최소 14px, 최대 18px, 그 사이는 vw에 따라 변화
```

`responsiveWidth`, `responsiveHeight`와 같은 넓이와 높이를 동적으로 계산하는 유틸함수를 만들어서 최소, 최대 크기에 따라 적절한 px값을 계산하는 방식으로 구현해 주었습니다.

해당 함수를 적용한 곳은 넓이나 높이에 가장 영항을 많이 받는 곳인 `typography`, `card`, `circle` 입니다. 이는 `constants` > `design.ts`에 `DESIGN_TOKENS`라는 상수로 정의해 주었습니다.

### 3. `ButtonBar` 컴포넌트의 기본 높이를 `auto`로 변경

버튼바 컴포넌트의 높이를 버튼 내부의 높이를 기준으로 전체 높이를 채우도록 하기 위해서 기존에 설정되어 있는 기본 값인 `4rem`을 `auto`로 변경했습니다.

## 변경 이후

### 메인 페이지
메인 페이지에서 타이포그래피를 반응형으로 처리한 결과물입니다.

https://github.com/user-attachments/assets/791d5806-4d5e-4acf-84ab-a27f950e6193

### 카드 게임 페이지
가장 큰 이슈가 있었던 카드 게임 페이지입니다. 가장 작은 화면인 넓이 320px, 높이 568px에서도 9개의 카드가 모두 보이도록 처리했습니다.

https://github.com/user-attachments/assets/043f88bf-66ad-400b-a4ca-4b5c9804e66a

# 💬 리뷰 중점사항

중점사항
