### PR TITLE
[fix] room이 없을 때는 broadcast 안하도록 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
@@ -24,13 +24,18 @@ public class RoomStateUpdateEventListener {
         try {
             log.info("방 상태 업데이트 이벤트 처리: joinCode={}, reason={}", event.joinCode(), event.reason());
 
-            sendPlayerStatus(event.joinCode());
-            sendProbabilitiesStatus(event.joinCode());
+            broadcastRoomState(event.joinCode());
 
             log.info("방 상태 브로드캐스트 완료: joinCode={}", event.joinCode());
-
         } catch (Exception e) {
             log.error("방 상태 업데이트 이벤트 처리 실패: joinCode={}, reason={}", event.joinCode(), event.reason(), e);
+        }
+    }
+
+    private void broadcastRoomState(String joinCode) {
+        if (roomService.roomExists(joinCode)) {
+            sendPlayerStatus(joinCode);
+            sendProbabilitiesStatus(joinCode);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListener.java
@@ -25,8 +25,6 @@ public class RoomStateUpdateEventListener {
             log.info("방 상태 업데이트 이벤트 처리: joinCode={}, reason={}", event.joinCode(), event.reason());
 
             broadcastRoomState(event.joinCode());
-
-            log.info("방 상태 브로드캐스트 완료: joinCode={}", event.joinCode());
         } catch (Exception e) {
             log.error("방 상태 업데이트 이벤트 처리 실패: joinCode={}, reason={}", event.joinCode(), event.reason(), e);
         }
@@ -36,6 +34,7 @@ public class RoomStateUpdateEventListener {
         if (roomService.roomExists(joinCode)) {
             sendPlayerStatus(joinCode);
             sendProbabilitiesStatus(joinCode);
+            log.info("방 상태 브로드캐스트 완료: joinCode={}", joinCode);
         }
     }
 

--- a/backend/src/test/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListenerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/event/RoomStateUpdateEventListenerTest.java
@@ -1,0 +1,69 @@
+package coffeeshout.global.websocket.event;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import coffeeshout.global.websocket.LoggingSimpMessagingTemplate;
+import coffeeshout.room.application.RoomService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RoomStateUpdateEventListenerTest {
+
+    @Mock
+    private RoomService roomService;
+
+    @Mock
+    private LoggingSimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private RoomStateUpdateEventListener listener;
+
+    @Test
+    void 방이_존재할_때는_상태_브로드캐스트를_수행한다() {
+        // given
+        String joinCode = "TEST3";
+        RoomStateUpdateEvent event = new RoomStateUpdateEvent(joinCode, "test reason");
+
+        when(roomService.roomExists(joinCode)).thenReturn(true);
+        when(roomService.getAllPlayers(joinCode)).thenReturn(List.of());
+        when(roomService.getProbabilities(joinCode)).thenReturn(Map.of());
+
+        // when
+        listener.handleRoomStateUpdate(event);
+
+        // then
+        verify(roomService).roomExists(joinCode);
+        verify(roomService).getAllPlayers(joinCode);
+        verify(roomService).getProbabilities(joinCode);
+        verify(messagingTemplate, times(2)).convertAndSend(anyString(), any());
+    }
+
+    @Test
+    void 방이_존재하지_않을_때는_상태_브로드캐스트를_수행하지_않는다() {
+        // given
+        String joinCode = "ERROR";
+        RoomStateUpdateEvent event = new RoomStateUpdateEvent(joinCode, "test reason");
+
+        when(roomService.roomExists(joinCode)).thenReturn(false);
+
+        // when
+        listener.handleRoomStateUpdate(event);
+
+        // then
+        verify(roomService).roomExists(joinCode);
+        verify(roomService, never()).getAllPlayers(anyString());
+        verify(roomService, never()).getProbabilities(anyString());
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any());
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #585

# 🚀 작업 내용

1. room이 없을 때는 broadcast 안하도록 수정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 존재하지 않는 방에 대해 상태 브로드캐스트를 중단해 불필요한 전송과 잠재적 오류를 방지했습니다.
- 리팩터링
  - 방 상태 전송 흐름을 하나의 경로로 통합해 일관성 및 유지보수성을 향상시켰습니다.
- 테스트
  - 방 존재/비존재 시나리오를 검증하는 단위 테스트를 추가해 동작 보증 및 회귀를 방지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->