### PR TITLE
[fix] 호스트가 아닌 플레이어만 Ready 상태 변경 가능하도록 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -9,6 +9,7 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.player.Menu;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.player.PlayerType;
 import coffeeshout.room.domain.player.Winner;
 import coffeeshout.room.domain.roulette.Probability;
 import coffeeshout.room.domain.service.JoinCodeGenerator;
@@ -71,7 +72,9 @@ public class RoomService {
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
         final Player player = room.findPlayer(new PlayerName(playerName));
 
-        player.updateReadyState(isReady);
+        if (player.getPlayerType() != PlayerType.HOST) {
+            player.updateReadyState(isReady);
+        }
 
         return room.getPlayers();
     }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #595

# 🚀 작업 내용

1. 호스트가 아닌 플레이어만 Ready 상태 변경 가능하도록 수정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 방장(HOST)의 준비 상태 변경 요청이 더 이상 반영되지 않으며, 참가자만 준비/해제를 할 수 있습니다.
  - 방장의 준비 상태는 UI에서 변하지 않거나 관련 버튼이 비활성화될 수 있습니다.
  - 참가자의 준비 상태 변경은 기존과 동일하게 즉시 반영됩니다.
  - 준비 상태 표시가 더 일관되며, 예기치 않은 상태 전환으로 인한 혼선을 줄입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->