### PR TITLE
[refactor] Storage 인스턴스 하나로 관리하기

### DIFF
--- a/frontend/src/contexts/Identifier/IdentifierProvider.tsx
+++ b/frontend/src/contexts/Identifier/IdentifierProvider.tsx
@@ -1,44 +1,39 @@
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { storageManager, STORAGE_KEYS, STORAGE_TYPES } from '@/utils/StorageManager';
 import { IdentifierContext } from './IdentifierContext';
-
-const STORAGE_KEYS = {
-  JOIN_CODE: 'coffee-shout-join-code',
-  MY_NAME: 'coffee-shout-my-name',
-  QR_CODE_URL: 'coffee-shout-qr-code-url',
-} as const;
 
 export const IdentifierProvider = ({ children }: PropsWithChildren) => {
   const [joinCode, setJoinCode] = useState<string>(() => {
-    return sessionStorage.getItem(STORAGE_KEYS.JOIN_CODE) || '';
+    return storageManager.getItem(STORAGE_KEYS.JOIN_CODE, STORAGE_TYPES.SESSION) || '';
   });
   const [myName, setMyName] = useState<string>(() => {
-    return sessionStorage.getItem(STORAGE_KEYS.MY_NAME) || '';
+    return storageManager.getItem(STORAGE_KEYS.MY_NAME, STORAGE_TYPES.SESSION) || '';
   });
   const [qrCodeUrl, setQrCodeUrl] = useState<string>(() => {
-    return sessionStorage.getItem(STORAGE_KEYS.QR_CODE_URL) || '';
+    return storageManager.getItem(STORAGE_KEYS.QR_CODE_URL, STORAGE_TYPES.SESSION) || '';
   });
 
   useEffect(() => {
     if (joinCode) {
-      sessionStorage.setItem(STORAGE_KEYS.JOIN_CODE, joinCode);
+      storageManager.setItem(STORAGE_KEYS.JOIN_CODE, joinCode, STORAGE_TYPES.SESSION);
     } else {
-      sessionStorage.removeItem(STORAGE_KEYS.JOIN_CODE);
+      storageManager.removeItem(STORAGE_KEYS.JOIN_CODE, STORAGE_TYPES.SESSION);
     }
   }, [joinCode]);
 
   useEffect(() => {
     if (myName) {
-      sessionStorage.setItem(STORAGE_KEYS.MY_NAME, myName);
+      storageManager.setItem(STORAGE_KEYS.MY_NAME, myName, STORAGE_TYPES.SESSION);
     } else {
-      sessionStorage.removeItem(STORAGE_KEYS.MY_NAME);
+      storageManager.removeItem(STORAGE_KEYS.MY_NAME, STORAGE_TYPES.SESSION);
     }
   }, [myName]);
 
   useEffect(() => {
     if (qrCodeUrl) {
-      sessionStorage.setItem(STORAGE_KEYS.QR_CODE_URL, qrCodeUrl);
+      storageManager.setItem(STORAGE_KEYS.QR_CODE_URL, qrCodeUrl, STORAGE_TYPES.SESSION);
     } else {
-      sessionStorage.removeItem(STORAGE_KEYS.QR_CODE_URL);
+      storageManager.removeItem(STORAGE_KEYS.QR_CODE_URL, STORAGE_TYPES.SESSION);
     }
   }, [qrCodeUrl]);
 

--- a/frontend/src/contexts/PlayerType/PlayerTypeProvider.tsx
+++ b/frontend/src/contexts/PlayerType/PlayerTypeProvider.tsx
@@ -1,19 +1,21 @@
 import { PlayerType } from '@/types/player';
+import { storageManager, STORAGE_KEYS, STORAGE_TYPES } from '@/utils/StorageManager';
 import { PlayerTypeContext } from './PlayerTypeContext';
 import { PropsWithChildren, useEffect, useState } from 'react';
 
-const STORAGE_KEY = 'coffee-shout-player-type' as const;
-
 export const PlayerTypeProvider = ({ children }: PropsWithChildren) => {
   const [playerType, setPlayerType] = useState<PlayerType | null>(() => {
-    return sessionStorage.getItem(STORAGE_KEY) as PlayerType | null;
+    return storageManager.getItem(
+      STORAGE_KEYS.PLAYER_TYPE,
+      STORAGE_TYPES.SESSION
+    ) as PlayerType | null;
   });
 
   useEffect(() => {
     if (playerType) {
-      sessionStorage.setItem(STORAGE_KEY, playerType);
+      storageManager.setItem(STORAGE_KEYS.PLAYER_TYPE, playerType, STORAGE_TYPES.SESSION);
     } else {
-      sessionStorage.removeItem(STORAGE_KEY);
+      storageManager.removeItem(STORAGE_KEYS.PLAYER_TYPE, STORAGE_TYPES.SESSION);
     }
   }, [playerType]);
 

--- a/frontend/src/features/home/pages/HomePage.tsx
+++ b/frontend/src/features/home/pages/HomePage.tsx
@@ -7,10 +7,11 @@ import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import Layout from '@/layouts/Layout';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { storageManager, STORAGE_KEYS, STORAGE_TYPES } from '@/utils/StorageManager';
+import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import EnterRoomModal from '../components/EnterRoomModal/EnterRoomModal';
 import Splash from '../components/Splash/Splash';
 import * as S from './HomePage.styled';
-import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -29,16 +30,14 @@ const HomePage = () => {
 
   useEffect(() => {
     const checkFirstVisit = () => {
-      try {
-        const hasVisited = sessionStorage.getItem('coffee-shout-visited');
+      const hasVisited = storageManager.getItem(
+        STORAGE_KEYS.COFFEE_SHOUT_VISITED,
+        STORAGE_TYPES.SESSION
+      );
 
-        if (!hasVisited) {
-          setShowSplash(true);
-          sessionStorage.setItem('coffee-shout-visited', 'true');
-        }
-      } catch (error) {
-        console.error('sessionStorage 오류 : ', error);
+      if (!hasVisited) {
         setShowSplash(true);
+        storageManager.setItem(STORAGE_KEYS.COFFEE_SHOUT_VISITED, 'true', STORAGE_TYPES.SESSION);
       }
     };
     checkFirstVisit();

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -18,6 +18,7 @@ import { Player } from '@/types/player';
 import { PlayerProbability, Probability } from '@/types/roulette';
 import { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { storageManager, STORAGE_KEYS } from '@/utils/StorageManager';
 import GameReadyButton from '../components/GameReadyButton/GameReadyButton';
 import GameStartButton from '../components/GameStartButton/GameStartButton';
 import GuideModal from '../components/GuideModal/GuideModal';
@@ -200,13 +201,13 @@ const LobbyPage = () => {
   }, [joinCode]);
 
   useEffect(() => {
-    const hasSeenGuide = localStorage.getItem('coffee-shout-first-time-user');
+    const isFirstTimeUser = storageManager.getItem(STORAGE_KEYS.COFFEE_SHOUT_FIRST_TIME_USER);
 
-    if (!hasSeenGuide) {
+    if (!isFirstTimeUser) {
       openModal(
         <GuideModal
           onClose={() => {
-            localStorage.setItem('coffee-shout-first-time-user', 'true');
+            storageManager.setItem(STORAGE_KEYS.COFFEE_SHOUT_FIRST_TIME_USER, 'true');
             closeModal();
           }}
         />,

--- a/frontend/src/utils/StorageManager.ts
+++ b/frontend/src/utils/StorageManager.ts
@@ -1,0 +1,120 @@
+export const STORAGE_KEYS = {
+  COFFEE_SHOUT_VISITED: 'coffee-shout-visited',
+  COFFEE_SHOUT_FIRST_TIME_USER: 'coffee-shout-first-time-user',
+  JOIN_CODE: 'coffee-shout-join-code',
+  MY_NAME: 'coffee-shout-my-name',
+  QR_CODE_URL: 'coffee-shout-qr-code-url',
+  PLAYER_TYPE: 'coffee-shout-player-type',
+} as const;
+
+export const STORAGE_TYPES = {
+  LOCAL: 'localStorage',
+  SESSION: 'sessionStorage',
+} as const;
+
+export type StorageType = 'localStorage' | 'sessionStorage';
+
+export class StorageManager {
+  private static instance: StorageManager;
+
+  public static getInstance(): StorageManager {
+    if (!StorageManager.instance) {
+      StorageManager.instance = new StorageManager();
+    }
+    return StorageManager.instance;
+  }
+
+  private constructor() {}
+
+  private getStorage(type: StorageType): Storage | null {
+    try {
+      if (typeof window === 'undefined') {
+        console.warn('스토리지에 접근할 수 없음');
+        return null;
+      }
+      return window[type];
+    } catch (error) {
+      console.error(`${type} 스토리지에 접근할 수 없음 :`, error);
+      return null;
+    }
+  }
+
+  public setItem(key: string, value: string, type: StorageType = STORAGE_TYPES.LOCAL): boolean {
+    try {
+      const storage = this.getStorage(type);
+      if (!storage) return false;
+
+      storage.setItem(key, value);
+      return true;
+    } catch (error) {
+      console.error(`값 넣기 실패 ${type}:`, error);
+      return false;
+    }
+  }
+
+  public getItem(key: string, type: StorageType = STORAGE_TYPES.LOCAL): string | null {
+    try {
+      const storage = this.getStorage(type);
+      if (!storage) return null;
+
+      return storage.getItem(key);
+    } catch (error) {
+      console.error(`값 가져오기 실패 ${type}:`, error);
+      return null;
+    }
+  }
+
+  public removeItem(key: string, type: StorageType = STORAGE_TYPES.LOCAL): boolean {
+    try {
+      const storage = this.getStorage(type);
+      if (!storage) return false;
+
+      storage.removeItem(key);
+      return true;
+    } catch (error) {
+      console.error(`삭제 실패 ${type}:`, error);
+      return false;
+    }
+  }
+
+  public hasItem(key: string, type: StorageType = STORAGE_TYPES.LOCAL): boolean {
+    return this.getItem(key, type) !== null;
+  }
+
+  public clear(type: StorageType = STORAGE_TYPES.LOCAL): boolean {
+    try {
+      const storage = this.getStorage(type);
+      if (!storage) return false;
+
+      storage.clear();
+      return true;
+    } catch (error) {
+      console.error(`초기화 실패 ${type}:`, error);
+      return false;
+    }
+  }
+
+  public setObject<T>(key: string, value: T, type: StorageType = STORAGE_TYPES.LOCAL): boolean {
+    try {
+      const jsonString = JSON.stringify(value);
+      return this.setItem(key, jsonString, type);
+    } catch (error) {
+      console.error('json 변환 실패 :', error);
+      return false;
+    }
+  }
+
+  public getObject<T>(key: string, type: StorageType = STORAGE_TYPES.LOCAL): T | null {
+    try {
+      const jsonString = this.getItem(key, type);
+      if (!jsonString) return null;
+
+      return JSON.parse(jsonString) as T;
+    } catch (error) {
+      console.error('json 파싱 실패 :', error);
+      return null;
+    }
+  }
+}
+
+export const storageManager = StorageManager.getInstance();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #669 

# 🚀 작업 내용

`Storage`를 하나의 클래스로 관리하기 위해 `StorageManager`를 구현했습니다.
프로젝트 내부에서 2가지의 `Storage`를 사용하고 있는데요.

```jsx

  useEffect(() => {
    const checkFirstVisit = () => {
      try {
        const hasVisited = sessionStorage.getItem('coffee-shout-visited');

        if (!hasVisited) {
          setShowSplash(true);
          sessionStorage.setItem('coffee-shout-visited', 'true');
        }
      } catch (error) {
        console.error('sessionStorage 오류 : ', error);
        setShowSplash(true);
      }
    };
    checkFirstVisit();
  }, []);
```

```jsx

  useEffect(() => {
    const hasSeenGuide = localStorage.getItem('coffee-shout-first-time-user');

    if (!hasSeenGuide) {
      openModal(
        <GuideModal
          onClose={() => {
            localStorage.setItem('coffee-shout-first-time-user', 'true');
            closeModal();
          }}
        />,
        {
          showCloseButton: false,
        }
      );
    }
  }, [openModal, closeModal]);
```

또한 기존에는 흩어져있던 `storage` 키들을 `StorageManager`에서 모아서 관리해주도록 했습니다.

```tsx
export const STORAGE_KEYS = {
  COFFEE_SHOUT_VISITED: 'coffee-shout-visited',
  COFFEE_SHOUT_FIRST_TIME_USER: 'coffee-shout-first-time-user',
  JOIN_CODE: 'coffee-shout-join-code',
  MY_NAME: 'coffee-shout-my-name',
  QR_CODE_URL: 'coffee-shout-qr-code-url',
  PLAYER_TYPE: 'coffee-shout-player-type',
} as const;
```

## 기존 구조의 문제점

1. **localStorage**나 **sessionStorage**와 관련된 로직이 분산되어 있고, 각각의 페이지에서 모두 다른 스토리지 객체에 접근하고 있습니다.
2. 문자열로 하드코딩된 키들이 여기저기 흩어져 있기 때문에 **오타나 중복의 가능성**이 있다는 문제가 있습니다.
3. 위에 있는 두 가지 방식이 다릅니다. 하나는 에러 처리를 해줬고, 하나는 **try-catch**로 에러 처리를 해주지 않았는데요. 그래서 **일관되지 않는 에러 처리**가 발생하고 있습니다.

## 개선 내용
`Stoarge`를 관리하는 클래스 생성해서 한 곳에서 관리하도록 수정했습니다. 
hook으로 만들어서 관리하는 방식도 있었지만, 클래스로 작성한 이유는 다음과 같습니다.

1. hook은 React 컴포넌트 내부에서만 사용 가능하지만, Storage는 유틸리티 함수나, API 호출 로직 등 어디서든 바로 사용이 가능합니다.
2. hook은 매번 useStorage와 같은 선언이 필요하지만, 클래스로 구현하게 되면 storageManager.setItem()과 같이 바로 접근할 수 있습니다.
3. 싱글톤 패턴으로 일관된 상태관리를 하고자 했습니다.


# 💬 리뷰 중점사항

중점사항
