### PR TITLE
[refactor] CardGameProvider 로직 분리

### DIFF
--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -1,123 +1,34 @@
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
-import { CardGameState, CardInfo, SelectedCardInfo } from '@/types/miniGame/cardGame';
-import { RoundType } from '@/types/miniGame/round';
-import { PropsWithChildren, useCallback, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { PropsWithChildren } from 'react';
 import { useIdentifier } from '../Identifier/IdentifierContext';
 import { CardGameContext } from './CardGameContext';
-
-type CardGameStateResponse = {
-  cardGameState: CardGameState;
-  currentRound: RoundType;
-  cardInfoMessages: CardInfo[];
-  allSelected: boolean;
-};
+import { useCardGameState } from './hooks/useCardGameState';
+import { useSelectedCard } from './hooks/useSelectedCard';
+import { useCardGameHandlers } from './hooks/useCardGameHandlers';
 
 const CardGameProvider = ({ children }: PropsWithChildren) => {
-  const navigate = useNavigate();
   const { joinCode, myName } = useIdentifier();
-  const { miniGameType } = useParams();
-  const [isTransition, setIsTransition] = useState<boolean>(false);
-  const [currentRound, setCurrentRound] = useState<RoundType>('FIRST');
-  const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
-  const [cardInfos, setCardInfos] = useState<CardInfo[]>([]);
-  const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
-    FIRST: {
-      isSelected: false,
-      type: null,
-      value: null,
-    },
-    SECOND: {
-      isSelected: false,
-      type: null,
-      value: null,
-    },
+
+  const {
+    isTransition,
+    currentRound,
+    currentCardGameState,
+    cardInfos,
+    updateCardGameState,
+    updateCardInfos,
+    updateCurrentRound,
+    updateTransition,
+  } = useCardGameState();
+
+  const { selectedCardInfo, setSelectedCardInfo, updateSelectedCardInfo } = useSelectedCard(myName);
+
+  const { handleCardGameState } = useCardGameHandlers({
+    updateCardGameState,
+    updateCardInfos,
+    updateCurrentRound,
+    updateTransition,
+    updateSelectedCardInfo,
   });
-
-  const updateSelectedCardInfo = useCallback(
-    (cardInfoMessages: CardInfo[], round: RoundType, shouldCheckAlreadySelected = false) => {
-      const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
-      if (!myCardInfo) return;
-
-      if (shouldCheckAlreadySelected && selectedCardInfo[round].isSelected) return;
-
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        [round]: {
-          isSelected: true,
-          type: myCardInfo.cardType,
-          value: myCardInfo.value,
-        },
-      }));
-    },
-    [myName, selectedCardInfo]
-  );
-
-  const handlePrepare = useCallback((cardInfoMessages: CardInfo[]) => {
-    setCurrentCardGameState('PREPARE');
-    setCardInfos(cardInfoMessages);
-  }, []);
-
-  const handlePlaying = useCallback(
-    (cardInfoMessages: CardInfo[], round: RoundType) => {
-      setCurrentCardGameState('PLAYING');
-      setCardInfos(cardInfoMessages);
-
-      if (round === 'SECOND') {
-        setIsTransition(false);
-      }
-
-      updateSelectedCardInfo(cardInfoMessages, round);
-    },
-    [updateSelectedCardInfo]
-  );
-
-  const handleScoreBoard = useCallback(
-    (cardInfoMessages: CardInfo[], round: RoundType) => {
-      setCurrentCardGameState('SCORE_BOARD');
-      setCardInfos(cardInfoMessages);
-
-      updateSelectedCardInfo(cardInfoMessages, round, true);
-    },
-    [updateSelectedCardInfo]
-  );
-
-  const handleLoading = useCallback(() => {
-    setIsTransition(true);
-    setCurrentRound('SECOND');
-    setCurrentCardGameState('LOADING');
-  }, []);
-
-  const handleGameDone = useCallback(() => {
-    navigate(`/room/${joinCode}/${miniGameType}/result`);
-  }, [navigate, joinCode, miniGameType]);
-
-  const handleCardGameState = useCallback(
-    (data: CardGameStateResponse) => {
-      const { cardGameState, currentRound, cardInfoMessages } = data;
-
-      switch (cardGameState) {
-        case 'PREPARE':
-          handlePrepare(cardInfoMessages);
-          break;
-        case 'PLAYING':
-          handlePlaying(cardInfoMessages, currentRound);
-          break;
-        case 'SCORE_BOARD':
-          handleScoreBoard(cardInfoMessages, currentRound);
-          break;
-        case 'LOADING':
-          if (currentRound === 'SECOND') {
-            handleLoading();
-          }
-          break;
-        case 'DONE':
-          handleGameDone();
-          break;
-      }
-    },
-    [handlePrepare, handlePlaying, handleScoreBoard, handleLoading, handleGameDone]
-  );
 
   useWebSocketSubscription(`/room/${joinCode}/gameState`, handleCardGameState);
 

