### PR TITLE
[fix] 룰렛 상태 테스트에 ROULETTE로 상태 변경 적용

### DIFF
--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -375,7 +375,7 @@ class RoomServiceTest extends ServiceTest {
                 new SelectedMenuRequest(2L, null, MenuTemperature.ICE));
         roomService.enterRoom(createdRoom.getJoinCode().getValue(), "게스트2",
                 new SelectedMenuRequest(3L, null, MenuTemperature.ICE));
-        ReflectionTestUtils.setField(createdRoom, "roomState", RoomState.PLAYING);
+        ReflectionTestUtils.setField(createdRoom, "roomState", RoomState.ROULETTE);
 
         // when
         Winner winner = roomService.spinRoulette(createdRoom.getJoinCode().getValue(), hostName);

--- a/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
@@ -170,7 +170,7 @@ class RoomTest {
         room.joinGuest(게스트_루키, new SelectedMenu(MenuFixture.아메리카노(), MenuTemperature.ICE));
         room.joinGuest(게스트_엠제이, new SelectedMenu(MenuFixture.아메리카노(), MenuTemperature.ICE));
 
-        ReflectionTestUtils.setField(room, "roomState", RoomState.PLAYING);
+        ReflectionTestUtils.setField(room, "roomState", RoomState.ROULETTE);
         Player host = room.findPlayer(호스트_한스);
 
         Winner winner = room.spinRoulette(host, roulette);

--- a/backend/src/test/java/coffeeshout/room/ui/RoomWebSocketControllerTest.java
+++ b/backend/src/test/java/coffeeshout/room/ui/RoomWebSocketControllerTest.java
@@ -225,7 +225,7 @@ class RoomWebSocketControllerTest extends WebSocketIntegrationTestSupport {
     @Test
     void 룰렛을_돌려서_당첨자를_선택한다() {
         // given
-        ReflectionTestUtils.setField(testRoom, "roomState", RoomState.PLAYING);
+        ReflectionTestUtils.setField(testRoom, "roomState", RoomState.ROULETTE);
 
         String subscribeUrlFormat = String.format("/topic/room/%s/winner", joinCode.getValue());
         String requestUrlFormat = String.format("/app/room/%s/spin-roulette", joinCode.getValue());


### PR DESCRIPTION


# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #773

# 🚀 작업 내용

- 테스트 코드에서 `roomState` 값을 기존 PLAYING에서 ROULETTE로 변경
- `RoomWebSocketControllerTest`, `RoomTest`, `RoomServiceTest` 수정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 테스트
  - 룰렛 시나리오의 사전 상태를 PLAYING에서 ROULETTE로 조정하여 서비스, 도메인, 웹소켓 컨트롤러 테스트 전반의 일관성과 정확성을 강화했습니다.
  - 승자 선택/구독 플로우의 검증 신뢰도를 높였습니다.
- 기타
  - 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->