### PR TITLE
[fix] SENTRY_DSN -> DSN_KEY로 변경

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,7 @@ import * as Sentry from '@sentry/react';
 
 if (process.env.NODE_ENV === 'production') {
   Sentry.init({
-    dsn: process.env.SENTRY_DSN || '',
+    dsn: process.env.DSN_KEY || '',
     release: process.env.VERSION || '1.0.0',
     environment: process.env.NODE_ENV || 'development',
     sendDefaultPii: true,


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🚀 작업 내용

기존에는 mode가 development 였어서 Sentry 초기 설정이 안돌아갔었음
지금은 mode를 제대로 설정해주니까 dev, prod 배포할 때도 모두 production mode 로 설정됨
이 과정에서 main.tsx 에서 조건문이 통과되어 `SENTRY_DSN`이 없다는 오류 발생

SENTRY_DSN -> DSN_KEY로 환경변수 이름 변경