--- a/frontend/src/contexts/CardGame/CardGameProvider.tsx
+++ b/frontend/src/contexts/CardGame/CardGameProvider.tsx
@@ -34,6 +34,25 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
     },
   });
 
+  const updateSelectedCardInfo = useCallback(
+    (cardInfoMessages: CardInfo[], round: RoundType, shouldCheckAlreadySelected = false) => {
+      const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
+      if (!myCardInfo) return;
+
+      if (shouldCheckAlreadySelected && selectedCardInfo[round].isSelected) return;
+
+      setSelectedCardInfo((prev) => ({
+        ...prev,
+        [round]: {
+          isSelected: true,
+          type: myCardInfo.cardType,
+          value: myCardInfo.value,
+        },
+      }));
+    },
+    [myName, selectedCardInfo]
+  );
+
   const handlePrepare = useCallback((cardInfoMessages: CardInfo[]) => {
     setCurrentCardGameState('PREPARE');
     setCardInfos(cardInfoMessages);
@@ -48,19 +67,9 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
         setIsTransition(false);
       }
 
-      const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
-      if (!myCardInfo) return;
-
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        [round]: {
-          isSelected: true,
-          type: myCardInfo.cardType,
-          value: myCardInfo.value,
-        },
-      }));
+      updateSelectedCardInfo(cardInfoMessages, round);
     },
-    [myName]
+    [updateSelectedCardInfo]
   );
 
   const handleScoreBoard = useCallback(
@@ -68,20 +77,9 @@ const CardGameProvider = ({ children }: PropsWithChildren) => {
       setCurrentCardGameState('SCORE_BOARD');
       setCardInfos(cardInfoMessages);
 
-      const mySelectedCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
-      if (!mySelectedCardInfo) return;
-      if (selectedCardInfo[round].isSelected) return;
-
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        [round]: {
-          isSelected: true,
-          type: mySelectedCardInfo.cardType,
-          value: mySelectedCardInfo.value,
-        },
-      }));
+      updateSelectedCardInfo(cardInfoMessages, round, true);
     },
