### PR TITLE
[fix] 메뉴 selectbox가 잘려서 보이는 문제

### DIFF
--- a/frontend/src/components/@common/SelectBox/SelectBox.styled.ts
+++ b/frontend/src/components/@common/SelectBox/SelectBox.styled.ts
@@ -101,7 +101,7 @@ export const Content = styled.ul<ContentProps>`
   border-radius: 4px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 
-  max-height: 200px;
+  max-height: 160px;
   overflow-y: auto;
 
   margin: 0;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #564 

# 🚀 작업 내용
높이가 작은 화면에서 `SelectBox`를 열 때 드롭다운 메뉴가 하단 버튼 아래로 밀려나서 보이지 않는 문제가 있었습니다. 해당 컴포넌트가 잘리는 원인은 `Layout.Content`의 `overflow` 속성으로 인해 드롭다운이 컨테이너를 벗어날 수 없었습니다.

해당 문제를 `portal`로 해결할 수 있었으나, 구현과 코드의 복잡도를 따졌을 때 `CSS`만으로도 충분히 해결 가능하다고 판단하여, `SelectBox`의 ul 태그의 최대 높이를 설정해 주는 방식으로 해결했습니다.

아래 화면은 개발자 도구를 통해 최소 높이인 568px으로 설정한 상태이고, 정상적으로 표시되는 것을 확인했습니다.

<img width="427" height="563" alt="image" src="https://github.com/user-attachments/assets/94f00689-6996-43ef-8f18-4ef857259c5a" />


# 💬 리뷰 중점사항

중점사항
