### PR TITLE
[feat] 호스트가 방을 나갈 경우, 다른 게스트에게 자동으로 호스트 권한 위임

### DIFF
--- a/frontend/src/contexts/PlayerType/PlayerTypeContext.ts
+++ b/frontend/src/contexts/PlayerType/PlayerTypeContext.ts
@@ -3,6 +3,7 @@ import { PlayerType } from '@/types/player';
 
 type PlayerTypeContextType = {
   playerType: PlayerType | null;
+  setPlayerType: (type: PlayerType | null) => void;
   setGuest: () => void;
   setHost: () => void;
 };

--- a/frontend/src/contexts/PlayerType/PlayerTypeProvider.tsx
+++ b/frontend/src/contexts/PlayerType/PlayerTypeProvider.tsx
@@ -12,8 +12,9 @@ export const PlayerTypeProvider = ({ children }: PropsWithChildren) => {
   const setHost = () => {
     setPlayerType('HOST');
   };
+
   return (
-    <PlayerTypeContext.Provider value={{ playerType, setGuest, setHost }}>
+    <PlayerTypeContext.Provider value={{ playerType, setPlayerType, setGuest, setHost }}>
       {children}
     </PlayerTypeContext.Provider>
   );

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -159,11 +159,7 @@ const EntryMenuPage = () => {
         </S.Container>
       </Layout.Content>
       <Layout.ButtonBar>
-        <Button
-          variant={isButtonDisabled ? 'disabled' : 'primary'}
-          onClick={handleNavigateToLobby}
-          height="large"
-        >
+        <Button variant={isButtonDisabled ? 'disabled' : 'primary'} onClick={handleNavigateToLobby}>
           {isHost ? '방 만들러 가기' : '방 참가하기'}
         </Button>
       </Layout.ButtonBar>

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -66,11 +66,7 @@ const EntryNamePage = () => {
         </S.Container>
       </Layout.Content>
       <Layout.ButtonBar>
-        <Button
-          variant={isButtonDisabled ? 'disabled' : 'primary'}
-          onClick={handleNavigateToMenu}
-          height="large"
-        >
+        <Button variant={isButtonDisabled ? 'disabled' : 'primary'} onClick={handleNavigateToMenu}>
           메뉴 선택하러 가기
         </Button>
       </Layout.ButtonBar>

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -35,7 +35,7 @@ const LobbyPage = () => {
   const { send } = useWebSocket();
   const { myName, joinCode } = useIdentifier();
   const { openModal, closeModal } = useModal();
-  const { playerType } = usePlayerType();
+  const { playerType, setPlayerType } = usePlayerType();
   const { updateCurrentProbabilities } = useProbabilityHistory();
   const { participants, setParticipants, isAllReady, checkPlayerReady } = useParticipants();
   const [currentSection, setCurrentSection] = useState<SectionType>('참가자');
@@ -45,8 +45,13 @@ const LobbyPage = () => {
   const handleParticipant = useCallback(
     (data: Player[]) => {
       setParticipants(data);
+
+      const currentPlayer = data.find((player) => player.playerName === myName);
+      if (currentPlayer) {
+        setPlayerType(currentPlayer.playerType);
+      }
     },
-    [setParticipants]
+    [setParticipants, myName, setPlayerType]
   );
 
   // TODO: 나중에 외부 state 로 분리할 것

--- a/frontend/src/features/room/order/components/MenuCount/MenuCount.tsx
+++ b/frontend/src/features/room/order/components/MenuCount/MenuCount.tsx
@@ -1,13 +1,10 @@
 import Headline3 from '@/components/@common/Headline3/Headline3';
 import Paragraph from '@/components/@common/Paragraph/Paragraph';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import * as S from './MenuCount.styled';
-import { Player } from '@/types/player';
 
-type Props = {
-  participants: Player[];
-};
-
-const MenuCount = ({ participants }: Props) => {
+const MenuCount = () => {
+  const { participants } = useParticipants();
   const simpleViewMap = new Map<string, number>();
 
   participants.forEach((participant) => {

--- a/frontend/src/features/room/order/components/PlayerMenu/PlayerMenu.tsx
+++ b/frontend/src/features/room/order/components/PlayerMenu/PlayerMenu.tsx
@@ -1,12 +1,10 @@
 import Paragraph from '@/components/@common/Paragraph/Paragraph';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import * as S from './PlayerMenu.styled';
-import { Player } from '@/types/player';
 
-type Props = {
-  participants: Player[];
-};
+const PlayerMenu = () => {
+  const { participants } = useParticipants();
 
-const PlayerMenu = ({ participants }: Props) => {
   return (
     <S.OrderList>
       {participants.map((participant, index) => (

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -7,7 +7,6 @@ import Headline1 from '@/components/@common/Headline1/Headline1';
 import Headline2 from '@/components/@common/Headline2/Headline2';
 import Headline3 from '@/components/@common/Headline3/Headline3';
 import IconButton from '@/components/@common/IconButton/IconButton';
-import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -19,7 +18,6 @@ const OrderPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { stopSocket, isConnected } = useWebSocket();
-  const { participants } = useParticipants();
   const [viewMode, setViewMode] = useState<'simple' | 'detail'>('simple');
 
   const handleToggle = () => {
@@ -51,11 +49,7 @@ const OrderPage = () => {
           <Headline2>주문 리스트 {viewMode === 'detail' ? '상세' : ''}</Headline2>
           <IconButton iconSrc={DetailIcon} onClick={handleToggle} />
         </S.ListHeader>
-        {viewMode === 'simple' ? (
-          <MenuCount participants={participants} />
-        ) : (
-          <PlayerMenu participants={participants} />
-        )}
+        {viewMode === 'simple' ? <MenuCount /> : <PlayerMenu />}
       </Layout.Content>
       <Layout.ButtonBar flexRatios={[5.5, 1]}>
         <Button variant="primary" onClick={handleClickGoMain}>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #550 

# 🚀 작업 내용

호스트가 방을 나가는 경우, 다른 게스트에게 자동으로 호스트 권한을 위임할 수 있도록 수정했습니다. https://github.com/woowacourse-teams/2025-coffee-shout/commit/2af9683f5af29bb61e980de070d09c9bd778870b

PlayerTypeContext에서 setPlayerType을 외부로 노출해, Lobby에서 플레이어 정보를 다시 불러올 때마다(즉, 다른 참여자가 방을 나갔다 들어오는 경우) 자신의 playerType을 갱신할 수 있도록 했습니다. 이를 통해 게스트에서 호스트로 권한이 승격되는 상황에서도 화면이 즉시 호스트용으로 렌더링되도록 보장했습니다.

# ✅ 추가 작업

## useParticipants 사용 위치 수정
MenuCount와 PlayerMenu 컴포넌트 내부에서 참여자 정보를 Context로 가져오도록 수정하였습니다. https://github.com/woowacourse-teams/2025-coffee-shout/commit/bf37fd23ae83e63cbf215894bc7148b551b0f538

## Button 컴포넌트 관련 불필요한 Props 제거
Button 컴포넌트의 height 속성의 기본값이 'large'이기 때문에 불필요한 Props 전달 부분을 제거하였습니다. https://github.com/woowacourse-teams/2025-coffee-shout/commit/25e0d0f83c8ccd0fb9e677b02c5ba420d390fa47