-    [myName, selectedCardInfo]
+    [updateSelectedCardInfo]
   );
 
   const handleLoading = useCallback(() => {

--- a/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
+++ b/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
@@ -1,0 +1,109 @@
+import { CardGameState, CardInfo } from '@/types/miniGame/cardGame';
+import { RoundType } from '@/types/miniGame/round';
+import { useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useIdentifier } from '../../Identifier/IdentifierContext';
+
+type CardGameStateResponse = {
+  cardGameState: CardGameState;
+  currentRound: RoundType;
+  cardInfoMessages: CardInfo[];
+  allSelected: boolean;
+};
+
+type CardGameStateHandlers = {
+  updateCardGameState: (state: CardGameState) => void;
+  updateCardInfos: (cardInfoMessages: CardInfo[]) => void;
+  updateCurrentRound: (round: RoundType) => void;
+  updateTransition: (transition: boolean) => void;
+  updateSelectedCardInfo: (
+    cardInfoMessages: CardInfo[],
+    round: RoundType,
+    shouldCheckAlreadySelected?: boolean
+  ) => void;
+};
+
+export const useCardGameHandlers = ({
+  updateCardGameState,
+  updateCardInfos,
+  updateCurrentRound,
+  updateTransition,
+  updateSelectedCardInfo,
+}: CardGameStateHandlers) => {
+  const navigate = useNavigate();
+  const { joinCode } = useIdentifier();
+  const { miniGameType } = useParams();
+
+  const handlePrepare = useCallback(
+    (cardInfoMessages: CardInfo[]) => {
+      updateCardGameState('PREPARE');
+      updateCardInfos(cardInfoMessages);
+    },
+    [updateCardGameState, updateCardInfos]
+  );
+
+  const handlePlaying = useCallback(
+    (cardInfoMessages: CardInfo[], round: RoundType) => {
+      updateCardGameState('PLAYING');
+      updateCardInfos(cardInfoMessages);
+
+      if (round === 'SECOND') {
+        updateTransition(false);
+      }
+
+      updateSelectedCardInfo(cardInfoMessages, round);
+    },
+    [updateCardGameState, updateCardInfos, updateTransition, updateSelectedCardInfo]
+  );
+
+  const handleScoreBoard = useCallback(
+    (cardInfoMessages: CardInfo[], round: RoundType) => {
+      updateCardGameState('SCORE_BOARD');
+      updateCardInfos(cardInfoMessages);
+
+      updateSelectedCardInfo(cardInfoMessages, round, true);
+    },
+    [updateCardGameState, updateCardInfos, updateSelectedCardInfo]
+  );
+
+  const handleLoading = useCallback(() => {
+    updateTransition(true);
+    updateCurrentRound('SECOND');
+    updateCardGameState('LOADING');
+  }, [updateTransition, updateCurrentRound, updateCardGameState]);
+
+  const handleGameDone = useCallback(() => {
+    navigate(`/room/${joinCode}/${miniGameType}/result`);
+  }, [navigate, joinCode, miniGameType]);
+
+  const handleCardGameState = useCallback(
+    (data: CardGameStateResponse) => {
+      const { cardGameState, currentRound, cardInfoMessages } = data;
+
+      switch (cardGameState) {
+        case 'PREPARE':
+          handlePrepare(cardInfoMessages);
+          break;
+        case 'PLAYING':
+          handlePlaying(cardInfoMessages, currentRound);
+          break;
+        case 'SCORE_BOARD':
+          handleScoreBoard(cardInfoMessages, currentRound);
+          break;
+        case 'LOADING':
+          if (currentRound === 'SECOND') {
+            handleLoading();
+          }
+          break;
+        case 'DONE':
+          handleGameDone();
+          break;
+      }
+    },
+    [handlePrepare, handlePlaying, handleScoreBoard, handleLoading, handleGameDone]
+  );
+
+  return {
+    handleCardGameState,
+  };
+};

--- a/frontend/src/contexts/CardGame/hooks/useCardGameState.ts
+++ b/frontend/src/contexts/CardGame/hooks/useCardGameState.ts
@@ -1,0 +1,37 @@
+import { CardGameState, CardInfo } from '@/types/miniGame/cardGame';
+import { RoundType } from '@/types/miniGame/round';
+import { useState } from 'react';
+
+export const useCardGameState = () => {
+  const [isTransition, setIsTransition] = useState<boolean>(false);
+  const [currentRound, setCurrentRound] = useState<RoundType>('FIRST');
+  const [currentCardGameState, setCurrentCardGameState] = useState<CardGameState>('READY');
+  const [cardInfos, setCardInfos] = useState<CardInfo[]>([]);
+
+  const updateCardGameState = (state: CardGameState) => {
+    setCurrentCardGameState(state);
+  };
+
+  const updateCardInfos = (cardInfoMessages: CardInfo[]) => {
+    setCardInfos(cardInfoMessages);
+  };
+
+  const updateCurrentRound = (round: RoundType) => {
+    setCurrentRound(round);
+  };
+
+  const updateTransition = (transition: boolean) => {
+    setIsTransition(transition);
+  };
+
+  return {
+    isTransition,
+    currentRound,
+    currentCardGameState,
+    cardInfos,
+    updateCardGameState,
+    updateCardInfos,
+    updateCurrentRound,
+    updateTransition,
+  };
+};

--- a/frontend/src/contexts/CardGame/hooks/useSelectedCard.ts
+++ b/frontend/src/contexts/CardGame/hooks/useSelectedCard.ts
@@ -1,0 +1,43 @@
+import { CardInfo, SelectedCardInfo } from '@/types/miniGame/cardGame';
+import { RoundType } from '@/types/miniGame/round';
+import { useCallback, useState } from 'react';
+
+export const useSelectedCard = (myName: string) => {
+  const [selectedCardInfo, setSelectedCardInfo] = useState<SelectedCardInfo>({
+    FIRST: {
+      isSelected: false,
+      type: null,
+      value: null,
+    },
+    SECOND: {
+      isSelected: false,
+      type: null,
+      value: null,
+    },
+  });
+
+  const updateSelectedCardInfo = useCallback(
+    (cardInfoMessages: CardInfo[], round: RoundType, shouldCheckAlreadySelected = false) => {
+      const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
+      if (!myCardInfo) return;
+
+      if (shouldCheckAlreadySelected && selectedCardInfo[round].isSelected) return;
+
+      setSelectedCardInfo((prev) => ({
+        ...prev,
+        [round]: {
+          isSelected: true,
+          type: myCardInfo.cardType,
+          value: myCardInfo.value,
+        },
+      }));
+    },
+    [myName, selectedCardInfo]
+  );
+
+  return {
+    selectedCardInfo,
+    setSelectedCardInfo,
+    updateSelectedCardInfo,
+  };
+};


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #668 

# 🚀 작업 내용

1. `handleCardGameState` 내부의 로직을 각 상태에 맞는 핸들러 함수로 분리 (4c12f5095365474838260d58fbaf4f73c6864fe0)
`handleCardGameState`는 게임의 상태를 관리하는 함수입니다. 원래는 각 상태에 따라 다른 액션을 취하는 코드를 모두 분기문으로 처리하고 있숩니다. 가독성과 역할의 분리를 위해 if문 내부에 있는 로직들을 별도의 핸들러 함수로 분리해주었습니다.

2. 카드를 선택하는 중복된 로직을 하나의 함수를 재사용하도록 분리했습니다. (0f2a5aae4488a2b608534ac5ea99247f36ce717e)
`updateSelectedCardInfo`라는 함수를 만들어서 중복 코드를 줄였습니다.

3. 각 상태의 관심사가 비슷한 것들끼리 커스텀 훅을 분리했습니다. (1b1232faa93a3b628ee66014561a079b46f11a72)

`useCardGameState`
- 카드 게임의 기본 상태 관리
- 관리하는 상태: `isTransition`, `currentRound`, `currentCardGameState`, `cardInfos`

`useSelectedCard`
- 선택된 카드 정보 관리
- 관리하는 상태: `selectedCardInfo`

`useCardGameHandlers`
- 게임 이벤트 처리 로직
- 제공하는 함수: `handleCardGameState` (웹소켓 이벤트를 처리하는 메인 핸들러)
- 다른 훅들의 상태 업데이트 함수들을 받아서 사용

# 💬 리뷰 중점사항

중점사항
