### PR TITLE
[perf] Layout Shift 제거

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,10 @@
   "scripts": {
     "dev": "webpack serve --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
+    "build:dev": "webpack --config webpack.dev.js",
+    "build:prod": "webpack --config webpack.prod.js",
+    "preview:dev": "npm run build:dev && npx serve -s dist -p 5000",
+    "preview:prod": "npm run build:prod && npx serve -s dist -p 5001",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write .",

--- a/frontend/src/features/home/components/Splash/Splash.styled.ts
+++ b/frontend/src/features/home/components/Splash/Splash.styled.ts
@@ -10,6 +10,7 @@ export const Container = styled.div`
 
 export const LogoImage = styled.img`
   width: 200px;
+  height: 225px;
   -webkit-user-drag: none;
   user-select: none;
 `;

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
@@ -30,14 +30,6 @@ export const BubbleImage = styled.img`
   top: -40px;
 `;
 
-export const CoffeeWrapper = styled.div`
-  width: 150px;
-  height: 169px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
 export const CoffeeImage = styled.img`
   width: 150px;
   height: 169px;

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
@@ -30,6 +30,15 @@ export const BubbleImage = styled.img`
   top: -40px;
 `;
 
+export const CoffeeWrapper = styled.div`
+  width: 150px;
+  height: 169px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const CoffeeImage = styled.img`
   width: 150px;
+  height: 169px;
 `;

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.styled.ts
@@ -17,7 +17,7 @@ export const Content = styled.div`
   gap: 3rem;
 `;
 
-export const ImageWrapper = styled.div`
+export const BubbleTextWrapper = styled.div`
   position: relative;
   display: flex;
   justify-content: center;

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
@@ -27,7 +27,9 @@ const PrepareOverlay = () => {
           <S.BubbleImage src={chatBubble} />
           <Headline1 color="white">{displayText}</Headline1>
         </S.ImageWrapper>
-        <S.CoffeeImage src={coffee} />
+        <S.CoffeeWrapper>
+          <S.CoffeeImage src={coffee} />
+        </S.CoffeeWrapper>
       </S.Content>
     </S.Backdrop>
   );

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
@@ -27,9 +27,7 @@ const PrepareOverlay = () => {
           <S.BubbleImage src={chatBubble} />
           <Headline1 color="white">{displayText}</Headline1>
         </S.BubbleTextWrapper>
-        <S.CoffeeWrapper>
-          <S.CoffeeImage src={coffee} />
-        </S.CoffeeWrapper>
+        <S.CoffeeImage src={coffee} />
       </S.Content>
     </S.Backdrop>
   );

--- a/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/PrepareOverlay/PrepareOverlay.tsx
@@ -23,10 +23,10 @@ const PrepareOverlay = () => {
   return (
     <S.Backdrop>
       <S.Content>
-        <S.ImageWrapper>
+        <S.BubbleTextWrapper>
           <S.BubbleImage src={chatBubble} />
           <Headline1 color="white">{displayText}</Headline1>
-        </S.ImageWrapper>
+        </S.BubbleTextWrapper>
         <S.CoffeeWrapper>
           <S.CoffeeImage src={coffee} />
         </S.CoffeeWrapper>

--- a/frontend/src/features/room/lobby/components/GuideModal/GuideModal.styled.ts
+++ b/frontend/src/features/room/lobby/components/GuideModal/GuideModal.styled.ts
@@ -17,5 +17,6 @@ export const Body = styled.div`
 
 export const Image = styled.img`
   width: 100%;
-  height: 100%;
+  height: 300px;
+  object-fit: contain;
 `;

--- a/frontend/src/features/room/order/pages/OrderPage.styled.ts
+++ b/frontend/src/features/room/order/pages/OrderPage.styled.ts
@@ -11,7 +11,7 @@ export const BannerContent = styled.div`
 
 export const Logo = styled.img`
   width: 120px;
-  height: 120px;
+  height: 60px;
 `;
 
 export const ListHeader = styled.div`

--- a/frontend/src/features/room/order/pages/OrderPage.styled.ts
+++ b/frontend/src/features/room/order/pages/OrderPage.styled.ts
@@ -3,10 +3,14 @@ import styled from '@emotion/styled';
 export const BannerContent = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
+  align-items: center;
   height: 100%;
-  color: white;
+  gap: 20px;
+`;
+
+export const Logo = styled.img`
+  width: 120px;
 `;
 
 export const IconWrapper = styled.div`
@@ -23,10 +27,5 @@ export const ListHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
-`;
-
-export const Logo = styled.img`
-  width: 100px;
   margin-bottom: 1rem;
 `;

--- a/frontend/src/features/room/order/pages/OrderPage.styled.ts
+++ b/frontend/src/features/room/order/pages/OrderPage.styled.ts
@@ -11,16 +11,7 @@ export const BannerContent = styled.div`
 
 export const Logo = styled.img`
   width: 120px;
-`;
-
-export const IconWrapper = styled.div`
-  margin-bottom: 1.5rem;
-
-  svg {
-    width: 4rem;
-    height: 4rem;
-    stroke-width: 1.5;
-  }
+  height: 120px;
 `;
 
 export const ListHeader = styled.div`

--- a/frontend/src/features/room/order/pages/OrderPage.tsx
+++ b/frontend/src/features/room/order/pages/OrderPage.tsx
@@ -39,7 +39,6 @@ const OrderPage = () => {
         <S.BannerContent>
           <S.Logo src={BreadLogoWhiteIcon} />
           <Headline1 color="white">{location.state?.winner}</Headline1>
-          <br />
           <Headline3 color="white">님이 당첨되었습니다!</Headline3>
         </S.BannerContent>
       </Layout.Banner>

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
@@ -16,6 +16,8 @@ export const RouletteWheelWrapper = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
+  width: 300px;
+  height: 364px;
 `;
 
 export const ProbabilityText = styled.div`

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.styled.ts
@@ -12,10 +12,6 @@ export const Container = styled.div`
 
 export const RouletteWheelWrapper = styled.div`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  position: relative;
   width: 300px;
   height: 364px;
 `;

--- a/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.styled.ts
+++ b/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.styled.ts
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  height: 100%;
   gap: 20px;
 `;
 

--- a/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.styled.ts
+++ b/frontend/src/features/room/roulette/pages/RouletteResultPage/RouletteResultPage.styled.ts
@@ -11,4 +11,5 @@ export const Container = styled.div`
 
 export const Logo = styled.img`
   width: 120px;
+  height: 60px;
 `;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #672 

# 🚀 작업 내용

성능 최적화 과정에서 Layout Shift가 발생하던 구간들을 확인하고 해결했습니다.

이번에 개선한 주요 구간은 총 5가지입니다.

커밋을 잘게 쪼개 놨는데요, 그냥 Files changed만 보면 조금 헷갈릴 수도 있어서, 커밋 로그를 보면서 확인해주시면 훨씬 이해하기 쉬울 것 같아요!

1. 게임 시작 시 Ready 상태 표시 (https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/034221012e7c8bb6226461070b4dfb520e27c46a, https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/cf0bce5ca06f8643fe6316808e4702083f89228d, https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/c24b71e77d96f774222816e78f0b3767883b9d60)
2. 당첨자 결과 화면 (https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/9d2273306ea4ec21c52672135dcc8cc2967efdc3, https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/9db2830ecaea6fa315b4626ba42806720a09f0c6, https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/bfdc54ce82f5021055fd0bf0dd214d9733d7b123)
3. 룰렛 현황 페이지 (룰렛 및 확률 표시 영역) (https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/e037c5db2adc0ed57437da913e203cda2e7e9794, https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/27283287b2d5f664972565e1c7843c1fee86ccc3)
4. 서비스 진입 시 Splash 화면 (https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/53b6d9ed737326c2ed4c51f58ee2ef86b8d3593c)
5. 로비 진입 시 게임 설명 모달 (https://github.com/woowacourse-teams/2025-coffee-shout/pull/739/commits/5a9ccabe4d7a292c8d4a0f7eeefd09724b1ad8b8)

자세한 내용은 프로젝트 노션의 문서화 페이지에 정리해 두었습니다. 확인 부탁드려요 🙇🏻‍♀️

PS. 원래는 바로가기 링크를 달려고 했는데, 공용 문서가 공개되어 있지 않고 또 제가 혼자서 막 게시하기엔 좀 애매하더라구요.(꾹이 노션이라..) 그래서 우선 제 개인 노션에 정리한 자료 링크를 공유드립니다. 여기서 바로 확인하실 수 있고, 공용 문서에 있는 내용이랑 완전히 동일합니다!
👉 [커피빵 Layout Shift 해결하기](https://www.notion.so/sooyeoniya/Layout-Shift-273dab79e00f800b9351d1c00e56eb3e?source=copy_link)