### PR TITLE
[fix] 백그라운드에서 포그라운드로 돌아올 때 사용자 정보 확인 및 리디렉션 처리

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,8 +13,8 @@ const App = () => {
   return (
     <ThemeProvider theme={theme}>
       <IdentifierProvider>
-        <WebSocketProvider>
-          <ParticipantsProvider>
+        <ParticipantsProvider>
+          <WebSocketProvider>
             <PlayerTypeProvider>
               <ProbabilityHistoryProvider>
                 <ToastProvider>
@@ -24,8 +24,8 @@ const App = () => {
                 </ToastProvider>
               </ProbabilityHistoryProvider>
             </PlayerTypeProvider>
-          </ParticipantsProvider>
-        </WebSocketProvider>
+          </WebSocketProvider>
+        </ParticipantsProvider>
       </IdentifierProvider>
     </ThemeProvider>
   );

--- a/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
@@ -1,18 +1,28 @@
 import { PropsWithChildren } from 'react';
+import { useBackgroundRedirect } from '../hooks/useBackgroundRedirect';
+import { usePageVisibility } from '../hooks/usePageVisibility';
 import { useWebSocketConnection } from '../hooks/useWebSocketConnection';
 import { useWebSocketMessaging } from '../hooks/useWebSocketMessaging';
 import { useWebSocketReconnection } from '../hooks/useWebSocketReconnection';
 import { WebSocketContext, WebSocketContextType } from './WebSocketContext';
 
 export const WebSocketProvider = ({ children }: PropsWithChildren) => {
+  const { isVisible } = usePageVisibility();
+
   const { client, isConnected, startSocket, stopSocket } = useWebSocketConnection();
 
   const { subscribe, send } = useWebSocketMessaging({ client, isConnected });
 
-  const { isVisible } = useWebSocketReconnection({
+  useWebSocketReconnection({
     isConnected,
+    isVisible,
     startSocket,
     stopSocket,
+  });
+
+  useBackgroundRedirect({
+    isConnected,
+    isVisible,
   });
 
   const contextValue: WebSocketContextType = {

--- a/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
+++ b/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
@@ -21,7 +21,6 @@ export const useBackgroundRedirect = ({ isConnected, isVisible }: Props) => {
     const currentUser = participants.find((participant) => participant.playerName === myName);
 
     if (!participants.length || !currentUser) {
-      console.log('❌ 사용자 정보에서 자기 자신을 찾을 수 없음 - 홈으로 리디렉션');
       navigate('/', { replace: true });
     }
   }, [myName, participants, navigate]);

--- a/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
+++ b/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
@@ -1,0 +1,40 @@
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type Props = {
+  isConnected: boolean;
+  isVisible: boolean;
+};
+
+export const useBackgroundRedirect = ({ isConnected, isVisible }: Props) => {
+  // TODO: 웹소켓 provider에 도메인 정보가 있는 것은 좋지 않음. 추후 리팩토링 필요
+  const { myName } = useIdentifier();
+  const { participants } = useParticipants();
+  const wasConnectedBeforeBackground = useRef(false);
+  const navigate = useNavigate();
+
+  const checkUserExistsAndRedirect = useCallback(() => {
+    if (!myName) return;
+
+    const currentUser = participants.find((participant) => participant.playerName === myName);
+
+    if (!participants.length || !currentUser) {
+      console.log('❌ 사용자 정보에서 자기 자신을 찾을 수 없음 - 홈으로 리디렉션');
+      navigate('/', { replace: true });
+    }
+  }, [myName, participants, navigate]);
+
+  useEffect(() => {
+    if (!isVisible && isConnected) {
+      wasConnectedBeforeBackground.current = true;
+    } else if (isVisible && wasConnectedBeforeBackground.current) {
+      const timeoutId = setTimeout(() => {
+        checkUserExistsAndRedirect();
+      }, 200);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isVisible, isConnected, checkUserExistsAndRedirect]);
+};

--- a/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
+++ b/frontend/src/apis/websocket/hooks/useBackgroundRedirect.ts
@@ -29,11 +29,7 @@ export const useBackgroundRedirect = ({ isConnected, isVisible }: Props) => {
     if (!isVisible && isConnected) {
       wasConnectedBeforeBackground.current = true;
     } else if (isVisible && wasConnectedBeforeBackground.current) {
-      const timeoutId = setTimeout(() => {
-        checkUserExistsAndRedirect();
-      }, 200);
-
-      return () => clearTimeout(timeoutId);
+      checkUserExistsAndRedirect();
     }
   }, [isVisible, isConnected, checkUserExistsAndRedirect]);
 };

--- a/frontend/src/apis/websocket/hooks/useWebSocketReconnection.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketReconnection.ts
@@ -1,18 +1,22 @@
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useCallback, useEffect, useRef } from 'react';
 import { WEBSOCKET_CONFIG } from '../constants/constants';
-import { usePageVisibility } from './usePageVisibility';
 
 type Props = {
   isConnected: boolean;
+  isVisible: boolean;
   startSocket: (joinCode: string, myName: string) => void;
   stopSocket: () => void;
 };
 
-export const useWebSocketReconnection = ({ isConnected, startSocket, stopSocket }: Props) => {
+export const useWebSocketReconnection = ({
+  isConnected,
+  isVisible,
+  startSocket,
+  stopSocket,
+}: Props) => {
   // TODO: 웹소켓 provider에 도메인 정보가 있는 것은 좋지 않음. 추후 리팩토링 필요
   const { joinCode, myName } = useIdentifier();
-  const { isVisible } = usePageVisibility();
   const wasConnectedBeforeBackground = useRef(false);
   const reconnectTimeoutRef = useRef<number | null>(null);
   const reconnectAttemptsRef = useRef(0);
@@ -88,8 +92,4 @@ export const useWebSocketReconnection = ({ isConnected, startSocket, stopSocket 
       resetReconnectAttempts();
     }
   }, [isConnected, resetReconnectAttempts]);
-
-  return {
-    isVisible,
-  };
 };


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #596 

# 🚀 작업 내용

## 문제 상황

현재는 백엔드에서 diconnect를 감지하는 경우 15초 동안 사용자 정보를 유지했다가 15초 이후에 돌아오는 경우에는 사용자가 백그라운드에서 포그라운드로 다시 돌아와도 재연결을 해주지 않는데요.

때문에 발생하는 문제가 있습니다. 

15초 이후에 백그라운드에서 포그라운드로 돌아올 경우, 해당 사용자의 정보가 끊겨서 더 이상 참여하고 있지 않은 방에 계속 머물러 있는 상태입니다. 이때 리디렉션을 해주기 위해 `useBackgroundRedirect` 훅을 만들었습니다.

useBackgroundRedirect 훅은 **웹소켓 연결 상태(isConnected)와 페이지 가시성(isVisible), 백그라운드 전 웹소켓 연결 상태(wasConnectedBeforeBackground)** 을 기반으로 동작합니다.
사용자가 백그라운드로 나갔다가 다시 돌아왔을 때, 현재 사용자가 여전히 participants 목록에 존재하는지 확인하고, 존재하지 않으면 홈(/)으로 리다이렉트합니다.

## 고민 사항

### setTimeout 지연 시간

백그라운드에서 포그라운드로 돌아온 경우, 웹소켓 연결 상태와 무관하게 약간의 지연을 두어 참가자 정보(participants 변수)가 업데이트될 시간을 주도록 했는데요. 처음에는 아래와 같이 0.2초로 설정했는데, 사용자 체감상 좀 느린 것 같기도 하고 해서 아예 setTimeout 을 제거했습니다.
제거 해도 우선 동작은 잘 됩니다. 하지만, 혹시 모를 업데이트 시간을 위해서 지연 시간을 살려두는게 맞을까요?

```tsx
const timeoutId = setTimeout(() => {
  checkUserExistsAndRedirect();
}, 200);
```

### useBackgroundRedirect와 useWebSocketReconnection의 위치 고민

두 훅은 웹소켓과 연관이 있고, 웹소켓 로직에서 제공하는 값들을 활용해 특정 역할을 수행합니다. 그런데 내부에서 도메인 종속적인 훅인 useIdentifier, useParticipants를 사용하고 있어 위치를 어디에 두어야 할지 고민이 됩니다.

이 훅들은 도메인에 강하게 결합되어 있기 때문에 WebSocketProvider 내부에 두는 것은 적절하지 않다고 생각합니다. 현재는 임시로 내부에 두었지만, TODO에 남겨둔 것처럼 추후에는 구조를 재검토하고 정리할 필요가 있을 것 같습니다. 이 부분은 함께 논의해보면 좋겠습니다!
