### PR TITLE
[fix] 호스트가 아닌 플레이어만 Ready 상태 변경 가능하도록 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/room/application/DelayedRoomRemovalService.java
+++ b/backend/src/main/java/coffeeshout/room/application/DelayedRoomRemovalService.java
@@ -1,0 +1,52 @@
+package coffeeshout.room.application;
+
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.service.RoomCommandService;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class DelayedRoomRemovalService {
+
+    private final TaskScheduler taskScheduler;
+    private final Duration removeDuration;
+    private final RoomCommandService roomCommandService;
+
+    public DelayedRoomRemovalService(
+            @Qualifier("delayRemovalScheduler") TaskScheduler taskScheduler,
+            @Value("${room.removalDelay}") Duration removalDelay,
+            RoomCommandService roomCommandService) {
+        validateRemovalDuration(removalDelay);
+        this.taskScheduler = taskScheduler;
+        this.removeDuration = removalDelay;
+        this.roomCommandService = roomCommandService;
+    }
+
+    private void validateRemovalDuration(Duration removalDelay) {
+        if (removalDelay == null || removalDelay.isNegative() || removalDelay.isZero()) {
+            throw new IllegalArgumentException("지연 삭제 시간은 양수여야 합니다.");
+        }
+    }
+
+    public void scheduleRemoveRoom(JoinCode joinCode) {
+        log.info("방 지연 삭제 스케줄링: joinCode={}, delay={}초",
+                joinCode.value(), removeDuration.getSeconds());
+
+        taskScheduler.schedule(() -> executeRoomRemoval(joinCode), Instant.now().plus(removeDuration));
+    }
+
+    private void executeRoomRemoval(JoinCode joinCode) {
+        try {
+            roomCommandService.delete(joinCode);
+            log.info("방 삭제 완료: joinCode={}", joinCode.value());
+        } catch (Exception e) {
+            log.error("방 삭제 중 오류 발생: joinCode={}", joinCode.value(), e);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -9,6 +9,7 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.player.Menu;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.player.PlayerType;
 import coffeeshout.room.domain.player.Winner;
 import coffeeshout.room.domain.roulette.Probability;
 import coffeeshout.room.domain.service.JoinCodeGenerator;
@@ -71,7 +72,9 @@ public class RoomService {
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
         final Player player = room.findPlayer(new PlayerName(playerName));
 
-        player.updateReadyState(isReady);
+        if (player.getPlayerType() != PlayerType.HOST) {
+            player.updateReadyState(isReady);
+        }
 
         return room.getPlayers();
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     name:
       coffee-shout
 
+room:
+  removalDelay: 1h
+
 logging:
   level:
     root: info

--- a/backend/src/test/java/coffeeshout/room/application/DelayedRoomRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/DelayedRoomRemovalServiceTest.java
@@ -1,0 +1,117 @@
+package coffeeshout.room.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.service.RoomCommandService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class DelayedRoomRemovalServiceTest {
+
+    @Mock
+    RoomCommandService roomCommandService;
+
+    @Mock
+    TaskScheduler taskScheduler;
+
+    @SuppressWarnings({"rawtypes"})
+    ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
+
+    DelayedRoomRemovalService delayedRoomRemovalService;
+
+    @BeforeEach
+    void setUp() {
+        Duration removalDelay = Duration.ofMillis(100);
+
+        delayedRoomRemovalService = new DelayedRoomRemovalService(
+                taskScheduler,
+                removalDelay,
+                roomCommandService
+        );
+    }
+
+    @Nested
+    class 방_지연_삭제_스케줄링 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 정상적으로_지연_삭제를_스케줄링한다() {
+            JoinCode joinCode = new JoinCode("ABCDE");
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            delayedRoomRemovalService.scheduleRemoveRoom(joinCode);
+
+            then(taskScheduler).should().schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void 서로_다른_방은_독립적으로_스케줄링된다() {
+            JoinCode joinCode1 = new JoinCode("ABCDE");
+            JoinCode joinCode2 = new JoinCode("FGHKJ");
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willReturn(scheduledFuture);
+
+            delayedRoomRemovalService.scheduleRemoveRoom(joinCode1);
+            delayedRoomRemovalService.scheduleRemoveRoom(joinCode2);
+
+            then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+        }
+    }
+
+    @Nested
+    class 실제_삭제_실행_시뮬레이션 {
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void RoomCommandService가_정상_호출된다() {
+            JoinCode joinCode = new JoinCode("ABCDE");
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willAnswer(invocation -> {
+                        Runnable task = invocation.getArgument(0);
+                        task.run();
+                        return scheduledFuture;
+                    });
+
+            delayedRoomRemovalService.scheduleRemoveRoom(joinCode);
+
+            then(roomCommandService).should().delete(joinCode);
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        void RoomCommandService에서_예외_발생해도_안전하게_처리한다() {
+            JoinCode joinCode = new JoinCode("ABCDE");
+            willThrow(new RuntimeException("방 삭제 실패"))
+                    .given(roomCommandService)
+                    .delete(any(JoinCode.class));
+
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
+                    .willAnswer(invocation -> {
+                        Runnable task = invocation.getArgument(0);
+                        task.run();
+                        return scheduledFuture;
+                    });
+
+            delayedRoomRemovalService.scheduleRemoveRoom(joinCode);
+
+            then(roomCommandService).should().delete(joinCode);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -2,6 +2,9 @@ package coffeeshout.room.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 import coffeeshout.fixture.MenuFixture;
 import coffeeshout.fixture.MiniGameDummy;
@@ -25,6 +28,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -37,6 +41,9 @@ class RoomServiceTest {
 
     @Autowired
     TestDataHelper testDataHelper;
+
+    @SpyBean
+    DelayedRoomRemovalService delayedRoomRemovalService;
 
     @Test
     void 방을_생성한다() {
@@ -448,5 +455,18 @@ class RoomServiceTest {
 
         // then
         assertThat(roomService.roomExists(joinCode.value())).isTrue();
+    }
+
+    @Test
+    void 방_생성_시_방_삭제_스케줄러가_호출된다() {
+        // given
+        String hostName = "호스트";
+        Long menuId = 1L;
+
+        // when
+        Room room = roomService.createRoom(hostName, menuId);
+
+        // then
+        verify(delayedRoomRemovalService).scheduleRemoveRoom(room.getJoinCode());
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

1. 호스트가 아닌 플레이어만 Ready 상태 변경 가능하도록 수정

# 💬 리뷰 중점사항

중점사항
