### PR TITLE
[feat] 세션 연결 해제 로그에 closeStatus 및 해제 사유 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionDisconnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionDisconnectEventListener.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 @Slf4j
@@ -19,8 +20,10 @@ public class SessionDisconnectEventListener {
     @EventListener
     public void handleSessionDisconnectEvent(SessionDisconnectEvent event) {
         final String sessionId = event.getSessionId();
+        final CloseStatus closeStatus = event.getCloseStatus();
 
-        log.info("세션 연결 해제 감지: sessionId={}", sessionId);
+        log.info("세션 연결 해제 감지: sessionId={}, closeStatus={}, reason={}", sessionId, closeStatus,
+                closeStatus.getReason());
 
         // 중복 처리 방지
         if (sessionManager.isDisconnectionProcessed(sessionId)) {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #622 

# 🚀 작업 내용

1. 사용자가 앱을 전환했는지, 종료했는지에 따라 Spring이 다르게 감지하는지 테스트해보려고 로깅을 좀 손봤습니다.

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 세션 종료 시 로그에 sessionId와 CloseStatus(코드·이유)를 함께 기록하도록 확장했습니다. 이를 통해 운영 중 연결 해제 원인 파악과 문제 진단이 더 정확하고 신속해집니다.
  - 기존의 연결 해제 처리 흐름(중복 검사, 플레이어 키 확인, 예약 제거)은 변경 없이 유지됩니다.
  - 사용자 기능 변경이나 외부 API 변화는 없으며, 다운타임이나 추가 설정 없이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->