### PR TITLE
[fix] dto 필드 이름 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -6,7 +6,6 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
-import coffeeshout.room.ui.response.QrCodeResponse;
 import coffeeshout.room.ui.response.RoomCreateResponse;
 import coffeeshout.room.ui.response.RoomEnterResponse;
 import java.util.List;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.request.async.DeferredResult;
 
 @RestController
 @RequestMapping("/rooms")
@@ -30,7 +28,7 @@ public class RoomRestController {
 
     @PostMapping
     public ResponseEntity<RoomCreateResponse> createRoom(@RequestBody RoomEnterRequest request) {
-        final Room room = roomService.createRoom(request.playerName(), request.selectedMenuRequest());
+        final Room room = roomService.createRoom(request.playerName(), request.menu());
 
         return ResponseEntity.ok(RoomCreateResponse.from(room));
     }
@@ -40,7 +38,7 @@ public class RoomRestController {
             @PathVariable String joinCode,
             @RequestBody RoomEnterRequest request
     ) {
-        final Room room = roomService.enterRoom(joinCode, request.playerName(), request.selectedMenuRequest());
+        final Room room = roomService.enterRoom(joinCode, request.playerName(), request.menu());
 
         return ResponseEntity.ok(RoomEnterResponse.from(room));
     }

--- a/backend/src/main/java/coffeeshout/room/ui/request/RoomEnterRequest.java
+++ b/backend/src/main/java/coffeeshout/room/ui/request/RoomEnterRequest.java
@@ -2,7 +2,7 @@ package coffeeshout.room.ui.request;
 
 public record RoomEnterRequest(
         String playerName,
-        SelectedMenuRequest selectedMenuRequest
+        SelectedMenuRequest menu
 ) {
 
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [X] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #632

# 🚀 작업 내용

1. api 명세에 맞게 DTO필드 이름 수정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 방 생성/입장 요청 페이로드의 필드명을 selectedMenuRequest에서 menu로 변경해 명칭을 일관화했습니다. 해당 필드명을 사용하는 클라이언트는 요청 본문을 업데이트해야 합니다.
- Chores
  - 미사용 임포트를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->