### PR TITLE
[fix] 메뉴 직접 입력시 로비로 넘어가지 않는 오류

### DIFF
--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -66,10 +66,10 @@ const EntryMenuPage = () => {
   }, []);
 
   useEffect(() => {
-    if (joinCode && qrCodeUrl && selectedMenu && isConnected) {
+    if (joinCode && qrCodeUrl && (selectedMenu || customMenuName) && isConnected) {
       navigate(`/room/${joinCode}/lobby`);
     }
-  }, [joinCode, qrCodeUrl, selectedMenu, isConnected, navigate]);
+  }, [joinCode, qrCodeUrl, selectedMenu, customMenuName, isConnected, navigate]);
 
   const resetMenuState = () => {
     setSelectedCategory(null);


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #704

# 🚀 작업 내용

메뉴 직접입력을 할때는 seletecMenu가 null이라서 아래 코드를 통과 못하는것 같더라고요 
```js
  useEffect(() => {
    if (joinCode && qrCodeUrl && selectedMenu  && isConnected) {
      navigate(`/room/${joinCode}/lobby`);
    }
  }, [joinCode, qrCodeUrl, selectedMenu, customMenuName, isConnected, navigate]);

```

그래서 아래와 같이 수정했습니다. 잘 작동하는거 확인 했습니다~
```js
  useEffect(() => {
    if (joinCode && qrCodeUrl && (selectedMenu || customMenuName) && isConnected) {
      navigate(`/room/${joinCode}/lobby`);
    }
  }, [joinCode, qrCodeUrl, selectedMenu, customMenuName, isConnected, navigate]);
```

# 💬 리뷰 중점사항

중점사항
