### PR TITLE
[fix] 잘못된 경로로 lobby 페이지에 접근했을 때 에러 페이지 뜨는 이슈

### DIFF
--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -33,7 +33,7 @@ type SectionComponents = Record<SectionType, ReactElement>;
 
 const LobbyPage = () => {
   const navigate = useNavigate();
-  const { qrCodeUrl } = useLocation().state;
+  const { qrCodeUrl } = useLocation().state || {};
   const { send } = useWebSocket();
   const { myName, joinCode } = useIdentifier();
   const { openModal, closeModal } = useModal();
@@ -227,10 +227,10 @@ const LobbyPage = () => {
   };
 
   useEffect(() => {
-    if (!playerType) {
+    if (!playerType || !qrCodeUrl) {
       navigate('/', { replace: true });
     }
-  }, [playerType, navigate]);
+  }, [playerType, navigate, qrCodeUrl]);
 
   if (!playerType) {
     return null;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #681

# 🚀 작업 내용


https://github.com/user-attachments/assets/40e67b63-caf8-4737-a7b9-66763e45bf65



1. 기존에는 `useLocation`으로 `state`를 받아오는 과정에서 넘겨받는 값이 없는 경우에 대한 에러 처리가 없었습니다. 따라서 `state`의 값이 없을 때 빈객체를 할당하도록 해주었습니다.
2. `navigate` 조건에도 `qrCodeUrl`이 없을 때, `main` 경로로 이동하도록 수정했습니다.

# 💬 리뷰 중점사항

중점사항
