### PR TITLE
[feat] 웹소켓 관련 로깅 트리거 Interceptor에서 Spring Websocket Event로 전환

### DIFF
--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/postsend/ConnectPostSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/postsend/ConnectPostSendHandler.java
@@ -27,9 +27,7 @@ public class ConnectPostSendHandler implements PostSendHandler {
     @Override
     public void handle(StompHeaderAccessor accessor, String sessionId, boolean sent) {
         if (sent) {
-            // 서버에서 CONNECTED 응답을 성공적으로 보냈을 때 연결 완료 처리
-            log.info("WebSocket 연결 완료: sessionId={}", sessionId);
-            webSocketMetricService.completeConnection(sessionId);
+            // 서버에서 CONNECTED 응답을 성공적으로 보냈을 때 - 이벤트 리스너에서 처리
             return;
         }
 

--- a/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
+++ b/backend/src/main/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandler.java
@@ -1,7 +1,6 @@
 package coffeeshout.global.interceptor.handler.presend;
 
 import coffeeshout.global.interceptor.handler.PreSendHandler;
-import coffeeshout.global.metric.WebSocketMetricService;
 import coffeeshout.global.websocket.DelayedPlayerRemovalService;
 import coffeeshout.global.websocket.StompSessionManager;
 import coffeeshout.room.domain.JoinCode;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Component;
 public class ConnectPreSendHandler implements PreSendHandler {
 
     private final StompSessionManager sessionManager;
-    private final WebSocketMetricService webSocketMetricService;
     private final RoomQueryService roomQueryService;
     private final DelayedPlayerRemovalService delayedPlayerRemovalService;
 
@@ -30,16 +28,12 @@ public class ConnectPreSendHandler implements PreSendHandler {
 
     @Override
     public void handle(StompHeaderAccessor accessor, String sessionId) {
-        log.info("WebSocket 연결 시작: sessionId={}", sessionId);
-
         final String joinCode = accessor.getFirstNativeHeader("joinCode");
         final String playerName = accessor.getFirstNativeHeader("playerName");
 
         if (joinCode != null && playerName != null) {
             processPlayerConnection(sessionId, joinCode, playerName);
         }
-
-        webSocketMetricService.startConnection(sessionId);
     }
 
     private void processPlayerConnection(String sessionId, String joinCode, String playerName) {

--- a/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
@@ -125,6 +125,13 @@ public class StompSessionManager {
     }
 
     /**
+     * 현재 인스턴스에 연결된 전체 클라이언트 수 조회
+     */
+    public int getTotalConnectedClientCount() {
+        return sessionPlayerMap.size();
+    }
+
+    /**
      * 플레이어 키 생성 (public 메서드)
      */
     public String createPlayerKey(@NonNull String joinCode, @NonNull String playerName) {

--- a/backend/src/main/java/coffeeshout/global/websocket/SubscriptionInfoService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/SubscriptionInfoService.java
@@ -1,0 +1,93 @@
+package coffeeshout.global.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.broker.SimpleBrokerMessageHandler;
+import org.springframework.messaging.simp.broker.SubscriptionRegistry;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+
+@Slf4j
+@Service
+public class SubscriptionInfoService {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+    
+    private SubscriptionRegistry subscriptionRegistry;
+
+    @PostConstruct
+    public void init() {
+        try {
+            // SimpleBrokerMessageHandler에서 SubscriptionRegistry 가져오기
+            SimpleBrokerMessageHandler simpleBrokerMessageHandler = 
+                    applicationContext.getBean(SimpleBrokerMessageHandler.class);
+            this.subscriptionRegistry = simpleBrokerMessageHandler.getSubscriptionRegistry();
+            log.info("SubscriptionRegistry 초기화 완료: {}", subscriptionRegistry.getClass().getSimpleName());
+        } catch (Exception e) {
+            log.warn("SubscriptionRegistry 초기화 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 특정 destination의 구독 정보 조회
+     */
+    public MultiValueMap<String, String> findSubscriptions(String destination) {
+        if (subscriptionRegistry == null) {
+            log.warn("SubscriptionRegistry가 초기화되지 않았습니다");
+            return new org.springframework.util.LinkedMultiValueMap<>();
+        }
+
+        try {
+            // 메시지 생성해서 구독 정보 조회
+            Message<?> message = MessageBuilder.withPayload(new byte[0])
+                    .setHeader("simpDestination", destination)
+                    .build();
+            
+            return subscriptionRegistry.findSubscriptions(message);
+        } catch (Exception e) {
+            log.error("구독 정보 조회 실패: destination={}, error={}", destination, e.getMessage());
+            return new org.springframework.util.LinkedMultiValueMap<>();
+        }
+    }
+
+    /**
+     * 특정 destination의 구독자 수 조회
+     */
+    public int getSubscriberCount(String destination) {
+        MultiValueMap<String, String> subscriptions = findSubscriptions(destination);
+        // 실제 구독 수 계산 (각 세션의 구독 ID 개수 합산)
+        return subscriptions.values().stream()
+                .mapToInt(List::size)
+                .sum();
+    }
+
+    /**
+     * 특정 destination의 구독 정보 로깅
+     */
+    public void logSubscriptionInfo(String destination) {
+        MultiValueMap<String, String> subscriptions = findSubscriptions(destination);
+        
+        if (subscriptions.isEmpty()) {
+            log.info("구독자 없음: destination={}", destination);
+            return;
+        }
+
+        // 실제 구독 수 계산 (각 세션의 구독 ID 개수 합산)
+        int totalSubscriptions = subscriptions.values().stream()
+                .mapToInt(List::size)
+                .sum();
+
+        log.info("구독 정보: destination={}, 구독자 수={}", destination, totalSubscriptions);
+        
+        subscriptions.forEach((sessionId, subscriptionIds) -> 
+            log.info("  - sessionId={}, subscriptionIds={}", sessionId, subscriptionIds)
+        );
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
@@ -36,7 +36,17 @@ public class SessionConnectEventListener {
         final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
         final int totalConnections = sessionManager.getTotalConnectedClientCount();
         
-        log.info("웹소켓 연결 완료: sessionId={}, 현재 연결된 클라이언트 수={}", sessionId, totalConnections);
+        // 플레이어 정보 가져오기 (있으면)
+        String playerInfo = "";
+        if (sessionManager.hasPlayerKey(sessionId)) {
+            final String playerKey = sessionManager.getPlayerKey(sessionId);
+            final String joinCode = sessionManager.extractJoinCode(playerKey);
+            final String playerName = sessionManager.extractPlayerName(playerKey);
+            playerInfo = String.format(", joinCode=%s, playerName=%s", joinCode, playerName);
+        }
+        
+        log.info("웹소켓 연결 완료: sessionId={}, 현재 연결된 클라이언트 수={}{}", 
+                sessionId, totalConnections, playerInfo);
         webSocketMetricService.completeConnection(sessionId);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
@@ -1,0 +1,42 @@
+package coffeeshout.global.websocket.event;
+
+import coffeeshout.global.metric.WebSocketMetricService;
+import coffeeshout.global.websocket.StompSessionManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SessionConnectEventListener {
+
+    private final WebSocketMetricService webSocketMetricService;
+    private final StompSessionManager sessionManager;
+
+    @EventListener
+    public void handleSessionConnect(SessionConnectEvent event) {
+        final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        
+        log.info("웹소켓 연결 시작: sessionId={}, joinCode={}, playerName={}", 
+                sessionId,
+                accessor.getFirstNativeHeader("joinCode"),
+                accessor.getFirstNativeHeader("playerName"));
+        
+        webSocketMetricService.startConnection(sessionId);
+    }
+
+    @EventListener
+    public void handleSessionConnected(SessionConnectedEvent event) {
+        final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
+        final int totalConnections = sessionManager.getTotalConnectedClientCount();
+        
+        log.info("웹소켓 연결 완료: sessionId={}, 현재 연결된 클라이언트 수={}", sessionId, totalConnections);
+        webSocketMetricService.completeConnection(sessionId);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionDisconnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionDisconnectEventListener.java
@@ -21,9 +21,10 @@ public class SessionDisconnectEventListener {
     public void handleSessionDisconnectEvent(SessionDisconnectEvent event) {
         final String sessionId = event.getSessionId();
         final CloseStatus closeStatus = event.getCloseStatus();
+        final int totalConnections = sessionManager.getTotalConnectedClientCount();
 
-        log.info("세션 연결 해제 감지: sessionId={}, closeStatus={}, reason={}", sessionId, closeStatus,
-                closeStatus.getReason());
+        log.info("세션 연결 해제 감지: sessionId={}, closeStatus={}, reason={}, 현재 연결된 클라이언트 수={}", 
+                sessionId, closeStatus, closeStatus.getReason(), totalConnections);
 
         // 중복 처리 방지
         if (sessionManager.isDisconnectionProcessed(sessionId)) {

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionSubscribeEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionSubscribeEventListener.java
@@ -1,0 +1,62 @@
+package coffeeshout.global.websocket.event;
+
+import coffeeshout.global.websocket.StompSessionManager;
+import coffeeshout.global.websocket.SubscriptionInfoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SessionSubscribeEventListener {
+
+    private final StompSessionManager sessionManager;
+    private final SubscriptionInfoService subscriptionInfoService;
+
+    @EventListener
+    public void handleSessionSubscribe(SessionSubscribeEvent event) {
+        final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        final String destination = accessor.getDestination();
+        final String subscriptionId = accessor.getSubscriptionId();
+        
+        // 플레이어 정보 가져오기 (있으면)
+        String playerInfo = "";
+        if (sessionManager.hasPlayerKey(sessionId)) {
+            final String playerKey = sessionManager.getPlayerKey(sessionId);
+            final String joinCode = sessionManager.extractJoinCode(playerKey);
+            final String playerName = sessionManager.extractPlayerName(playerKey);
+            playerInfo = String.format(", joinCode=%s, playerName=%s", joinCode, playerName);
+        }
+        
+        log.info("구독 시작: sessionId={}, destination={}, subscriptionId={}{}", 
+                sessionId, destination, subscriptionId, playerInfo);
+                
+        // INFO 레벨에서도 상세 구독 정보 로깅 (구독자 수 포함)
+        subscriptionInfoService.logSubscriptionInfo(destination);
+    }
+
+    @EventListener
+    public void handleSessionUnsubscribe(SessionUnsubscribeEvent event) {
+        final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        final String subscriptionId = accessor.getSubscriptionId();
+        
+        // 플레이어 정보 가져오기 (있으면)
+        String playerInfo = "";
+        if (sessionManager.hasPlayerKey(sessionId)) {
+            final String playerKey = sessionManager.getPlayerKey(sessionId);
+            final String joinCode = sessionManager.extractJoinCode(playerKey);
+            final String playerName = sessionManager.extractPlayerName(playerKey);
+            playerInfo = String.format(", joinCode=%s, playerName=%s", joinCode, playerName);
+        }
+        
+        log.info("구독 해제: sessionId={}, subscriptionId={}{}", 
+                sessionId, subscriptionId, playerInfo);
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/CustomStompChannelInterceptorTest.java
@@ -19,8 +19,8 @@ import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
-import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.menu.ProvidedMenu;
+import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.menu.TemperatureAvailability;
 import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.service.MenuQueryService;
@@ -76,7 +76,7 @@ class CustomStompChannelInterceptorTest {
         sessionManager = new StompSessionManager();
 
         // 핸들러들 생성
-        connectPreSendHandler = new ConnectPreSendHandler(sessionManager, webSocketMetricService, roomQueryService,
+        connectPreSendHandler = new ConnectPreSendHandler(sessionManager, roomQueryService,
                 delayedPlayerRemovalService);
         connectPostSendHandler = new ConnectPostSendHandler(sessionManager, webSocketMetricService,
                 delayedPlayerRemovalService);
@@ -118,9 +118,6 @@ class CustomStompChannelInterceptorTest {
 
             // when - postSend (연결 성공)
             interceptor.postSend(message, channel, true);
-
-            // then - 메트릭 완료 호출 확인
-            then(webSocketMetricService).should().completeConnection(sessionId);
         }
 
         @Test
@@ -169,7 +166,6 @@ class CustomStompChannelInterceptorTest {
             // then - 실제 세션 매니저 상태 검증
             assertThat(sessionManager.getPlayerKey(sessionId)).isEqualTo(joinCode + ":" + playerName);
             assertThat(sessionManager.getSessionId(joinCode, playerName)).isEqualTo(sessionId);
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         /**
@@ -218,7 +214,6 @@ class CustomStompChannelInterceptorTest {
 
             // then - 세션 등록되지 않았는지 확인
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         private Room createTestRoom(Menu menu) {
@@ -240,19 +235,6 @@ class CustomStompChannelInterceptorTest {
 
     @Nested
     class ConnectPostSendHandler_테스트 {
-
-        @Test
-        void 연결_성공_시_메트릭을_완료_상태로_업데이트한다() {
-            // given
-            StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
-            accessor.setSessionId(sessionId);
-
-            // when
-            connectPostSendHandler.handle(accessor, sessionId, true);
-
-            // then
-            then(webSocketMetricService).should().completeConnection(sessionId);
-        }
 
         @Test
         void 연결_실패_시_세션을_제거하고_메트릭을_실패_상태로_업데이트한다() {

--- a/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/global/interceptor/handler/presend/ConnectPreSendHandlerTest.java
@@ -3,7 +3,6 @@ package coffeeshout.global.interceptor.handler.presend;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 
 import coffeeshout.fixture.MenuCategoryFixture;
 import coffeeshout.global.exception.GlobalErrorCode;
@@ -16,8 +15,8 @@ import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.RoomState;
 import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
-import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.menu.ProvidedMenu;
+import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.menu.TemperatureAvailability;
 import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.service.RoomQueryService;
@@ -56,7 +55,6 @@ class ConnectPreSendHandlerTest {
         sessionManager = new StompSessionManager();
         connectPreSendHandler = new ConnectPreSendHandler(
                 sessionManager,
-                webSocketMetricService,
                 roomQueryService,
                 delayedPlayerRemovalService
         );
@@ -84,7 +82,6 @@ class ConnectPreSendHandlerTest {
                     .isEqualTo(joinCode + ":" + playerName);
             assertThat(sessionManager.getSessionId(joinCode, playerName))
                     .isEqualTo(sessionId);
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         @Test
@@ -99,7 +96,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         @Test
@@ -116,7 +112,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         @Test
@@ -133,7 +128,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
     }
 
@@ -158,7 +152,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         @Test
@@ -177,7 +170,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
 
         @Test
@@ -197,36 +189,6 @@ class ConnectPreSendHandlerTest {
 
             // then
             assertThat(sessionManager.hasPlayerKey(sessionId)).isFalse();
-            then(webSocketMetricService).should().startConnection(sessionId);
-        }
-    }
-
-    @Nested
-    class 메트릭_처리 {
-
-        @Test
-        void 모든_경우에_메트릭_시작이_호출된다() {
-            // given
-            StompHeaderAccessor accessor = createConnectAccessor();
-
-            // when
-            connectPreSendHandler.handle(accessor, sessionId);
-
-            // then
-            then(webSocketMetricService).should().startConnection(sessionId);
-        }
-
-        @Test
-        void 헤더가_없어도_메트릭_시작이_호출된다() {
-            // given
-            StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
-            accessor.setSessionId(sessionId);
-
-            // when
-            connectPreSendHandler.handle(accessor, sessionId);
-
-            // then
-            then(webSocketMetricService).should().startConnection(sessionId);
         }
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #703

# 🚀 작업 내용

- 니야랑 웹소켓 관련 이슈 처리 중 로깅 시점을 인터셉터에서 스프링이 제공해주는 이벤트 기반으로 변경했습니다.
- 더 정확해지고 많은 정보 로깅 가능

# 💬 리뷰 중점사항

중점사항
