### PR TITLE
[refactor] PlayerDisconnectionService에서 플레이어 제거 로직 삭제 및 관련 코드 정리

### DIFF
--- a/backend/src/main/java/coffeeshout/global/config/MiniGameTaskSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/MiniGameTaskSchedulerConfig.java
@@ -1,7 +1,6 @@
 package coffeeshout.global.config;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.buf.UEncoder.SafeCharsSet;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -30,7 +29,7 @@ public class MiniGameTaskSchedulerConfig {
 
         // 에러 핸들러 (스케줄 실행 중 예외 로깅)
         scheduler.setErrorHandler(t ->
-                log.error("스케줄 실행 중 예외가 발생했습니다.")
+                log.error("스케줄 실행 중 예외가 발생했습니다.", t)
         );
 
         // 종료 시 현재 실행 중인 작업 완료 대기

--- a/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
@@ -44,31 +44,8 @@ public class PlayerDisconnectionService {
 
             log.info("플레이어 연결 해제 처리: joinCode={}, playerName={}, reason={}", joinCode, playerName, reason);
 
-            // 방에서 플레이어 제거
-            removePlayerFromRoom(joinCode, playerName);
-
         } catch (Exception e) {
             log.error("플레이어 연결 해제 처리 실패: playerKey={}, sessionId={}, reason={}", playerKey, sessionId, reason, e);
-        }
-    }
-
-    /**
-     * 방에서 플레이어 제거
-     */
-    private void removePlayerFromRoom(String joinCode, String playerName) {
-        try {
-            // 방에서 플레이어 제거
-            boolean removed = roomService.removePlayer(joinCode, playerName);
-
-            if (removed) {
-                eventPublisher.publishEvent(new RoomStateUpdateEvent(joinCode, "PLAYER_REMOVED"));
-                log.info("플레이어 방에서 제거 완료: joinCode={}, playerName={}", joinCode, playerName);
-                return;
-            }
-
-            log.warn("플레이어 제거 실패 (이미 없음): joinCode={}, playerName={}", joinCode, playerName);
-        } catch (Exception e) {
-            log.error("방에서 플레이어 제거 실패: joinCode={}, playerName={}", joinCode, playerName, e);
         }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -78,6 +78,8 @@ class DelayedPlayerRemovalServiceTest {
 
             // then
             then(taskScheduler).should(never()).schedule(any(Runnable.class), any(Instant.class));
+            then(playerDisconnectionService).should(never()).cancelReady(any());
+            then(sessionManager).should(never()).removeSession(any());
         }
 
         @Test


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #686

# 🚀 작업 내용

- `PlayerDisconnectionService`에서 제거된 `removePlayerFromRoom` 메서드
- 플레이어 제거 로직이 중복되어 불필요한 코드 삭제
- 예외 처리 로직 간소화 및 가독성 개선
- `MiniGameTaskSchedulerConfig`의 로그 메시지에 Exception 객체 추가

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 플레이어가 연결 해제되어도 방에서 즉시 방에서 제거되지 않습니다(재접속 시 편의성 향상).

- Bug Fixes
  - 스케줄러 실행 중 예외 발생 시 스택 트레이스를 포함해 오류가 기록되도록 개선했습니다.

- Tests
  - 게임 진행 중인 방에서는 플레이어 준비 취소와 세션 제거가 호출되지 않음을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->