### PR TITLE
[feat] 이미지 저장 버튼 삭제

### DIFF
--- a/frontend/src/assets/download-icon.svg
+++ b/frontend/src/assets/download-icon.svg
@@ -1,5 +1,0 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.75 13.75L16 19L21.25 13.75" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M16 5V19" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M27 19V26C27 26.2652 26.8946 26.5196 26.7071 26.7071C26.5196 26.8946 26.2652 27 26 27H6C5.73478 27 5.48043 26.8946 5.29289 26.7071C5.10536 26.5196 5 26.2652 5 26V19" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -2,7 +2,6 @@ import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import BreadLogoWhiteIcon from '@/assets/bread-logo-white.svg';
 import DetailIcon from '@/assets/detail-icon.svg';
-import DownloadIcon from '@/assets/download-icon.svg';
 import Button from '@/components/@common/Button/Button';
 import Headline1 from '@/components/@common/Headline1/Headline1';
 import Headline2 from '@/components/@common/Headline2/Headline2';
@@ -70,12 +69,9 @@ const OrderPage = () => {
           <PlayerMenu participants={participants} />
         )}
       </Layout.Content>
-      <Layout.ButtonBar flexRatios={[5.5, 1]}>
+      <Layout.ButtonBar>
         <Button variant="primary" onClick={handleClickGoMain}>
           메인 화면으로 가기
-        </Button>
-        <Button variant="primary" onClick={() => {}}>
-          <img src={DownloadIcon} />
         </Button>
       </Layout.ButtonBar>
     </Layout>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #578

# 🚀 작업 내용

1. 이미지 저장 기능이 불필요하다고 판단해서 버튼을 삭제했습니다.

# 💬 리뷰 중점사항

중점사항
