### PR TITLE
[chore] Toast 타이머 단축

### DIFF
--- a/frontend/src/components/@common/Toast/ToastContext.tsx
+++ b/frontend/src/components/@common/Toast/ToastContext.tsx
@@ -53,7 +53,7 @@ export const ToastProvider = ({ children }: PropsWithChildren) => {
   );
 
   const showToast = useCallback(
-    ({ message, type = 'info', duration = 3000 }: ToastOptions) => {
+    ({ message, type = 'info', duration = 1200 }: ToastOptions) => {
       clearTimer();
       displayToast(message, type);
       setupExitTimer(duration);


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #652 

# 🚀 작업 내용

### 문제 상황
토스트의 위치 때문에 토글을 누를 수 없어서 사용자 입장에서 3초를 기다려야 하는 불편함이 있었습니다.

### 해결 방안
원래는 토스트의 위치를 조금 위로 올리려고 했습니다. 하지만, 여러 사람에게 피드백을 받아본 결과, 토글과 가로 폭이 맞지 않아서, 약간 어색하다는 평이 있었습니다.

<img width="328" height="184" alt="image" src="https://github.com/user-attachments/assets/a99335fd-b7c4-459a-963c-3db394f47f0c" />

문제 상황을 다시 보면서 근본적인 원인을 살펴보니, 토스트의 타이머가 조금 길게 설정되어 있다는 점을 발견했습니다.
그래서 타이머를 1.2초로 줄였구요, 그 결과 사용자가 토글을 누르기까지의 대기 시간이 확 줄어들어 사용성이 훨씬 개선되었습니다!

**타이머 3초 → 1.2초 줄이기**

https://github.com/user-attachments/assets/0195ca9f-9155-4de8-8791-580f95dc35f7
