### PR TITLE
[fix] 안드로이드에서 버튼 클릭시 배경색 안변하는 오류

### DIFF
--- a/frontend/src/components/@common/Button/Button.styled.ts
+++ b/frontend/src/components/@common/Button/Button.styled.ts
@@ -7,6 +7,7 @@ type Props = {
   $variant: ButtonVariant;
   $width: string;
   $height: Size;
+  $isTouching: boolean;
 };
 
 export const Container = styled.button<Props>`
@@ -31,19 +32,25 @@ export const Container = styled.button<Props>`
   border-radius: 12px;
   cursor: pointer;
 
-  ${({ $variant, theme }) => {
+  ${({ $variant, theme, $isTouching }) => {
     switch ($variant) {
-      case 'secondary':
+      case 'secondary': {
+        const baseColor = theme.color.gray[50];
+        const activeColor = theme.color.gray[100];
+
         return `
-          background: ${theme.color.gray[50]};
+          background: ${baseColor};
           color: ${theme.color.gray[700]};
+          
+          /* 데스크톱: hover 효과 */
           @media (hover: hover) and (pointer: fine) {
-            &:hover { background: ${theme.color.gray[100]}; }
+            &:hover { background: ${activeColor}; }
           }
-          @media (hover: none) {
-            &:active { background: ${theme.color.gray[100]}; }
-          }
+          
+          /* 터치 디바이스: isPressed 상태로 제어 */
+          ${$isTouching && `background: ${activeColor};`}
         `;
+      }
 
       case 'loading':
         return `
@@ -67,17 +74,23 @@ export const Container = styled.button<Props>`
         `;
 
       case 'primary':
-      default:
+      default: {
+        const baseColor = theme.color.point[400];
+        const activeColor = theme.color.point[500];
+
         return `
-          background: ${theme.color.point[400]};
+          background: ${baseColor};
           color: ${theme.color.white};
+          
+          /* 데스크톱: hover 효과 */
           @media (hover: hover) and (pointer: fine) {
-            &:hover { background: ${theme.color.point[500]}; }
+            &:hover { background: ${activeColor}; }
           }
-          @media (hover: none) {
-            &:active { background: ${theme.color.point[500]}; }
-          }
+          
+          /* 터치 디바이스: isPressed 상태로 제어 */
+            ${$isTouching && `background: ${activeColor};`}
         `;
+      }
     }
   }}
 `;

--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
+import { useState, type ComponentProps, type MouseEvent, type TouchEvent } from 'react';
 import * as S from './Button.styled';
 import { isTouchDevice } from '@/utils/isTouchDevice';
 import { Size } from '@/types/styles';
@@ -20,12 +20,21 @@ const Button = ({
 }: Props) => {
   const isDisabled = variant === 'disabled' || variant === 'loading';
   const isTouch = isTouchDevice();
+  const [isTouching, setIsTouching] = useState(false);
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     if (isTouch) return;
     if (isDisabled) return;
 
     onClick?.(e);
+  };
+
+  const handleTouchStart = (e: TouchEvent<HTMLButtonElement>) => {
+    if (!isTouch) return;
+    if (isDisabled) return;
+
+    e.preventDefault();
+    setIsTouching(true);
   };
 
   const handleTouchEnd = (e: TouchEvent<HTMLButtonElement>) => {
@@ -35,16 +44,19 @@ const Button = ({
     e.preventDefault();
 
     onClick?.(e);
+    setIsTouching(false);
   };
 
   return (
     <S.Container
       type="button"
       $variant={variant}
+      $isTouching={isTouching}
       $width={width}
       $height={height}
       disabled={isDisabled}
       onClick={handleClick}
+      onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       {...rest}
     >

--- a/frontend/src/components/@common/IconButton/IconButton.styled.ts
+++ b/frontend/src/components/@common/IconButton/IconButton.styled.ts
@@ -1,26 +1,35 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.button`
+type Props = {
+  $isTouching: boolean;
+};
+
+export const Container = styled.button<Props>`
   width: 40px;
   height: 40px;
   border: none;
   border-radius: 4px;
-  background-color: ${({ theme }) => theme.color.gray[100]};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
-  @media (hover: hover) and (pointer: fine) {
-    &:hover {
-      background-color: ${({ theme }) => theme.color.gray[200]};
-    }
-  }
-  @media (hover: none) {
-    &:active {
-      background-color: ${({ theme }) => theme.color.gray[200]};
-    }
-  }
+  ${({ theme, $isTouching }) => {
+    const baseColor = theme.color.gray[100];
+    const activeColor = theme.color.gray[200];
+
+    return `
+      background-color: ${baseColor};
+      
+      /* 데스크톱: hover 효과 */
+      @media (hover: hover) and (pointer: fine) {
+        &:hover { background-color: ${activeColor}; }
+      }
+      
+      /* 터치 디바이스: isPressed 상태로 제어 */
+      ${$isTouching && `background-color: ${activeColor};`}
+    `;
+  }}
 `;
 
 export const Icon = styled.img`

--- a/frontend/src/components/@common/IconButton/IconButton.tsx
+++ b/frontend/src/components/@common/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type MouseEvent, type TouchEvent } from 'react';
+import { useState, type ComponentProps, type MouseEvent, type TouchEvent } from 'react';
 import * as S from './IconButton.styled';
 import { isTouchDevice } from '@/utils/isTouchDevice';
 
@@ -9,20 +9,34 @@ type Props = {
 
 const IconButton = ({ iconSrc, onClick, ...rest }: Props) => {
   const isTouch = isTouchDevice();
+  const [isTouching, setIsTouching] = useState(false);
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     if (isTouch) return;
     onClick(e);
   };
 
+  const handleTouchStart = (e: TouchEvent<HTMLButtonElement>) => {
+    if (!isTouch) return;
+    e.preventDefault();
+    setIsTouching(true);
+  };
+
   const handleTouchEnd = (e: TouchEvent<HTMLButtonElement>) => {
     if (!isTouch) return;
     e.preventDefault();
     onClick(e);
+    setIsTouching(false);
   };
 
   return (
-    <S.Container onClick={handleClick} onTouchEnd={handleTouchEnd} {...rest}>
+    <S.Container
+      onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      $isTouching={isTouching}
+      {...rest}
+    >
       <S.Icon src={iconSrc} alt={'icon-button'} />
     </S.Container>
   );

--- a/frontend/src/components/@common/RoomActionButton/RoomActionButton.styled.ts
+++ b/frontend/src/components/@common/RoomActionButton/RoomActionButton.styled.ts
@@ -1,6 +1,10 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.button`
+type Props = {
+  $isTouching: boolean;
+};
+
+export const Container = styled.button<Props>`
   position: relative;
   display: flex;
   flex-direction: column;
@@ -9,20 +13,25 @@ export const Container = styled.button`
 
   width: 100%;
   height: 130px;
-  background-color: ${({ theme }) => theme.color.gray[50]};
   border-radius: 12px;
   padding: 28px 20px;
 
-  @media (hover: hover) and (pointer: fine) {
-    &:hover {
-      background-color: ${({ theme }) => theme.color.gray[200]};
-    }
-  }
-  @media (hover: none) {
-    &:active {
-      background-color: ${({ theme }) => theme.color.gray[200]};
-    }
-  }
+  ${({ theme, $isTouching }) => {
+    const baseColor = theme.color.gray[50];
+    const activeColor = theme.color.gray[200];
+
+    return `
+      background-color: ${baseColor};
+      
+      /* 데스크톱: hover 효과 */
+      @media (hover: hover) and (pointer: fine) {
+        &:hover { background-color: ${activeColor}; }
+      }
+      
+      /* 터치 디바이스: isPressed 상태로 제어 */
+      ${$isTouching && `background-color: ${activeColor};`}
+    `;
+  }}
 `;
 
 export const NextStepIcon = styled.img`

--- a/frontend/src/components/@common/RoomActionButton/RoomActionButton.tsx
+++ b/frontend/src/components/@common/RoomActionButton/RoomActionButton.tsx
@@ -1,5 +1,5 @@
 import NextStepIcon from '@/assets/next-step-icon.svg';
-import type { ComponentProps, MouseEvent, TouchEvent } from 'react';
+import { useState, type ComponentProps, type MouseEvent, type TouchEvent } from 'react';
 import Description from '../Description/Description';
 import Headline3 from '../Headline3/Headline3';
 import * as S from './RoomActionButton.styled';
@@ -13,6 +13,7 @@ type Props = {
 
 const RoomActionButton = ({ title, descriptions, onClick, ...rest }: Props) => {
   const isTouch = isTouchDevice();
+  const [isTouching, setIsTouching] = useState(false);
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     if (isTouch) return;
@@ -20,16 +21,29 @@ const RoomActionButton = ({ title, descriptions, onClick, ...rest }: Props) => {
     onClick?.(e);
   };
 
+  const handleTouchStart = (e: TouchEvent<HTMLButtonElement>) => {
+    if (!isTouch) return;
+
+    e.preventDefault();
+    setIsTouching(true);
+  };
+
   const handleTouchEnd = (e: TouchEvent<HTMLButtonElement>) => {
     if (!isTouch) return;
 
     e.preventDefault();
-
     onClick?.(e);
+    setIsTouching(false);
   };
 
   return (
-    <S.Container onClick={handleClick} onTouchEnd={handleTouchEnd} {...rest}>
+    <S.Container
+      onClick={handleClick}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      $isTouching={isTouching}
+      {...rest}
+    >
       <Headline3>{title}</Headline3>
       <div>
         {descriptions.map((description, index) => (


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #729 

# 🚀 작업 내용

## 문제 

안드로이드 모바일 웹에서는 버튼을 클릭했을때 배경색이 안변하는 오류가 있었습니다. 

원래 방식은 미디어 쿼리를 사용해서 `hover:none`;(마우스 포인트가 없을때) 일때  &:active로 배경색을 적용해주고 있었는데요 
```css
  @media (hover: none) {
            &:active { background: ${theme.color.point[500]};
 }
```
이 방식이 안드로이드에서는 작동을 안하고 있었습니다! 🤯
아래는 예상 원인입니다 ( 확실하지는 않음)
```md
안드로이드 크롬의 :active 트리거 조건

모바일 브라우저(특히 안드로이드 크롬)는 :active 상태를 터치 시작 시점부터 유지하지 않아요.

기본적으로 :active 스타일은 터치다운 → 터치업 사이에만 적용되는데,
일부 브라우저는 터치 이벤트가 클릭 이벤트로 승격되기 전까지 :active를 붙이지 않는 경우가 있어요.
```
gpt가 추천해준  css 속성도 다 적용해보았지만 여전히 적용되지 않아서 상태로 css를 관리하는 방식으로 변경했습니다. 

## 적용한  해결 방식
isTouching이라는 상태를 만들어서 onTouchStart일때  true onTouchEnd일때는 false로 바꿔주는 방식입니다!
 onTouchStart 이벤트는 터치 가능한 디바이스에서만 적용되어서 이것만으로도 터치디바이스인지 확인할 수 있습니다. 
따라서 기존에 있던 `@media (hover: none)` 조건은 삭제하였습니다. 
```css
  /* 데스크톱: hover 효과 */
      @media (hover: hover) and (pointer: fine) {
        &:hover { background-color: ${activeColor}; }
      }
      
      /* 터치 디바이스: isPressed 상태로 제어 */
      ${$isTouching && `background-color: ${activeColor};`}
```

# 💬 리뷰 중점사항

지금 적용한 곳에 css를 다 달아놨는데 삭제하는게 나을까요? 
