### PR TITLE
[feat] useFetch 커스텀 훅 구현

### DIFF
--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -9,7 +9,6 @@ export type ApiRequestOptions<TData> = {
   method?: Method;
   headers?: Record<string, string>;
   body?: TData;
-  params?: Record<string, string | number | boolean | null | undefined>;
   retry?: {
     count: number;
     delay: number;
@@ -26,29 +25,9 @@ export const apiRequest = async <T, TData>(
   url: string,
   options: ApiRequestOptions<TData> = {}
 ): Promise<T> => {
-  const {
-    method = 'GET',
-    headers = {},
-    body = null,
-    params = null,
-    retry = { count: 0, delay: 1000 },
-  } = options;
+  const { method = 'GET', headers = {}, body = null, retry = { count: 0, delay: 1000 } } = options;
 
   let requestUrl = API_URL + url;
-
-  if (params) {
-    const searchParams = new URLSearchParams();
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== null && value !== undefined) {
-        searchParams.append(key, String(value));
-      }
-    });
-
-    const queryString = searchParams.toString();
-    if (queryString) {
-      requestUrl += (url.includes('?') ? '&' : '?') + queryString;
-    }
-  }
 
   const defaultHeaders: Record<string, string> = {
     'Content-Type': 'application/json',

--- a/frontend/src/apis/rest/useFetch.ts
+++ b/frontend/src/apis/rest/useFetch.ts
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from './api';
 
 type UseFetchOptions<T> = {
   endpoint: string;
-  params?: Record<string, string | number | boolean | null | undefined>;
   enabled?: boolean;
   onSuccess?: (data: T) => void;
   onError?: (error: Error) => void;
@@ -17,24 +16,11 @@ type UseFetchReturn<T> = {
 };
 
 const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
-  const { endpoint, params, enabled = true, onSuccess, onError } = options;
+  const { endpoint, enabled = true, onSuccess, onError } = options;
 
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
-
-  const stableParams = useMemo(() => {
-    if (!params) return {};
-
-    const filteredParams: Record<string, string | number | boolean> = {};
-    Object.entries(params).forEach(([key, value]) => {
-      if (value !== undefined && value !== null) {
-        filteredParams[key] = value;
-      }
-    });
-
-    return filteredParams;
-  }, [params]);
 
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
@@ -45,7 +31,7 @@ const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
     try {
       setLoading(true);
       setError(null);
-      const result = await api.get<T>(endpoint, { params: stableParams });
+      const result = await api.get<T>(endpoint);
       setData(result);
       onSuccessRef.current?.(result);
     } catch (err) {
@@ -54,7 +40,7 @@ const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
     } finally {
       setLoading(false);
     }
-  }, [endpoint, stableParams, enabled]);
+  }, [endpoint, enabled]);
 
   useEffect(() => {
     if (enabled) {

--- a/frontend/src/apis/rest/useFetch.ts
+++ b/frontend/src/apis/rest/useFetch.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { api } from './api';
+
+type UseFetchOptions<T> = {
+  endpoint: string;
+  params?: Record<string, string | number | boolean | null | undefined>;
+  enabled?: boolean;
+  onSuccess?: (data: T) => void;
+  onError?: (error: Error) => void;
+};
+
+type UseFetchReturn<T> = {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+};
+
+const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
+  const { endpoint, params, enabled = true, onSuccess, onError } = options;
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const stableParams = useMemo(() => {
+    if (!params) return {};
+
+    const filteredParams: Record<string, string | number | boolean> = {};
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        filteredParams[key] = value;
+      }
+    });
+
+    return filteredParams;
+  }, [params]);
+
+  const fetchData = useCallback(async () => {
+    if (!enabled) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await api.get<T>(endpoint, { params: stableParams });
+      setData(result);
+      onSuccess?.(result);
+    } catch (err) {
+      setError(err as Error);
+      onError?.(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, [endpoint, stableParams, enabled, onSuccess, onError]);
+
+  useEffect(() => {
+    if (enabled) {
+      fetchData();
+    }
+  }, [enabled, fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
+};
+
+export default useFetch;

--- a/frontend/src/apis/rest/useFetch.ts
+++ b/frontend/src/apis/rest/useFetch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api } from './api';
 
 type UseFetchOptions<T> = {
@@ -36,6 +36,9 @@ const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
     return filteredParams;
   }, [params]);
 
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
   const fetchData = useCallback(async () => {
     if (!enabled) return;
 
@@ -44,14 +47,14 @@ const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
       setError(null);
       const result = await api.get<T>(endpoint, { params: stableParams });
       setData(result);
-      onSuccess?.(result);
+      onSuccessRef.current?.(result);
     } catch (err) {
       setError(err as Error);
-      onError?.(err as Error);
+      onErrorRef.current?.(err as Error);
     } finally {
       setLoading(false);
     }
-  }, [endpoint, stableParams, enabled, onSuccess, onError]);
+  }, [endpoint, stableParams, enabled]);
 
   useEffect(() => {
     if (enabled) {

--- a/frontend/src/apis/rest/useLazyFetch.ts
+++ b/frontend/src/apis/rest/useLazyFetch.ts
@@ -11,7 +11,7 @@ type UseLazyFetchReturn<T> = {
   data: T | null;
   loading: boolean;
   error: Error | null;
-  execute: (params?: Record<string, string | number | boolean>) => Promise<T | null>;
+  execute: () => Promise<T | null>;
 };
 
 const useLazyFetch = <T>(options: UseLazyFetchOptions<T>): UseLazyFetchReturn<T> => {
@@ -24,25 +24,22 @@ const useLazyFetch = <T>(options: UseLazyFetchOptions<T>): UseLazyFetchReturn<T>
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
 
-  const execute = useCallback(
-    async (params?: Record<string, string | number | boolean>) => {
-      try {
-        setLoading(true);
-        setError(null);
-        const result = await api.get<T>(endpoint, { params: params || {} });
-        setData(result);
-        onSuccessRef.current?.(result);
-        return result;
-      } catch (err) {
-        setError(err as Error);
-        onErrorRef.current?.(err as Error);
-        return null;
-      } finally {
-        setLoading(false);
-      }
-    },
-    [endpoint]
-  );
+  const execute = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await api.get<T>(endpoint);
+      setData(result);
+      onSuccessRef.current?.(result);
+      return result;
+    } catch (err) {
+      setError(err as Error);
+      onErrorRef.current?.(err as Error);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [endpoint]);
 
   return { data, loading, error, execute };
 };

--- a/frontend/src/apis/rest/useLazyFetch.ts
+++ b/frontend/src/apis/rest/useLazyFetch.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import { api } from './api';
+
+type UseLazyFetchOptions<T> = {
+  endpoint: string;
+  onSuccess?: (data: T) => void;
+  onError?: (error: Error) => void;
+};
+
+type UseLazyFetchReturn<T> = {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  execute: (params?: Record<string, string | number | boolean>) => Promise<T | null>;
+};
+
+const useLazyFetch = <T>(options: UseLazyFetchOptions<T>): UseLazyFetchReturn<T> => {
+  const { endpoint, onSuccess, onError } = options;
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const execute = useCallback(
+    async (params?: Record<string, string | number | boolean>) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const result = await api.get<T>(endpoint, { params: params || {} });
+        setData(result);
+        onSuccess?.(result);
+        return result;
+      } catch (err) {
+        setError(err as Error);
+        onError?.(err as Error);
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [endpoint, onSuccess, onError]
+  );
+
+  return { data, loading, error, execute };
+};
+
+export default useLazyFetch;

--- a/frontend/src/apis/rest/useLazyFetch.ts
+++ b/frontend/src/apis/rest/useLazyFetch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { api } from './api';
 
 type UseLazyFetchOptions<T> = {
@@ -21,6 +21,9 @@ const useLazyFetch = <T>(options: UseLazyFetchOptions<T>): UseLazyFetchReturn<T>
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+
   const execute = useCallback(
     async (params?: Record<string, string | number | boolean>) => {
       try {
@@ -28,17 +31,17 @@ const useLazyFetch = <T>(options: UseLazyFetchOptions<T>): UseLazyFetchReturn<T>
         setError(null);
         const result = await api.get<T>(endpoint, { params: params || {} });
         setData(result);
-        onSuccess?.(result);
+        onSuccessRef.current?.(result);
         return result;
       } catch (err) {
         setError(err as Error);
-        onError?.(err as Error);
+        onErrorRef.current?.(err as Error);
         return null;
       } finally {
         setLoading(false);
       }
     },
-    [endpoint, onSuccess, onError]
+    [endpoint]
   );
 
   return { data, loading, error, execute };

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectMenu/SelectMenu.tsx
@@ -3,8 +3,8 @@ import MenuListItem from '@/components/@common/MenuListItem/MenuListItem';
 import * as S from './SelectMenu.styled';
 import SelectionCard from '@/components/@common/SelectionCard/SelectionCard';
 import { CategoryWithColor, Menu } from '@/types/menu';
-import { useEffect, useState, PropsWithChildren } from 'react';
-import { api } from '@/apis/rest/api';
+import { PropsWithChildren } from 'react';
+import useFetch from '@/apis/rest/useFetch';
 
 type Props = {
   onMenuSelect: (menu: Menu) => void;
@@ -13,14 +13,9 @@ type Props = {
 } & PropsWithChildren;
 
 const SelectMenu = ({ onMenuSelect, selectedCategory, selectedMenu, children }: Props) => {
-  const [menus, setMenus] = useState<Menu[]>([]);
-
-  useEffect(() => {
-    (async () => {
-      const menus = await api.get<Menu[]>(`/menu-categories/${selectedCategory.id}/menus`);
-      setMenus(menus);
-    })();
-  }, [selectedCategory]);
+  const { data: menus } = useFetch<Menu[]>({
+    endpoint: `/menu-categories/${selectedCategory.id}/menus`,
+  });
 
   const handleClickMenu = (menu: Menu) => {
     onMenuSelect(menu);
@@ -38,7 +33,7 @@ const SelectMenu = ({ onMenuSelect, selectedCategory, selectedMenu, children }: 
         {!selectedMenu && (
           <S.MenuListWrapper>
             <S.MenuList>
-              {menus.map((menu) => (
+              {menus?.map((menu) => (
                 <MenuListItem
                   key={menu.id}
                   text={menu.name}

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -26,7 +26,7 @@ const EntryNamePage = () => {
   const { showToast } = useToast();
 
   const { execute: checkGuestName } = useLazyFetch<PlayerNameCheckResponse>({
-    endpoint: `/rooms/check-guestName?joinCode=${joinCode}`,
+    endpoint: `/rooms/check-guestName?joinCode=${joinCode}&guestName=${name}`,
   });
 
   const handleNavigateToHome = () => {

--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -26,7 +26,7 @@ const EntryNamePage = () => {
   const { showToast } = useToast();
 
   const { execute: checkGuestName } = useLazyFetch<PlayerNameCheckResponse>({
-    endpoint: `/rooms/check-guestName`,
+    endpoint: `/rooms/check-guestName?joinCode=${joinCode}`,
   });
 
   const handleNavigateToHome = () => {
@@ -35,7 +35,7 @@ const EntryNamePage = () => {
 
   const handleNavigateToMenu = async () => {
     if (playerType === 'GUEST') {
-      const response = await checkGuestName({ joinCode, guestName: name });
+      const response = await checkGuestName();
 
       if (response?.exist) {
         showToast({

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
@@ -20,7 +20,7 @@ const EnterRoomModal = ({ onClose }: Props) => {
   const { joinCode, setJoinCode } = useIdentifier();
 
   const { execute: checkJoinCode } = useLazyFetch<JoinCodeCheckResponse>({
-    endpoint: `/rooms/check-joinCode`,
+    endpoint: `/rooms/check-joinCode?joinCode=${joinCode}`,
     onSuccess: (data) => {
       if (!data.exist) {
         alert('참여코드가 유효한 방이 존재하지 않습니다.');
@@ -43,7 +43,7 @@ const EnterRoomModal = ({ onClose }: Props) => {
       return;
     }
 
-    checkJoinCode({ joinCode });
+    checkJoinCode();
   };
 
   const handleJoinCodeChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
@@ -5,8 +5,7 @@ import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EnterRoomModal.styled';
-import { api } from '@/apis/rest/api';
-import { ApiError, NetworkError } from '@/apis/rest/error';
+import useLazyFetch from '@/apis/rest/useLazyFetch';
 
 type JoinCodeCheckResponse = {
   exist: boolean;
@@ -20,36 +19,31 @@ const EnterRoomModal = ({ onClose }: Props) => {
   const navigate = useNavigate();
   const { joinCode, setJoinCode } = useIdentifier();
 
-  const handleEnter = async () => {
+  const { execute: checkJoinCode } = useLazyFetch<JoinCodeCheckResponse>({
+    endpoint: `/rooms/check-joinCode`,
+    onSuccess: (data) => {
+      if (!data.exist) {
+        alert('참여코드가 유효한 방이 존재하지 않습니다.');
+        return;
+      }
+
+      navigate(`/entry/name`);
+      onClose();
+    },
+    onError: (err) => {
+      // 추후 에러 바운더리에서 처리
+      alert(err.message);
+      setJoinCode('');
+    },
+  });
+
+  const handleEnter = () => {
     if (!joinCode.trim()) {
       alert('초대코드를 입력해주세요.');
       return;
     }
 
-    try {
-      const { exist } = await api.get<JoinCodeCheckResponse>(
-        `/rooms/check-joinCode?joinCode=${joinCode}`
-      );
-
-      if (!exist) {
-        alert('참여코드가 유효한 방이 존재하지 않습니다.');
-        return;
-      }
-    } catch (error) {
-      if (error instanceof ApiError) {
-        alert(error.message);
-      } else if (error instanceof NetworkError) {
-        alert('네트워크 연결을 확인해주세요');
-      } else {
-        alert('알 수 없는 오류가 발생했습니다');
-      }
-
-      setJoinCode('');
-      return;
-    }
-
-    navigate(`/entry/name`);
-    onClose();
+    checkJoinCode({ joinCode });
   };
 
   const handleJoinCodeChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
+++ b/frontend/src/features/room/lobby/components/MenuModifyModal/MenuModifyModal.tsx
@@ -1,9 +1,8 @@
-import { api } from '@/apis/rest/api';
-import { ApiError, NetworkError } from '@/apis/rest/error';
+import useFetch from '@/apis/rest/useFetch';
 import Button from '@/components/@common/Button/Button';
 import Paragraph from '@/components/@common/Paragraph/Paragraph';
 import SelectBox, { Option } from '@/components/@common/SelectBox/SelectBox';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import * as S from './MenuModifyModal.styled';
 import { Menu } from '@/types/menu';
 import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
@@ -19,36 +18,22 @@ const MenuModifyModal = ({ myMenu, onClose }: Props) => {
     id: -1,
     name: myMenu,
   });
-  const [coffeeOptions, setCoffeeOptions] = useState<Option[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const { send } = useWebSocket();
   const { myName, joinCode } = useIdentifier();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        setLoading(true);
+  const {
+    data: menus,
+    loading,
+    error,
+  } = useFetch<Menu[]>({
+    endpoint: '/menus',
+  });
 
-        const menus = await api.get<Menu[]>('/menus');
-        const options = menus.map((menu) => ({
-          id: menu.id,
-          name: menu.name,
-        }));
-        setCoffeeOptions(options);
-      } catch (error) {
-        if (error instanceof ApiError) {
-          setError(error.message);
-        } else if (error instanceof NetworkError) {
-          setError('네트워크 연결을 확인해주세요');
-        } else {
-          setError('알 수 없는 오류가 발생했습니다');
-        }
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
+  const coffeeOptions =
+    menus?.map((menu) => ({
+      id: menu.id,
+      name: menu.name,
+    })) || [];
 
   const handleModify = async () => {
     if (!modifiedMenu) {
@@ -64,20 +49,17 @@ const MenuModifyModal = ({ myMenu, onClose }: Props) => {
     onClose();
   };
 
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div>{error.message}</div>;
+
   return (
     <S.Container>
       <Paragraph>변경할 메뉴를 선택해주세요</Paragraph>
-      {loading ? (
-        <div>로딩 중...</div>
-      ) : error ? (
-        <div>{error}</div>
-      ) : (
-        <SelectBox
-          value={modifiedMenu.name}
-          options={coffeeOptions}
-          onChange={(value) => setModifiedMenu(value)}
-        />
-      )}
+      <SelectBox
+        value={modifiedMenu.name}
+        options={coffeeOptions}
+        onChange={(value) => setModifiedMenu(value)}
+      />
       <S.ButtonContainer>
         <Button variant="secondary" onClick={onClose}>
           취소

--- a/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
@@ -1,5 +1,4 @@
-import { api } from '@/apis/rest/api';
-import { ApiError, NetworkError } from '@/apis/rest/error';
+import useFetch from '@/apis/rest/useFetch';
 import CardIcon from '@/assets/card-icon.svg';
 import GameActionButton from '@/components/@common/GameActionButton/GameActionButton';
 import SectionTitle from '@/components/@composition/SectionTitle/SectionTitle';
@@ -9,7 +8,6 @@ import {
   MINI_GAME_NAME_MAP,
   MiniGameType,
 } from '@/types/miniGame/common';
-import { useEffect, useState } from 'react';
 import * as S from './MiniGameSection.styled';
 
 type Props = {
@@ -18,39 +16,23 @@ type Props = {
 };
 
 export const MiniGameSection = ({ selectedMiniGames, handleMiniGameClick }: Props) => {
-  const [miniGames, setMiniGames] = useState<MiniGameType[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const { playerType } = usePlayerType();
-
-  useEffect(() => {
-    (async () => {
-      try {
-        setLoading(true);
-        const _miniGames = await api.get<MiniGameType[]>('/rooms/minigames');
-        setMiniGames(_miniGames);
-      } catch (error) {
-        if (error instanceof ApiError) {
-          setError(error.message);
-        } else if (error instanceof NetworkError) {
-          setError('네트워크 연결을 확인해주세요');
-        } else {
-          setError('알 수 없는 오류가 발생했습니다');
-        }
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
+  const {
+    data: miniGames,
+    loading,
+    error,
+  } = useFetch<MiniGameType[]>({
+    endpoint: '/rooms/minigames',
+  });
 
   if (loading) return <div>로딩 중...</div>;
-  if (error) return <div>{error}</div>;
+  if (error) return <div>{error.message}</div>;
 
   return (
     <>
       <SectionTitle title="미니게임" description="미니게임을 선택해주세요" />
       <S.Wrapper>
-        {miniGames.map((miniGame) => (
+        {miniGames?.map((miniGame) => (
           <GameActionButton
             key={miniGame}
             isSelected={selectedMiniGames.includes(miniGame)}

--- a/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
+++ b/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
@@ -16,7 +16,7 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
   const navigate = useNavigate();
 
   const { execute: checkRoomExists } = useLazyFetch<{ exist: boolean }>({
-    endpoint: `/rooms/check-joinCode`,
+    endpoint: `/rooms/check-joinCode?joinCode=${joinCode}`,
     onError: (error) => {
       console.error('방 존재 여부 체크 실패:', error);
       navigateToHome('방 존재 여부 체크 실패');
@@ -48,7 +48,7 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
     }
 
     // 방 존재 여부 체크
-    const response = await checkRoomExists({ joinCode });
+    const response = await checkRoomExists();
 
     if (!response?.exist) {
       navigateToHome('방이 존재하지 않음');

--- a/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
+++ b/frontend/src/features/room/lobby/hooks/useParticipantValidation.ts
@@ -1,4 +1,4 @@
-import { api } from '@/apis/rest/api';
+import useLazyFetch from '@/apis/rest/useLazyFetch';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
@@ -14,6 +14,14 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
   const { participants } = useParticipants();
   const { playerType } = usePlayerType();
   const navigate = useNavigate();
+
+  const { execute: checkRoomExists } = useLazyFetch<{ exist: boolean }>({
+    endpoint: `/rooms/check-joinCode`,
+    onError: (error) => {
+      console.error('방 존재 여부 체크 실패:', error);
+      navigateToHome('방 존재 여부 체크 실패');
+    },
+  });
 
   const navigateToHome = useCallback(
     (reason: string) => {
@@ -39,18 +47,11 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
       return;
     }
 
-    try {
-      const { exist } = await api.get<{ exist: boolean }>(
-        `/rooms/check-joinCode?joinCode=${joinCode}`
-      );
+    // 방 존재 여부 체크
+    const response = await checkRoomExists({ joinCode });
 
-      if (!exist) {
-        navigateToHome('방이 존재하지 않음');
-        return;
-      }
-    } catch (error) {
-      console.error('방 존재 여부 체크 실패:', error);
-      navigateToHome('방 존재 여부 체크 실패');
+    if (!response?.exist) {
+      navigateToHome('방이 존재하지 않음');
       return;
     }
 
@@ -64,7 +65,7 @@ export const useParticipantValidation = ({ isConnected }: Props) => {
     if (!currentUser) {
       navigateToHome('사용자 정보에서 자기 자신을 찾을 수 없음');
     }
-  }, [joinCode, playerType, myName, participants, navigateToHome]);
+  }, [joinCode, playerType, myName, participants, navigateToHome, checkRoomExists]);
 
   /**
    * 웹소켓 연결되고 participants가 로드된 후 유효성 검사

--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/hooks/useRouletteProbabilities.ts
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/hooks/useRouletteProbabilities.ts
@@ -1,9 +1,8 @@
-import { api } from '@/apis/rest/api';
+import useFetch from '@/apis/rest/useFetch';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { useProbabilityHistory } from '@/contexts/ProbabilityHistory/ProbabilityHistoryContext';
 import { colorList } from '@/constants/color';
-import { useEffect, useState } from 'react';
 
 type ProbabilityResponse = {
   playerName: string;
@@ -14,25 +13,19 @@ const useRouletteProbabilities = () => {
   const { joinCode } = useIdentifier();
   const { getParticipantColorIndex } = useParticipants();
   const { updateCurrentProbabilities } = useProbabilityHistory();
-  const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const data = await api.get<ProbabilityResponse[]>(`/rooms/${joinCode}/probabilities`);
-        updateCurrentProbabilities(
-          data.map((probability) => ({
-            ...probability,
-            playerColor: colorList[getParticipantColorIndex(probability.playerName)],
-          }))
-        );
-      } catch (error) {
-        console.error(error);
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, [joinCode, getParticipantColorIndex, updateCurrentProbabilities]);
+  const { loading: isLoading } = useFetch<ProbabilityResponse[]>({
+    endpoint: `/rooms/${joinCode}/probabilities`,
+    enabled: !!joinCode,
+    onSuccess: (data) => {
+      updateCurrentProbabilities(
+        data.map((probability) => ({
+          ...probability,
+          playerColor: colorList[getParticipantColorIndex(probability.playerName)],
+        }))
+      );
+    },
+  });
 
   return {
     isLoading,

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -86,7 +86,7 @@ export default (_, argv) => {
       }),
       new WebpackBundleAnalyzer.BundleAnalyzerPlugin({
         analyzerMode: 'static',
-        openAnalyzer: true,
+        openAnalyzer: false,
         reportFilename: 'bundle-report.html',
       }),
     ],


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #791 

# 🚀 작업 내용

1. `useFetch` 훅을 구현했습니다.

각 props에 대한 설명은 아래와 같습니다.
```tsx
type UseFetchOptions<T> = {
  endpoint: string; // 요청할 경로
  enabled?: boolean; // fetchData 함수를 실행시킬 특정 값 or 조건
  onSuccess?: (data: T) => void; // 데이터 페칭 성공 시 실행시키는 핸들러
  onError?: (error: Error) => void; // 데이터 페칭 실패 시 실행시키는 핸들러
};
```

오늘 아침에 제가 설명했던 구조에는 `params` `props`가 별도로 있었는데요.
구현하다보니 `params` 객체 형태로 쿼리 파라미터를 넘기는 방식이 아니라, `endPoint`에 모든 문자를 다 적어주는 방식으로 변경했습니다.

그 이유는 `params`를 넘겨주는 과정에서 새로운 객체가 계속 생성되는 바람에 `useFetch`의 `fetchData` 함수가 계속해서 생성되기 때문이었습니다.

따라서 아래와 같이 `useMemo`로 `params`의 감싸주는 방법으로 어찌저찌 해결은 했는데요.

```tsx
  const miniGamesParams = useMemo(() => ({ joinCode }), [joinCode]);

  useFetch<MiniGameType[]>({
    endpoint: `/rooms/minigames/selected`,
    params: miniGamesParams,
    enabled: !!joinCode,
    onSuccess: (data) => {
      setSelectedMiniGames(data);
    },
  });
```

생각해보니 `useFetch`를 쓰는 과정에서 위의 방법처럼 `useMemo`로 값을 래핑하고 넘겨줘야 한다면, 오히려 불편할 것 같다는 생각이 들어서 `params`를 없애고, 쿼리스트링을 포함한 api 경로를 모두 작성하는 방식으로 수정했습니다,,!
혹시나 더 좋은 방법이 있다면 알려주세용 ㅎ.ㅎ

<br/>

2. 


# 💬 리뷰 중점사항

중점사항
