### PR TITLE
[feat] http 처리 메트릭 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/filter/HttpMetricFilter.java
+++ b/backend/src/main/java/coffeeshout/global/filter/HttpMetricFilter.java
@@ -1,0 +1,37 @@
+package coffeeshout.global.filter;
+
+import coffeeshout.global.metric.HttpMetricService;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpMetricFilter implements Filter {
+
+    private final HttpMetricService httpMetricService;
+
+    public HttpMetricFilter(HttpMetricService httpMetricService) {
+        this.httpMetricService = httpMetricService;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!(request instanceof HttpServletRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        httpMetricService.incrementConcurrentRequests();
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            httpMetricService.decrementConcurrentRequests();
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/metric/HttpMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/HttpMetricService.java
@@ -2,29 +2,31 @@ package coffeeshout.global.metric;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class HttpMetricService {
 
-    private final AtomicInteger concurrentRequests = new AtomicInteger(0);
-    private final MeterRegistry meterRegistry;
+    private final LongAdder concurrentRequests;
 
     public HttpMetricService(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
+        concurrentRequests = new LongAdder();
 
         // 실시간 동시 연결 수 게이지 등록
-        Gauge.builder("http.concurrent.requests", concurrentRequests, AtomicInteger::get)
+        Gauge.builder("http.concurrent.requests", concurrentRequests, LongAdder::sum)
                 .description("현재 동시 HTTP 처리 수")
+                .baseUnit("requests")
                 .register(meterRegistry);
     }
 
     public void incrementConcurrentRequests() {
-        concurrentRequests.incrementAndGet();
+        concurrentRequests.increment();
     }
 
     public void decrementConcurrentRequests() {
-        concurrentRequests.decrementAndGet();
+        if (concurrentRequests.sum() > 0) {
+            concurrentRequests.decrement();
+        }
     }
 }

--- a/backend/src/main/java/coffeeshout/global/metric/HttpMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/HttpMetricService.java
@@ -1,0 +1,30 @@
+package coffeeshout.global.metric;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpMetricService {
+
+    private final AtomicInteger concurrentRequests = new AtomicInteger(0);
+    private final MeterRegistry meterRegistry;
+
+    public HttpMetricService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+
+        // 실시간 동시 연결 수 게이지 등록
+        Gauge.builder("http.concurrent.requests", concurrentRequests, AtomicInteger::get)
+                .description("현재 동시 HTTP 처리 수")
+                .register(meterRegistry);
+    }
+
+    public void incrementConcurrentRequests() {
+        concurrentRequests.incrementAndGet();
+    }
+
+    public void decrementConcurrentRequests() {
+        concurrentRequests.decrementAndGet();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,7 +22,10 @@ management:
       percentiles-histogram:
         http.server.requests: true
       percentiles:
-        http.server.requests: 0.5,0.95,0.99
+        http.server.requests:
+          - 0.5
+          - 0.9
+          - 0.99
       maximum-expected-value:
         http.server.requests: 2s # 예상 최대 응답 시간
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,6 +18,14 @@ management:
   metrics:
     enable:
       tomcat: true
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5,0.95,0.99
+      maximum-expected-value:
+        http.server.requests: 2s # 예상 최대 응답 시간
+
   prometheus:
     metrics:
       export:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,16 +18,6 @@ management:
   metrics:
     enable:
       tomcat: true
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true
-      percentiles:
-        http.server.requests:
-          - 0.5
-          - 0.9
-          - 0.99
-      maximum-expected-value:
-        http.server.requests: 3s # 예상 최대 응답 시간
 
   prometheus:
     metrics:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,7 +27,7 @@ management:
           - 0.9
           - 0.99
       maximum-expected-value:
-        http.server.requests: 2s # 예상 최대 응답 시간
+        http.server.requests: 3s # 예상 최대 응답 시간
 
   prometheus:
     metrics:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #575

# 🚀 작업 내용

1.  HTTP 처리 수에 대한 메트릭을 추가하였습니다.
2. http 응답 시간 분포를 확인하기 위해 yml 파일 추가했습니다.
<img width="1493" height="907" alt="{C4E3506D-50E9-448B-AF6E-4CBE4688A8F0}" src="https://github.com/user-attachments/assets/8d6f26e3-9bfc-4a6e-bbcc-88f39fbd2ba7" />


# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 동시 처리 중인 HTTP 요청 수를 실시간으로 추적하는 신규 지표가 추가되었습니다(동기/비동기 및 오류 경로 모두 안전하게 처리).
  * HTTP 서버 요청에 대한 퍼센타일(50/90/99) 및 퍼센타일 히스토그램 수집이 활성화되었습니다.
  * 최대 기대 처리시간을 3초로 설정해 느린 요청을 조기 식별하고 대시보드·알림에 활용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->