### PR TITLE
[fix] 특정 비율에서 서비스 설명 모달내용이 모달창을 뚫고 내려오는 문제 해결

### DIFF
--- a/frontend/src/features/room/lobby/components/GuideModal/GuideContent/GuideContent.styled.ts
+++ b/frontend/src/features/room/lobby/components/GuideModal/GuideContent/GuideContent.styled.ts
@@ -9,8 +9,8 @@ export const ContentContainer = styled.div`
 `;
 
 export const ImageContainer = styled.div`
-  width: 200px;
-  height: 380px;
+  width: 40%;
+  height: 70%;
   margin: 16px 0px;
 `;
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #482 

# 🚀 작업 내용

이미지 크기를 px으로 고정하지 않고, 부모 크기의 %로 차지하도록 수정해줬습니다.

# 💬 리뷰 중점사항

중점사항
