### PR TITLE
[perf] 렌더링 최적화 - 룰렛 애니메이션 렌더링 최적화

### DIFF
--- a/frontend/src/features/room/roulette/components/AnimatedRouletteWheel/AnimatedRouletteWheel.tsx
+++ b/frontend/src/features/room/roulette/components/AnimatedRouletteWheel/AnimatedRouletteWheel.tsx
@@ -1,0 +1,29 @@
+import { useProbabilityHistory } from '@/contexts/ProbabilityHistory/ProbabilityHistoryContext';
+import { useRouletteTransition } from '@/features/roulette/hooks/useRouletteTransition';
+import RouletteWheel from '@/features/roulette/components/RouletteWheel/RouletteWheel';
+
+export const AnimatedRouletteWheel = ({
+  finalRotation,
+  isSpinning,
+}: {
+  finalRotation: number;
+  isSpinning: boolean;
+}) => {
+  const { probabilityHistory } = useProbabilityHistory();
+  const animatedSectors = useRouletteTransition(
+    probabilityHistory.prev,
+    probabilityHistory.current
+  );
+
+  if (!animatedSectors) return null;
+
+  return (
+    <RouletteWheel
+      sectors={animatedSectors}
+      finalRotation={finalRotation}
+      isSpinning={isSpinning}
+    />
+  );
+};
+
+export default AnimatedRouletteWheel;

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
@@ -10,7 +10,7 @@ export const Container = styled.div`
   justify-content: center;
 `;
 
-export const Wrapper = styled.div`
+export const RouletteWheelWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
@@ -10,6 +10,14 @@ export const Container = styled.div`
   justify-content: center;
 `;
 
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`;
+
 export const ProbabilityText = styled.div`
   text-align: center;
   padding-bottom: 2rem;

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
@@ -1,11 +1,10 @@
 import Headline4 from '@/components/@common/Headline4/Headline4';
-import RouletteWheel from '@/features/roulette/components/RouletteWheel/RouletteWheel';
 import * as S from './RoulettePlaySection.styled';
 import { useProbabilityHistory } from '@/contexts/ProbabilityHistory/ProbabilityHistoryContext';
-import { useRouletteTransition } from '@/features/roulette/hooks/useRouletteTransition';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { convertProbabilitiesToAngles } from '@/features/roulette/utils/convertProbabilitiesToAngles';
 import { calculateFinalRotation } from '../../utils/calculateFinalRotation';
+import { AnimatedRouletteWheel } from '../AnimatedRouletteWheel/AnimatedRouletteWheel';
 
 type Props = {
   isSpinning: boolean;
@@ -40,7 +39,9 @@ const RoulettePlaySection = ({ isSpinning, winner, randomAngle }: Props) => {
 
   return (
     <S.Container>
-      <RouletteWheelWrapper finalRotation={finalRotation} isSpinning={isSpinning} />
+      <S.RouletteWheelWrapper>
+        <AnimatedRouletteWheel finalRotation={finalRotation} isSpinning={isSpinning} />
+      </S.RouletteWheelWrapper>
       <S.ProbabilityText>
         <Headline4>
           현재 확률 : {myCurrentProbability + '%'} {'('}
@@ -57,29 +58,3 @@ const RoulettePlaySection = ({ isSpinning, winner, randomAngle }: Props) => {
 };
 
 export default RoulettePlaySection;
-
-const RouletteWheelWrapper = ({
-  finalRotation,
-  isSpinning,
-}: {
-  finalRotation: number;
-  isSpinning: boolean;
-}) => {
-  const { probabilityHistory } = useProbabilityHistory();
-  const animatedSectors = useRouletteTransition(
-    probabilityHistory.prev,
-    probabilityHistory.current
-  );
-
-  if (!animatedSectors) return null;
-
-  return (
-    <S.Wrapper>
-      <RouletteWheel
-        sectors={animatedSectors}
-        finalRotation={finalRotation}
-        isSpinning={isSpinning}
-      />
-    </S.Wrapper>
-  );
-};

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
@@ -21,10 +21,6 @@ const formatPercent = new Intl.NumberFormat('ko-KR', {
 const RoulettePlaySection = ({ isSpinning, winner, randomAngle }: Props) => {
   const { myName } = useIdentifier();
   const { probabilityHistory } = useProbabilityHistory();
-  const animatedSectors = useRouletteTransition(
-    probabilityHistory.prev,
-    probabilityHistory.current
-  );
 
   const myPrevProbability =
     probabilityHistory.prev.find((player) => player.playerName === myName)?.probability ?? 0;
@@ -42,15 +38,9 @@ const RoulettePlaySection = ({ isSpinning, winner, randomAngle }: Props) => {
       })
     : 0;
 
-  if (!animatedSectors) return null;
-
   return (
     <S.Container>
-      <RouletteWheel
-        isSpinning={isSpinning}
-        sectors={animatedSectors}
-        finalRotation={finalRotation}
-      />
+      <RouletteWheelWrapper finalRotation={finalRotation} isSpinning={isSpinning} />
       <S.ProbabilityText>
         <Headline4>
           현재 확률 : {myCurrentProbability + '%'} {'('}
@@ -67,3 +57,29 @@ const RoulettePlaySection = ({ isSpinning, winner, randomAngle }: Props) => {
 };
 
 export default RoulettePlaySection;
+
+const RouletteWheelWrapper = ({
+  finalRotation,
+  isSpinning,
+}: {
+  finalRotation: number;
+  isSpinning: boolean;
+}) => {
+  const { probabilityHistory } = useProbabilityHistory();
+  const animatedSectors = useRouletteTransition(
+    probabilityHistory.prev,
+    probabilityHistory.current
+  );
+
+  if (!animatedSectors) return null;
+
+  return (
+    <S.Wrapper>
+      <RouletteWheel
+        sectors={animatedSectors}
+        finalRotation={finalRotation}
+        isSpinning={isSpinning}
+      />
+    </S.Wrapper>
+  );
+};

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.styled.ts
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.styled.ts
@@ -7,10 +7,6 @@ type WrapperProps = {
 };
 
 export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: relative;
 `;
 

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
@@ -4,6 +4,7 @@ import * as S from './RouletteWheel.styled';
 import { WHEEL_CONFIG } from '../../constants/config';
 import { convertProbabilitiesToAngles } from '../../utils';
 import RouletteSlice from '../RouletteSlice/RouletteSlice';
