### PR TITLE
[feat] alert -> toast로 변경

### DIFF
--- a/frontend/src/components/@common/Toast/Toast.styled.ts
+++ b/frontend/src/components/@common/Toast/Toast.styled.ts
@@ -51,7 +51,7 @@ export const Container = styled.div<Props>`
     0 1px 2px rgba(0, 0, 0, 0.24);
   padding: 4px 16px;
   z-index: ${Z_INDEX.TOAST};
-  bottom: 24px;
+  bottom: 82px;
   left: 50%;
   transform: translateX(-50%);
 

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -11,6 +11,7 @@ import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EntryMenuPage.styled';
+import useToast from '@/components/@common/Toast/useToast';
 
 // TODO: category 타입 따로 관리 필요 (string이 아니라 유니온 타입으로 지정해서 아이콘 매핑해야함)
 type MenusResponse = {
@@ -43,6 +44,7 @@ const EntryMenuPage = () => {
   const { startSocket, isConnected } = useWebSocket();
   const { playerType } = usePlayerType();
   const { joinCode, myName, setJoinCode } = useIdentifier();
+  const { showToast } = useToast();
   const [selectedValue, setSelectedValue] = useState<Option>({ id: -1, name: '' });
   const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
   const [loading, setLoading] = useState(true);
@@ -85,14 +87,20 @@ const EntryMenuPage = () => {
 
   const handleNavigateToLobby = async () => {
     if (!myName) {
-      alert('닉네임을 다시 입력해주세요.');
+      showToast({
+        type: 'error',
+        message: '닉네임을 다시 입력해주세요.',
+      });
       navigate(-1);
       return;
     }
 
     const menuId = selectedValue.id;
     if (menuId === -1) {
-      alert('메뉴를 선택하지 않았습니다.');
+      showToast({
+        type: 'error',
+        message: '메뉴를 선택하지 않았습니다.',
+      });
       return;
     }
 
@@ -124,11 +132,20 @@ const EntryMenuPage = () => {
       if (playerType === 'GUEST') return await handleGuest();
     } catch (error) {
       if (error instanceof ApiError) {
-        alert('방 생성/참가에 실패했습니다.');
+        showToast({
+          type: 'error',
+          message: '방 생성/참가에 실패했습니다.',
+        });
       } else if (error instanceof NetworkError) {
-        alert('네트워크 연결을 확인해주세요.');
+        showToast({
+          type: 'error',
+          message: '네트워크 연결을 확인해주세요.',
+        });
       } else {
-        alert('알 수 없는 오류가 발생했습니다.');
+        showToast({
+          type: 'error',
+          message: '알 수 없는 오류가 발생했습니다.',
+        });
       }
     } finally {
       setLoading(false);

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -10,6 +10,7 @@ import Layout from '@/layouts/Layout';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EntryNamePage.styled';
+import useToast from '@/components/@common/Toast/useToast';
 
 const MAX_NAME_LENGTH = 10;
 
@@ -22,6 +23,7 @@ const EntryNamePage = () => {
   const navigate = useNavigate();
   const { setMyName, joinCode } = useIdentifier();
   const { playerType } = usePlayerType();
+  const { showToast } = useToast();
 
   const handleNavigateToHome = () => {
     navigate('/');
@@ -34,7 +36,10 @@ const EntryNamePage = () => {
       );
 
       if (exist) {
-        alert('중복된 닉네임이 존재합니다. 새로운 닉네임을 입력해주세요.');
+        showToast({
+          type: 'error',
+          message: '중복된 닉네임이 존재합니다. 새로운 닉네임을 입력해주세요.',
+        });
         return;
       }
     }

--- a/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
+++ b/frontend/src/features/room/lobby/components/ParticipantSection/ParticipantSection.tsx
@@ -21,11 +21,6 @@ export const ParticipantSection = ({ participants }: Props) => {
   const mySelect = participants.filter((participant) => participant.playerName === myName)[0];
 
   const handleModifyMenu = () => {
-    if (!mySelect) {
-      alert('⚠️ 내 정보가 존재하지 않아 메뉴 변경 모달을 열 수 없습니다.');
-      return;
-    }
-
     openModal(<MenuModifyModal myMenu={mySelect.menuResponse.name} onClose={closeModal} />, {
       title: '음료 변경',
       showCloseButton: true,

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -26,6 +26,7 @@ import { MiniGameSection } from '../components/MiniGameSection/MiniGameSection';
 import { ParticipantSection } from '../components/ParticipantSection/ParticipantSection';
 import { RouletteSection } from '../components/RouletteSection/RouletteSection';
 import * as S from './LobbyPage.styled';
+import useToast from '@/components/@common/Toast/useToast';
 
 type SectionType = '참가자' | '룰렛' | '미니게임';
 type SectionComponents = Record<SectionType, ReactElement>;
@@ -35,6 +36,7 @@ const LobbyPage = () => {
   const { send } = useWebSocket();
   const { myName, joinCode } = useIdentifier();
   const { openModal, closeModal } = useModal();
+  const { showToast } = useToast();
   const { playerType, setPlayerType } = usePlayerType();
   const { updateCurrentProbabilities } = useProbabilityHistory();
   const { participants, setParticipants, isAllReady, checkPlayerReady } = useParticipants();
@@ -104,12 +106,18 @@ const LobbyPage = () => {
 
   const handleClickGameStartButton = () => {
     if (participants.length < 2) {
-      alert('참여자가 없어 게임을 진행할 수 없습니다.');
+      showToast({
+        type: 'error',
+        message: '참여자가 없어 게임을 진행할 수 없습니다.',
+      });
       return;
     }
 
     if (selectedMiniGames.length === 0) {
-      alert('선택된 미니게임이 없어 게임을 진행할 수 없습니다.');
+      showToast({
+        type: 'error',
+        message: '선택된 미니게임이 없어 게임을 진행할 수 없습니다.',
+      });
       return;
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #605 

# 🚀 작업 내용

1. 기존에 `alert`로 처리하던 로직에 `toast` 컴포넌트를 사용하도록 수정했습니다.
2. `Modal` 내부에서 처리하는 `alert`는 `Toast`로 변경하지 않았습니다. 추후 수정이 필요할 것 같습니다. 

# 💬 리뷰 중점사항

중점사항
