### PR TITLE
[fix] 웹소켓 끊김 시 방 생존 여부 상태를 활용한 로비 화면 분기 처리

### DIFF
--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -1,7 +1,7 @@
 import { ApiError, NetworkError } from './error';
 import { reportApiError } from '@/apis/utils/reportSentryError';
 
-const API_URL = process.env.API_URL;
+const getApiUrl = () => process.env.API_URL;
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -34,7 +34,7 @@ export const apiRequest = async <T, TData>(
     retry = { count: 0, delay: 1000 },
   } = options;
 
-  let requestUrl = API_URL + url;
+  let requestUrl = getApiUrl() + url;
 
   if (params) {
     const searchParams = new URLSearchParams();

--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -1,7 +1,7 @@
 import { ApiError, NetworkError } from './error';
 import { reportApiError } from '@/apis/utils/reportSentryError';
 
-const getApiUrl = () => process.env.API_URL;
+const API_URL = process.env.API_URL;
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
@@ -34,7 +34,7 @@ export const apiRequest = async <T, TData>(
     retry = { count: 0, delay: 1000 },
   } = options;
 
-  let requestUrl = getApiUrl() + url;
+  let requestUrl = API_URL + url;
 
   if (params) {
     const searchParams = new URLSearchParams();

--- a/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
+++ b/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
@@ -1,3 +1,4 @@
+import { api } from '@/apis/rest/api';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
@@ -9,13 +10,17 @@ type Props = {
 };
 
 export const useParticipantValidation = ({ isConnected }: Props) => {
-  const { myName } = useIdentifier();
+  const { myName, joinCode } = useIdentifier();
   const { participants } = useParticipants();
   const { playerType } = usePlayerType();
   const navigate = useNavigate();
 
-  const validateUserExistsAndRedirect = useCallback(() => {
-    // TODO: 방 생존 여부 받아서 처리 (participants가 아무도 없을 때를 의존하지 않고 방 생존 여부에 의존하기)
+  const validateUserExistsAndRedirect = useCallback(async () => {
+    if (!joinCode) {
+      console.log('joinCode가 없음 - 홈으로 리디렉션');
+      navigate('/', { replace: true });
+      return;
+    }
 
     if (!playerType) {
       console.log('playerType이 없음 - 홈으로 리디렉션');
@@ -25,6 +30,22 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
 
     if (!myName) {
       console.log('해당 사용자 닉네임이 없음 - 홈으로 리디렉션');
+      navigate('/', { replace: true });
+      return;
+    }
+
+    try {
+      const { exist } = await api.get<{ exist: boolean }>(
+        `/rooms/check-joinCode?joinCode=${joinCode}`
+      );
+
+      if (!exist) {
+        console.log('방이 존재하지 않음 - 홈으로 리디렉션');
+        navigate('/', { replace: true });
+        return;
+      }
+    } catch (error) {
+      console.error('방 존재 여부 체크 실패:', error);
       navigate('/', { replace: true });
       return;
     }
@@ -40,7 +61,7 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
       console.log('사용자 정보에서 자기 자신을 찾을 수 없음 - 홈으로 리디렉션');
       navigate('/', { replace: true });
     }
-  }, [playerType, myName, participants, navigate]);
+  }, [playerType, myName, joinCode, participants, navigate]);
 
   /**
    * 웹소켓 연결되고 participants가 로드된 후 유효성 검사

--- a/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
+++ b/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
@@ -15,22 +15,27 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
   const { playerType } = usePlayerType();
   const navigate = useNavigate();
 
+  const navigateToHome = useCallback(
+    (reason: string) => {
+      console.log(`${reason} - 홈으로 리디렉션`);
+      navigate('/', { replace: true });
+    },
+    [navigate]
+  );
+
   const validateUserExistsAndRedirect = useCallback(async () => {
     if (!joinCode) {
-      console.log('joinCode가 없음 - 홈으로 리디렉션');
-      navigate('/', { replace: true });
+      navigateToHome('joinCode가 없음');
       return;
     }
 
     if (!playerType) {
-      console.log('playerType이 없음 - 홈으로 리디렉션');
-      navigate('/', { replace: true });
+      navigateToHome('playerType이 없음');
       return;
     }
 
     if (!myName) {
-      console.log('해당 사용자 닉네임이 없음 - 홈으로 리디렉션');
-      navigate('/', { replace: true });
+      navigateToHome('해당 사용자 닉네임이 없음');
       return;
     }
 
@@ -40,13 +45,12 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
       );
 
       if (!exist) {
-        console.log('방이 존재하지 않음 - 홈으로 리디렉션');
-        navigate('/', { replace: true });
+        navigateToHome('방이 존재하지 않음');
         return;
       }
     } catch (error) {
       console.error('방 존재 여부 체크 실패:', error);
-      navigate('/', { replace: true });
+      navigateToHome('방 존재 여부 체크 실패');
       return;
     }
 
@@ -58,10 +62,9 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
     const currentUser = participants.find((participant) => participant.playerName === myName);
 
     if (!currentUser) {
-      console.log('사용자 정보에서 자기 자신을 찾을 수 없음 - 홈으로 리디렉션');
-      navigate('/', { replace: true });
+      navigateToHome('사용자 정보에서 자기 자신을 찾을 수 없음');
     }
-  }, [playerType, myName, joinCode, participants, navigate]);
+  }, [joinCode, playerType, myName, participants, navigateToHome]);
 
   /**
    * 웹소켓 연결되고 participants가 로드된 후 유효성 검사

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -12,7 +12,7 @@ const __dirname = dirname(__filename);
 const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf8'));
 const appVersion = packageJson.version;
 
-export default (env, argv) => {
+export default (_, argv) => {
   const mode = argv.mode || 'development';
 
   const dotenvEnv = dotenv.config({ path: path.resolve(process.cwd(), `.env.${mode}`) });


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #693 

# 🚀 작업 내용

해당 이슈는, 웹소켓 재연결 때문에 발생하는 문제입니다.

기본적으로 저희 서비스는, 참여자가 15초 이내에 해당 방에 다시 돌아오지 않을 경우, 서버에서 해당 사용자를 방에서 삭제합니다.
그렇기 때문에 참여자는 15초 이후에 방에 들어왔을 때, 어떤 액션도 취할 수 없습니다. 이미 이 방에 존재하지 않는 사용자이기 때문입니다.

보통은 방에서 사라지면, 해당 방에 남아있는 참여자들에게 모두 participants 정보가 브로드캐스트 됩니다.
이때, 15초 이후에 참여한 사용자도 마찬가지로 방에 들어왔을 때 웹소켓이 재연결되면서 participants 정보를 다시 받게 됩니다. 이때, 현재 본인이 현재 방에 남아있는지를 확인할 수 있는데요, 15초 이후에 진입하면 그 사용자는 더이상 방에 존재하지 않으므로 홈으로 리디렉션하도록 처리해두었습니다.

하지만, 문제는 방이 사라졌을 때 입니다.
참여자가 1명이거나, 2명 이상에서도 모두 재현 가능합니다.
모든 참여자가 15초 이상 동안 어떠한 이유로 웹소켓이 끊긴 채 방에 참여하지 않고 있을 경우에는 방이 사라지게 됩니다.

방이 사라지면, 해당 방 자체가 서버에서 지워졌으므로 브로드캐스트를 해주지 않습니다. 애초에 STOMP 자체에 의해 웹소켓이 재연결 된다고 하더라도, LobbyPage에서 클라이언트는 서버에 send를 보내지만 응답은 오지 않습니다. 즉, LobbyPage에서 매번 갱신되어야 할 participants 정보가 갱신되지 않는 것입니다. 이렇게 participants 정보가 갱신되지 않게 되면, 클라이언트에서 관리하는 participants 상태를 그대로 사용합니다. 때문에, 사용자는 이 방에 계속 남아있는 상태로 되는 것이죠.

따라서, 방이 존재하는지에 대한 여부가 필요했습니다. 방이 존재하는지에 대한 여부를 LobbyPage에서 매번 웹소켓이 끊겼을 때마다 확인이 가능하다면, 방이 존재하지 않을 때 바로 삭제해줄 수 있습니다.


여기서 방에 진입하는 경로를 살펴봤는데요. 처음 방을 생성 또는 참가하거나, 아니면 웹소켓 재연결 할 때입니다.
이때 방을 생성 또는 참가하는 경로에서는, 방이 존재하지 않을 때 방에 진입할 수 없게 막아두었기 때문에 상관이 없습니다.
하지만, 웹소켓 재연결될 때는 확인할 수 없으므로 이때 방 존재 여부에 따라서 홈으로 리디렉션 해줄지 안해줄지를 판별해주도록 코드를 수정했습니다.


https://github.com/user-attachments/assets/8c9991d5-a4cd-4f4e-8d87-f08ee8cc9902