+import { memo } from 'react';
 
 type Props =
   | {
@@ -31,7 +32,7 @@ const RouletteWheel = ({
 
   return (
     <S.Container>
-      <S.Pin />
+      <Pin />
       <S.Wrapper $isSpinning={isSpinning} $finalRotation={finalRotation}>
         <svg
           width={WHEEL_CONFIG.SIZE}
@@ -52,3 +53,6 @@ const RouletteWheel = ({
 };
 
 export default RouletteWheel;
+
+const Pin = memo(() => <S.Pin />);
+Pin.displayName = 'Pin';


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #710 

# 🚀 작업 내용

일단 룰렛 애니메이션 관련 부분 최적화를 진행했습니다!

## 최적화 진행 전 문제 
- 룰렛 뿐만 아니라 감싸고 있는 컨테이너도 같이 렌더링이 됨
-  그결과 현재확률 부분 text도 같이 렌더링이 됨됨 


https://github.com/user-attachments/assets/a73cae22-e0ff-443f-a4cf-cdd5e54d3386

## 문제 원인 
1. 아래는 이전 이후 확률을 받아서 변화하는 각도를 각 프레임마다 반환해주는 훅인데요 이 부분때문에 재랜더링이 일어나면서 애니메이션이 보여지게 됨니다. 
```js
  const animatedSectors = useRouletteTransition(
    probabilityHistory.prev,
    probabilityHistory.current
  );
```

문제는 이 훅이 RoulettePlaySection에 있어서 전체 화면이 재 랜더링이 되고 있었습니다. 
그래서 `AnimatedRouletteWheel` 이라는 컴포넌트를 따로 만들어서 이 안에서 훅을 불러오도록 했습니다

2. RouletteWheel 컴포넌트에서 레이아웃까지 담당해주고 있었더라고요. 그래서 레이아웃을 담당하는 부분을 더 상위 컴포넌트로 빼버렸습니다

3. 룰렛의 pin부분은 사실 변하지 않는 부분이므로 memo를 사용해서 감싸주었습니다. 

## 개선 결과 

- 재렌더링 되는 부분이 축소되면서 텍스트는 렌더링 되지 않음
- pin 재렌더링 되지 않음 

https://github.com/user-attachments/assets/35845ae1-1812-4dae-806c-5b312fa23a23



# 💬 리뷰 중점사항

중점사항
