### PR TITLE
[fix] 카테고리와 메뉴 선택 화면에서 스크롤 안되는 현상

### DIFF
--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.styled.ts
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.styled.ts
@@ -5,4 +5,5 @@ export const Container = styled.div`
   flex-direction: column;
   gap: 28px;
   padding-top: 8px;
+  height: 100%;
 `;

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.styled.ts
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.styled.ts
@@ -3,4 +3,6 @@ import styled from '@emotion/styled';
 export const CategoryList = styled.div`
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
+  height: 100%;
 `;

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.styled.ts
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.styled.ts
@@ -10,4 +10,10 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  height: 100%;
+`;
+
+export const MenuListWrapper = styled.div`
+  height: 100%;
+  overflow-y: auto;
 `;

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.tsx
@@ -36,11 +36,17 @@ const SelectMenu = ({ onMenuSelect, selectedCategory, selectedMenu, children }: 
           imageUrl={selectedCategory.imageUrl}
         />
         {!selectedMenu && (
-          <S.MenuList>
-            {menus.map((menu) => (
-              <MenuListItem key={menu.id} text={menu.name} onClick={() => handleClickMenu(menu)} />
-            ))}
-          </S.MenuList>
+          <S.MenuListWrapper>
+            <S.MenuList>
+              {menus.map((menu) => (
+                <MenuListItem
+                  key={menu.id}
+                  text={menu.name}
+                  onClick={() => handleClickMenu(menu)}
+                />
+              ))}
+            </S.MenuList>
+          </S.MenuListWrapper>
         )}
         {children}
       </S.Wrapper>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #735 
# 🚀 작업 내용

카테고리와 메뉴 선택화면에서 스크롤이 가능하도록 수정했습니다!

 

https://github.com/user-attachments/assets/78297e92-bedd-4d94-ba51-e973cb6f10a9


# 💬 리뷰 중점사항


