### PR TITLE
[refactor] 방 생성 속도 개선

### DIFF
--- a/backend/src/main/java/coffeeshout/room/application/DelayedRoomRemovalService.java
+++ b/backend/src/main/java/coffeeshout/room/application/DelayedRoomRemovalService.java
@@ -35,10 +35,14 @@ public class DelayedRoomRemovalService {
     }
 
     public void scheduleRemoveRoom(JoinCode joinCode) {
-        log.info("방 지연 삭제 스케줄링: joinCode={}, delay={}초",
-                joinCode.getValue(), removeDuration.getSeconds());
+        try {
+            log.info("방 지연 삭제 스케줄링: joinCode={}, delay={}초",
+                    joinCode.getValue(), removeDuration.getSeconds());
 
-        taskScheduler.schedule(() -> executeRoomRemoval(joinCode), Instant.now().plus(removeDuration));
+            taskScheduler.schedule(() -> executeRoomRemoval(joinCode), Instant.now().plus(removeDuration));
+        } catch (Exception e) {
+            log.error("방 제거 스케줄링 실패: joinCode={}", joinCode.getValue(), e);
+        }
     }
 
     private void executeRoomRemoval(JoinCode joinCode) {

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -65,7 +65,7 @@ public class RoomService {
 
         // 방 생성
         final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
-        final Room room = roomCommandService.createRoom(joinCode, new PlayerName(hostName),
+        final Room room = roomCommandService.saveIfAbsentRoom(joinCode, new PlayerName(hostName),
                 menu, selectedMenuRequest.temperature(), qrCodeUrl);
 
         // 방 생성 후 이벤트 전달

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -8,7 +8,6 @@ import coffeeshout.room.domain.Playable;
 import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.event.RoomCreateEvent;
 import coffeeshout.room.domain.event.RoomJoinEvent;
-import coffeeshout.room.domain.menu.CustomMenu;
 import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.menu.SelectedMenu;
@@ -50,7 +49,6 @@ public class RoomService {
     private final MenuQueryService menuQueryService;
     private final QrCodeService qrCodeService;
     private final JoinCodeGenerator joinCodeGenerator;
-    private final DelayedRoomRemovalService delayedRoomRemovalService;
     private final RoomEventPublisher roomEventPublisher;
     private final RoomEventWaitManager roomEventWaitManager;
     private final MenuCommandService menuCommandService;
@@ -61,18 +59,28 @@ public class RoomService {
 
     // === 비동기 메서드들 (REST Controller용) ===
 
-    public CompletableFuture<Room> createRoomAsync(String hostName, SelectedMenuRequest selectedMenuRequest) {
+    public Room createRoom(String hostName, SelectedMenuRequest selectedMenuRequest) {
         final JoinCode joinCode = joinCodeGenerator.generate();
+        // QR 코드 생성
+        final String qrCodeUrl = qrCodeService.getQrCodeUrl(joinCode.getValue());
 
-        final RoomCreateEvent event = new RoomCreateEvent(hostName, selectedMenuRequest, joinCode.getValue());
+        // 방 생성
+        Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
+        roomCommandService.createRoom(joinCode, new PlayerName(hostName),
+                menu, selectedMenuRequest.temperature(), qrCodeUrl);
 
-        return processEventAsync(
-                event.eventId(),
-                () -> roomEventPublisher.publishEvent(event),
-                "방 생성",
-                String.format("joinCode=%s", joinCode.getValue()),
-                room -> String.format("joinCode=%s", room.getJoinCode().getValue())
+        // 방 생성 후 이벤트 전달
+        final RoomCreateEvent event = new RoomCreateEvent(
+                hostName,
+                selectedMenuRequest,
+                joinCode.getValue(),
+                qrCodeUrl
         );
+
+        roomEventPublisher.publishEvent(event);
+
+        // 해당 방 정보 수신
+        return roomQueryService.getByJoinCode(joinCode);
     }
 
     public CompletableFuture<Room> enterRoomAsync(
@@ -113,20 +121,6 @@ public class RoomService {
                 });
     }
 
-    // === 기존 동기 메서드들 (테스트용 + 하위 호환성) ===
-
-    public Room createRoom(String hostName, SelectedMenuRequest selectedMenuRequest) {
-        try {
-            return createRoomAsync(hostName, selectedMenuRequest).join();
-        } catch (Exception e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException runtimeException) {
-                throw runtimeException;
-            }
-            throw new RuntimeException("방 생성 실패", cause);
-        }
-    }
-
     public List<Player> changePlayerReadyState(String joinCode, String playerName, Boolean isReady) {
         return changePlayerReadyStateInternal(joinCode, playerName, isReady);
     }
@@ -145,29 +139,6 @@ public class RoomService {
     public List<Player> getPlayersInternal(String joinCode) {
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
         return room.getPlayers();
-    }
-
-    public Room createRoomInternal(
-            String hostName,
-            SelectedMenuRequest selectedMenuRequest,
-            String joinCodeValue
-    ) {
-        final JoinCode joinCode = new JoinCode(joinCodeValue);
-        final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
-        final Room room = Room.createNewRoom(
-                joinCode,
-                new PlayerName(hostName),
-                new SelectedMenu(menu, selectedMenuRequest.temperature())
-        );
-        assignQrCodeUrl(room);
-        scheduleRemoveRoom(joinCode);
-
-        return roomCommandService.save(room);
-    }
-
-    private void assignQrCodeUrl(Room room) {
-        final String qrCodeUrl = qrCodeService.getQrCodeUrl(room.getJoinCode().getValue());
-        room.assignQrCodeUrl(qrCodeUrl);
     }
 
     public Room enterRoom(String joinCode, String guestName, SelectedMenuRequest selectedMenuRequest) {
@@ -288,14 +259,6 @@ public class RoomService {
     public boolean isReadyState(String joinCode) {
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
         return room.isReadyState();
-    }
-
-    private void scheduleRemoveRoom(JoinCode joinCode) {
-        try {
-            delayedRoomRemovalService.scheduleRemoveRoom(joinCode);
-        } catch (Exception e) {
-            log.error("방 제거 스케줄링 실패: joinCode={}", joinCode.getValue(), e);
-        }
     }
 
     public Room showRoulette(String joinCode) {

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -57,10 +57,9 @@ public class RoomService {
     @Value("${room.event.timeout:PT5S}")
     private Duration eventTimeout;
 
-    // === 비동기 메서드들 (REST Controller용) ===
-
     public Room createRoom(String hostName, SelectedMenuRequest selectedMenuRequest) {
         final JoinCode joinCode = joinCodeGenerator.generate();
+
         // QR 코드 생성
         final String qrCodeUrl = qrCodeService.getQrCodeUrl(joinCode.getValue());
 
@@ -82,6 +81,8 @@ public class RoomService {
         // 해당 방 정보 수신
         return roomQueryService.getByJoinCode(joinCode);
     }
+
+    // === 비동기 메서드들 (REST Controller용) ===
 
     public CompletableFuture<Room> enterRoomAsync(
             String joinCode,

--- a/backend/src/main/java/coffeeshout/room/application/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RoomService.java
@@ -64,8 +64,8 @@ public class RoomService {
         final String qrCodeUrl = qrCodeService.getQrCodeUrl(joinCode.getValue());
 
         // 방 생성
-        Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
-        roomCommandService.createRoom(joinCode, new PlayerName(hostName),
+        final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
+        final Room room = roomCommandService.createRoom(joinCode, new PlayerName(hostName),
                 menu, selectedMenuRequest.temperature(), qrCodeUrl);
 
         // 방 생성 후 이벤트 전달
@@ -79,7 +79,7 @@ public class RoomService {
         roomEventPublisher.publishEvent(event);
 
         // 해당 방 정보 수신
-        return roomQueryService.getByJoinCode(joinCode);
+        return room;
     }
 
     // === 비동기 메서드들 (REST Controller용) ===

--- a/backend/src/main/java/coffeeshout/room/domain/JoinCode.java
+++ b/backend/src/main/java/coffeeshout/room/domain/JoinCode.java
@@ -12,8 +12,8 @@ import lombok.NonNull;
 @Getter
 public final class JoinCode {
 
-    private static final String CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-    private static final int CODE_LENGTH = 5;
+    private static final String CHARSET = "ABCDFGHJKLMNPQRSTUVWXYZ346789";
+    private static final int CODE_LENGTH = 4;
 
     private final String value;
     private String qrCodeUrl;

--- a/backend/src/main/java/coffeeshout/room/domain/event/RoomCreateEvent.java
+++ b/backend/src/main/java/coffeeshout/room/domain/event/RoomCreateEvent.java
@@ -14,10 +14,14 @@ public record RoomCreateEvent(
         RoomEventType eventType,
         String hostName,
         SelectedMenuRequest selectedMenuRequest,
-        String joinCode
+        String joinCode,
+        String qrCodeUrl
 ) implements RoomBaseEvent, Traceable {
 
-    public RoomCreateEvent(String hostName, SelectedMenuRequest selectedMenuRequest, String joinCode) {
+    public RoomCreateEvent(String hostName,
+                           SelectedMenuRequest selectedMenuRequest,
+                           String joinCode,
+                           String qrCodeUrl) {
         this(
                 UUID.randomUUID().toString(),
                 TraceInfoExtractor.extract(),
@@ -25,7 +29,8 @@ public record RoomCreateEvent(
                 RoomEventType.ROOM_CREATE,
                 hostName,
                 selectedMenuRequest,
-                joinCode
+                joinCode,
+                qrCodeUrl
         );
     }
 

--- a/backend/src/main/java/coffeeshout/room/domain/exception/RoomDuplicationException.java
+++ b/backend/src/main/java/coffeeshout/room/domain/exception/RoomDuplicationException.java
@@ -1,0 +1,7 @@
+package coffeeshout.room.domain.exception;
+
+public class RoomDuplicationException extends RuntimeException {
+    public RoomDuplicationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/domain/exception/RoomDuplicationException.java
+++ b/backend/src/main/java/coffeeshout/room/domain/exception/RoomDuplicationException.java
@@ -1,7 +1,0 @@
-package coffeeshout.room.domain.exception;
-
-public class RoomDuplicationException extends RuntimeException {
-    public RoomDuplicationException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/coffeeshout/room/domain/repository/JoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/JoinCodeRepository.java
@@ -4,7 +4,5 @@ import coffeeshout.room.domain.JoinCode;
 
 public interface JoinCodeRepository {
 
-    boolean existsByJoinCode(JoinCode joinCode);
-
-    void save(JoinCode joinCode);
+    boolean save(JoinCode joinCode);
 }

--- a/backend/src/main/java/coffeeshout/room/domain/repository/JoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/JoinCodeRepository.java
@@ -1,0 +1,10 @@
+package coffeeshout.room.domain.repository;
+
+import coffeeshout.room.domain.JoinCode;
+
+public interface JoinCodeRepository {
+
+    boolean existsByJoinCode(JoinCode joinCode);
+
+    void save(JoinCode joinCode);
+}

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -18,6 +18,7 @@ public class JoinCodeGenerator {
                 .limit(100) // 안전망
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("입장 코드 생성이 실패했습니다."));
-        return joinCodeRepository.save(joinCode);
+        joinCodeRepository.save(joinCode);
+        return joinCode;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -2,23 +2,33 @@ package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.repository.JoinCodeRepository;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JoinCodeGenerator {
 
+    private static final int MAX_RETRY_COUNT = 100;
+
     private final JoinCodeRepository joinCodeRepository;
 
     public JoinCode generate() {
-        JoinCode joinCode = Stream.generate(JoinCode::generate)
-                .dropWhile(joinCodeRepository::existsByJoinCode)
-                .limit(100) // 안전망
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("입장 코드 생성이 실패했습니다."));
-        joinCodeRepository.save(joinCode);
-        return joinCode;
+        for (int attempt = 0; attempt < MAX_RETRY_COUNT; attempt++) {
+            JoinCode joinCode = JoinCode.generate();
+
+            boolean saved = joinCodeRepository.save(joinCode);
+
+            if (saved) {
+                log.debug("JoinCode 생성 성공: {} (시도 횟수: {})", joinCode.getValue(), attempt + 1);
+                return joinCode;
+            }
+
+            log.debug("JoinCode 중복 발생: {} (재시도 중... {}/{})", joinCode.getValue(), attempt + 1, MAX_RETRY_COUNT);
+        }
+
+        throw new IllegalStateException("입장 코드 생성이 실패했습니다. 최대 시도 횟수를 초과했습니다.");
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -2,18 +2,34 @@ package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.repository.JoinCodeRepository;
-import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class JoinCodeGenerator {
 
     private static final int MAX_RETRY_COUNT = 100;
 
     private final JoinCodeRepository joinCodeRepository;
+    private final Counter generationSuccessCounter;
+    private final Counter duplicationCounter;
+    private final Counter maxRetryExceededCounter;
+
+    public JoinCodeGenerator(JoinCodeRepository joinCodeRepository, MeterRegistry meterRegistry) {
+        this.joinCodeRepository = joinCodeRepository;
+        this.generationSuccessCounter = Counter.builder("joinCode.generation.success")
+                .description("JoinCode 생성 성공 횟수")
+                .register(meterRegistry);
+        this.duplicationCounter = Counter.builder("joinCode.generation.duplication")
+                .description("JoinCode 생성 중복 발생 횟수")
+                .register(meterRegistry);
+        this.maxRetryExceededCounter = Counter.builder("joinCode.generation.max_retry_exceeded")
+                .description("JoinCode 생성 최대 재시도 횟수 초과")
+                .register(meterRegistry);
+    }
 
     public JoinCode generate() {
         for (int attempt = 0; attempt < MAX_RETRY_COUNT; attempt++) {
@@ -22,13 +38,16 @@ public class JoinCodeGenerator {
             final boolean saved = joinCodeRepository.save(joinCode);
 
             if (saved) {
+                generationSuccessCounter.increment();
                 log.debug("JoinCode 생성 성공: {} (시도 횟수: {})", joinCode.getValue(), attempt + 1);
                 return joinCode;
             }
 
+            duplicationCounter.increment();
             log.debug("JoinCode 중복 발생: {} (재시도 중... {}/{})", joinCode.getValue(), attempt + 1, MAX_RETRY_COUNT);
         }
 
+        maxRetryExceededCounter.increment();
         throw new IllegalStateException("입장 코드 생성이 실패했습니다. 최대 시도 횟수를 초과했습니다.");
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -1,7 +1,7 @@
 package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
-import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.room.domain.repository.JoinCodeRepository;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,12 +10,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JoinCodeGenerator {
 
-    // TODO Redis Repository 필요 분산 환경에서 하나만 처리되도록 해야함
-    private final RoomRepository roomRepository;
+    private final JoinCodeRepository joinCodeRepository;
 
     public JoinCode generate() {
         return Stream.generate(JoinCode::generate)
-                .dropWhile(roomRepository::existsByJoinCode)
+                .dropWhile(joinCodeRepository::existsByJoinCode)
                 .limit(100) // 안전망
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("입장 코드 생성이 실패했습니다."));

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -17,9 +17,9 @@ public class JoinCodeGenerator {
 
     public JoinCode generate() {
         for (int attempt = 0; attempt < MAX_RETRY_COUNT; attempt++) {
-            JoinCode joinCode = JoinCode.generate();
+            final JoinCode joinCode = JoinCode.generate();
 
-            boolean saved = joinCodeRepository.save(joinCode);
+            final boolean saved = joinCodeRepository.save(joinCode);
 
             if (saved) {
                 log.debug("JoinCode 생성 성공: {} (시도 횟수: {})", joinCode.getValue(), attempt + 1);

--- a/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/JoinCodeGenerator.java
@@ -13,10 +13,11 @@ public class JoinCodeGenerator {
     private final JoinCodeRepository joinCodeRepository;
 
     public JoinCode generate() {
-        return Stream.generate(JoinCode::generate)
+        JoinCode joinCode = Stream.generate(JoinCode::generate)
                 .dropWhile(joinCodeRepository::existsByJoinCode)
                 .limit(100) // 안전망
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("입장 코드 생성이 실패했습니다."));
+        return joinCodeRepository.save(joinCode);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -52,9 +52,10 @@ public class RoomCommandService {
         final Room room = Room.createNewRoom(joinCode, hostName, new SelectedMenu(menu, menuTemperature));
         room.assignQrCodeUrl(qrCodeUrl);
 
+        Room saved = save(room);
         // 방 생성 후 조인코드 저장
         joinCodeRepository.save(joinCode);
 
-        return save(room);
+        return saved;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -37,4 +37,19 @@ public class RoomCommandService {
 
         return save(room);
     }
+
+    public void createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
+                           String qrCodeUrl) {
+        if (roomRepository.existsByJoinCode(joinCode)) {
+            log.info("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
+            return;
+        }
+
+        log.info("JoinCode[{}] 방 생성 - 호스트 이름: {}, 메뉴 정보: {}, 온도 : {} ", joinCode, hostName, menu, menuTemperature);
+
+        final Room room = Room.createNewRoom(joinCode, hostName, new SelectedMenu(menu, menuTemperature));
+        room.assignQrCodeUrl(qrCodeUrl);
+
+        save(room);
+    }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -38,11 +38,11 @@ public class RoomCommandService {
         return save(room);
     }
 
-    public void createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
+    public Room createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
                            String qrCodeUrl) {
         if (roomRepository.existsByJoinCode(joinCode)) {
             log.warn("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
-            return;
+            return roomQueryService.getByJoinCode(joinCode);
         }
 
         log.info("JoinCode[{}] 방 생성 - 호스트 이름: {}, 메뉴 정보: {}, 온도 : {} ", joinCode, hostName, menu, menuTemperature);
@@ -50,6 +50,6 @@ public class RoomCommandService {
         final Room room = Room.createNewRoom(joinCode, hostName, new SelectedMenu(menu, menuTemperature));
         room.assignQrCodeUrl(qrCodeUrl);
 
-        save(room);
+        return save(room);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -2,7 +2,6 @@ package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
-import coffeeshout.room.domain.exception.RoomDuplicationException;
 import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.menu.SelectedMenu;
@@ -39,11 +38,11 @@ public class RoomCommandService {
         return save(room);
     }
 
-    public Room createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
-                           String qrCodeUrl) throws RoomDuplicationException {
+    public Room saveIfAbsentRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
+                                 String qrCodeUrl) {
         if (roomRepository.existsByJoinCode(joinCode)) {
             log.warn("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
-            throw new RoomDuplicationException("이미 존재하는 방입니다.");
+            return roomQueryService.getByJoinCode(joinCode);
         }
 
         log.info("JoinCode[{}] 방 생성 - 호스트 이름: {}, 메뉴 정보: {}, 온도 : {} ", joinCode, hostName, menu, menuTemperature);

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -6,6 +6,7 @@ import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.repository.JoinCodeRepository;
 import coffeeshout.room.domain.repository.RoomRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RoomCommandService {
 
+    private final JoinCodeRepository joinCodeRepository;
     private final RoomRepository roomRepository;
     private final RoomQueryService roomQueryService;
 
@@ -49,6 +51,9 @@ public class RoomCommandService {
 
         final Room room = Room.createNewRoom(joinCode, hostName, new SelectedMenu(menu, menuTemperature));
         room.assignQrCodeUrl(qrCodeUrl);
+
+        // 방 생성 후 조인코드 저장
+        joinCodeRepository.save(joinCode);
 
         return save(room);
     }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -6,7 +6,6 @@ import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.player.PlayerName;
-import coffeeshout.room.domain.repository.JoinCodeRepository;
 import coffeeshout.room.domain.repository.RoomRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RoomCommandService {
 
-    private final JoinCodeRepository joinCodeRepository;
     private final RoomRepository roomRepository;
     private final RoomQueryService roomQueryService;
 
@@ -52,10 +50,6 @@ public class RoomCommandService {
         final Room room = Room.createNewRoom(joinCode, hostName, new SelectedMenu(menu, menuTemperature));
         room.assignQrCodeUrl(qrCodeUrl);
 
-        Room saved = save(room);
-        // 방 생성 후 조인코드 저장
-        joinCodeRepository.save(joinCode);
-
-        return saved;
+        return save(room);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -41,7 +41,7 @@ public class RoomCommandService {
     public void createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
                            String qrCodeUrl) {
         if (roomRepository.existsByJoinCode(joinCode)) {
-            log.info("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
+            log.warn("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
             return;
         }
 

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -2,6 +2,7 @@ package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.exception.RoomDuplicationException;
 import coffeeshout.room.domain.menu.Menu;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.menu.SelectedMenu;
@@ -39,10 +40,10 @@ public class RoomCommandService {
     }
 
     public Room createRoom(JoinCode joinCode, PlayerName hostName, Menu menu, MenuTemperature menuTemperature,
-                           String qrCodeUrl) {
+                           String qrCodeUrl) throws RoomDuplicationException {
         if (roomRepository.existsByJoinCode(joinCode)) {
             log.warn("JoinCode[{}] 방 생성 실패 - 이미 존재하는 방", joinCode);
-            return roomQueryService.getByJoinCode(joinCode);
+            throw new RoomDuplicationException("이미 존재하는 방입니다.");
         }
 
         log.info("JoinCode[{}] 방 생성 - 호스트 이름: {}, 메뉴 정보: {}, 온도 : {} ", joinCode, hostName, menu, menuTemperature);

--- a/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
@@ -20,17 +20,10 @@ public class RedisJoinCodeRepository implements JoinCodeRepository {
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
-    public boolean existsByJoinCode(JoinCode joinCode) {
+    public boolean save(JoinCode joinCode) {
         final String key = JOIN_CODE_KEY_PREFIX + joinCode.getValue();
-
-        // null이 발생할 수 있으므로 다음과 같이 처리해야함
-        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
-    }
-
-    @Override
-    public void save(JoinCode joinCode) {
-        final String key = JOIN_CODE_KEY_PREFIX + joinCode.getValue();
-        // value는 간단히 "1"로 저장 (존재 여부만 확인하면 되므로)
-        redisTemplate.opsForValue().set(key, "1", ttl);
+        // SETNX 명령어로 원자적으로 저장 (키가 없을 때만 저장)
+        Boolean success = redisTemplate.opsForValue().setIfAbsent(key, "1", ttl);
+        return Boolean.TRUE.equals(success);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
@@ -1,0 +1,35 @@
+package coffeeshout.room.infra;
+
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.repository.JoinCodeRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisJoinCodeRepository implements JoinCodeRepository {
+
+    private static final String JOIN_CODE_SET_KEY = "room:joinCodes";
+
+    @Value("${room.removalDelay}")
+    private Duration ttl;
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public boolean existsByJoinCode(JoinCode joinCode) {
+        Boolean isMember = redisTemplate.opsForSet().isMember(JOIN_CODE_SET_KEY, joinCode.getValue());
+
+        // null이 발생할 수 있으므로 다음과 같이 처리해야함
+        return Boolean.TRUE.equals(isMember);
+    }
+
+    @Override
+    public void save(JoinCode joinCode) {
+        redisTemplate.opsForSet().add(JOIN_CODE_SET_KEY, joinCode.getValue());
+        redisTemplate.expire(JOIN_CODE_SET_KEY, ttl);
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
@@ -28,9 +28,10 @@ public class RedisJoinCodeRepository implements JoinCodeRepository {
     }
 
     @Override
-    public void save(JoinCode joinCode) {
+    public JoinCode save(JoinCode joinCode) {
         final String key = JOIN_CODE_KEY_PREFIX + joinCode.getValue();
         // value는 간단히 "1"로 저장 (존재 여부만 확인하면 되므로)
         redisTemplate.opsForValue().set(key, "1", ttl);
+        return joinCode;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/RedisJoinCodeRepository.java
@@ -28,10 +28,9 @@ public class RedisJoinCodeRepository implements JoinCodeRepository {
     }
 
     @Override
-    public JoinCode save(JoinCode joinCode) {
+    public void save(JoinCode joinCode) {
         final String key = JOIN_CODE_KEY_PREFIX + joinCode.getValue();
         // value는 간단히 "1"로 저장 (존재 여부만 확인하면 되므로)
         redisTemplate.opsForValue().set(key, "1", ttl);
-        return joinCode;
     }
 }

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
@@ -2,6 +2,7 @@ package coffeeshout.room.infra.messaging.handler;
 
 import coffeeshout.room.application.DelayedRoomRemovalService;
 import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.event.RoomCreateEvent;
 import coffeeshout.room.domain.event.RoomEventType;
 import coffeeshout.room.domain.menu.Menu;
@@ -32,7 +33,7 @@ public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent>
             final SelectedMenuRequest selectedMenuRequest = event.selectedMenuRequest();
             final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
 
-            roomCommandService.createRoom(
+            Room room = roomCommandService.createRoom(
                     new JoinCode(joinCode),
                     new PlayerName(event.hostName()),
                     menu,
@@ -40,8 +41,12 @@ public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent>
                     event.qrCodeUrl()
             );
 
-            log.info("방 생성 이벤트 처리 완료: eventId={}, joinCode={}",
-                    event.eventId(), joinCode);
+            log.info("방 생성 이벤트 처리 완료: eventId={}, hostName={}, joinCode={}, qrCodeUrl={}",
+                    event.eventId(),
+                    room.getHost().getName(),
+                    room.getJoinCode().getValue(),
+                    room.getJoinCode().getQrCodeUrl()
+            );
 
             delayedRoomRemovalService.scheduleRemoveRoom(new JoinCode(joinCode));
         } catch (Exception e) {

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
@@ -26,7 +26,7 @@ public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent>
 
     @Override
     public void handle(RoomCreateEvent event) {
-        String joinCode = event.joinCode();
+        final String joinCode = event.joinCode();
 
         try {
             log.info("방 생성 이벤트 수신: eventId={}, hostName={}, joinCode={}",
@@ -35,7 +35,7 @@ public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent>
             final SelectedMenuRequest selectedMenuRequest = event.selectedMenuRequest();
             final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
 
-            Room room = roomCommandService.createRoom(
+            final Room room = roomCommandService.createRoom(
                     new JoinCode(joinCode),
                     new PlayerName(event.hostName()),
                     menu,

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
@@ -1,10 +1,14 @@
 package coffeeshout.room.infra.messaging.handler;
 
-import coffeeshout.room.application.RoomService;
-import coffeeshout.room.domain.Room;
+import coffeeshout.room.application.DelayedRoomRemovalService;
+import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.event.RoomCreateEvent;
 import coffeeshout.room.domain.event.RoomEventType;
-import coffeeshout.room.infra.messaging.RoomEventWaitManager;
+import coffeeshout.room.domain.menu.Menu;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.service.MenuCommandService;
+import coffeeshout.room.domain.service.RoomCommandService;
+import coffeeshout.room.ui.request.SelectedMenuRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,29 +18,34 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent> {
 
-    private final RoomService roomService;
-    private final RoomEventWaitManager roomEventWaitManager;
+    private final DelayedRoomRemovalService delayedRoomRemovalService;
+    private final RoomCommandService roomCommandService;
+    private final MenuCommandService menuCommandService;
 
     @Override
     public void handle(RoomCreateEvent event) {
         try {
+            String joinCode = event.joinCode();
             log.info("방 생성 이벤트 수신: eventId={}, hostName={}, joinCode={}",
-                    event.eventId(), event.hostName(), event.joinCode());
+                    event.eventId(), event.hostName(), joinCode);
 
-            final Room room = roomService.createRoomInternal(
-                    event.hostName(),
-                    event.selectedMenuRequest(),
-                    event.joinCode()
+            SelectedMenuRequest selectedMenuRequest = event.selectedMenuRequest();
+            Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
+
+            roomCommandService.createRoom(
+                    new JoinCode(joinCode),
+                    new PlayerName(event.hostName()),
+                    menu,
+                    selectedMenuRequest.temperature(),
+                    event.qrCodeUrl()
             );
 
-            roomEventWaitManager.notifySuccess(event.eventId(), room);
-
             log.info("방 생성 이벤트 처리 완료: eventId={}, joinCode={}",
-                    event.eventId(), event.joinCode());
+                    event.eventId(), joinCode);
 
+            delayedRoomRemovalService.scheduleRemoveRoom(new JoinCode(joinCode));
         } catch (Exception e) {
             log.error("방 생성 이벤트 처리 실패", e);
-            roomEventWaitManager.notifyFailure(event.eventId(), e);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandler.java
@@ -29,8 +29,8 @@ public class RoomCreateEventHandler implements RoomEventHandler<RoomCreateEvent>
             log.info("방 생성 이벤트 수신: eventId={}, hostName={}, joinCode={}",
                     event.eventId(), event.hostName(), joinCode);
 
-            SelectedMenuRequest selectedMenuRequest = event.selectedMenuRequest();
-            Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
+            final SelectedMenuRequest selectedMenuRequest = event.selectedMenuRequest();
+            final Menu menu = menuCommandService.convertMenu(selectedMenuRequest.id(), selectedMenuRequest.customName());
 
             roomCommandService.createRoom(
                     new JoinCode(joinCode),

--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -32,7 +32,7 @@ public class RoomRestController {
     private final RoomService roomService;
 
     @PostMapping
-    public ResponseEntity<RoomCreateResponse> createRoom(@RequestBody RoomEnterRequest request) {
+    public ResponseEntity<RoomCreateResponse> createRoom(@Valid @RequestBody RoomEnterRequest request) {
         Room room = roomService.createRoom(request.playerName(), request.menu());
 
         return ResponseEntity.ok(RoomCreateResponse.from(room));

--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -33,7 +33,7 @@ public class RoomRestController {
 
     @PostMapping
     public ResponseEntity<RoomCreateResponse> createRoom(@Valid @RequestBody RoomEnterRequest request) {
-        Room room = roomService.createRoom(request.playerName(), request.menu());
+        final Room room = roomService.createRoom(request.playerName(), request.menu());
 
         return ResponseEntity.ok(RoomCreateResponse.from(room));
     }

--- a/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
+++ b/backend/src/main/java/coffeeshout/room/ui/RoomRestController.java
@@ -2,6 +2,7 @@ package coffeeshout.room.ui;
 
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.application.RoomService;
+import coffeeshout.room.domain.Room;
 import coffeeshout.room.ui.request.RoomEnterRequest;
 import coffeeshout.room.ui.response.GuestNameExistResponse;
 import coffeeshout.room.ui.response.JoinCodeExistResponse;
@@ -31,16 +32,10 @@ public class RoomRestController {
     private final RoomService roomService;
 
     @PostMapping
-    public CompletableFuture<ResponseEntity<RoomCreateResponse>> createRoom(@RequestBody RoomEnterRequest request) {
-        return roomService.createRoomAsync(request.playerName(), request.menu())
-                .thenApply(room -> ResponseEntity.ok(RoomCreateResponse.from(room)))
-                .exceptionally(throwable -> {
-                    final Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
-                    if (cause instanceof RuntimeException runtimeException) {
-                        throw runtimeException;
-                    }
-                    throw new RuntimeException("방 생성 실패", cause);
-                });
+    public ResponseEntity<RoomCreateResponse> createRoom(@RequestBody RoomEnterRequest request) {
+        Room room = roomService.createRoom(request.playerName(), request.menu());
+
+        return ResponseEntity.ok(RoomCreateResponse.from(room));
     }
 
     @PostMapping("/{joinCode}")

--- a/backend/src/test/java/coffeeshout/fixture/RoomFixture.java
+++ b/backend/src/test/java/coffeeshout/fixture/RoomFixture.java
@@ -13,7 +13,7 @@ public final class RoomFixture {
 
     public static Room 호스트_꾹이() {
         final Room room = new Room(
-                new JoinCode("A4B2C"),
+                new JoinCode("A4BX"),
                 PlayerFixture.호스트꾹이().getName(),
                 new SelectedMenu(MenuFixture.아메리카노(), MenuTemperature.ICE)
         );

--- a/backend/src/test/java/coffeeshout/fixture/TestDataHelper.java
+++ b/backend/src/test/java/coffeeshout/fixture/TestDataHelper.java
@@ -22,19 +22,26 @@ public class TestDataHelper {
     @Autowired
     private MenuRepository menuRepository;
 
-    public Room createDummyRoom(String joinCode, String hostName) {
+    public Room createDummyRoom(JoinCode joinCode, PlayerName hostName) {
         Menu menu = menuRepository.findById(1L).orElseThrow();
-        Room room = new Room(new JoinCode(joinCode), new PlayerName(hostName),
-                new SelectedMenu(menu, MenuTemperature.ICE));
+        Room room = new Room(joinCode, hostName, new SelectedMenu(menu, MenuTemperature.ICE));
         return roomRepository.save(room);
     }
 
-    public Room createDummyPlayingRoom(String joinCode, String hostName) {
+    public Room createDummyPlayingRoom(JoinCode joinCode, PlayerName hostName) {
         Menu menu = menuRepository.findById(1L).orElseThrow();
-        Room room = new Room(new JoinCode(joinCode), new PlayerName(hostName),
+        Room room = new Room(joinCode, hostName,
                 new SelectedMenu(menu, MenuTemperature.ICE));
         ReflectionTestUtils.setField(room, "roomState", RoomState.PLAYING);
         return roomRepository.save(room);
+    }
+
+    public Room createDummyRoom(String joinCode, String hostName) {
+        return createDummyRoom(new JoinCode(joinCode), new PlayerName(hostName));
+    }
+
+    public Room createDummyPlayingRoom(String joinCode, String hostName) {
+        return createDummyPlayingRoom(new JoinCode(joinCode), new PlayerName(hostName));
     }
 }
 

--- a/backend/src/test/java/coffeeshout/minigame/ui/CardGameIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/minigame/ui/CardGameIntegrationTest.java
@@ -30,7 +30,7 @@ class CardGameIntegrationTest extends WebSocketIntegrationTestSupport {
 
     @BeforeEach
     void setUp(@Autowired RoomRepository roomRepository) throws Exception {
-        joinCode = new JoinCode("A4B2C");
+        joinCode = new JoinCode("A4BX");
         Room room = RoomFixture.호스트_꾹이();
         room.getPlayers().forEach(player -> player.updateReadyState(true));
         host = room.getHost();

--- a/backend/src/test/java/coffeeshout/room/application/DelayedRoomRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/DelayedRoomRemovalServiceTest.java
@@ -34,6 +34,8 @@ class DelayedRoomRemovalServiceTest {
 
     DelayedRoomRemovalService delayedRoomRemovalService;
 
+    JoinCode joinCode;
+
     @BeforeEach
     void setUp() {
         Duration removalDelay = Duration.ofMillis(100);
@@ -43,6 +45,8 @@ class DelayedRoomRemovalServiceTest {
                 removalDelay,
                 roomCommandService
         );
+
+        joinCode = new JoinCode("ABCD");
     }
 
     @Nested
@@ -51,7 +55,6 @@ class DelayedRoomRemovalServiceTest {
         @Test
         @SuppressWarnings("unchecked")
         void 정상적으로_지연_삭제를_스케줄링한다() {
-            JoinCode joinCode = new JoinCode("ABCDE");
             given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
                     .willReturn(scheduledFuture);
 
@@ -63,8 +66,8 @@ class DelayedRoomRemovalServiceTest {
         @Test
         @SuppressWarnings("unchecked")
         void 서로_다른_방은_독립적으로_스케줄링된다() {
-            JoinCode joinCode1 = new JoinCode("ABCDE");
-            JoinCode joinCode2 = new JoinCode("FGHKJ");
+            JoinCode joinCode1 = new JoinCode("ABCD");
+            JoinCode joinCode2 = new JoinCode("FGHK");
             given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
                     .willReturn(scheduledFuture);
 
@@ -81,7 +84,6 @@ class DelayedRoomRemovalServiceTest {
         @Test
         @SuppressWarnings("unchecked")
         void RoomCommandService가_정상_호출된다() {
-            JoinCode joinCode = new JoinCode("ABCDE");
             given(taskScheduler.schedule(any(Runnable.class), any(Instant.class)))
                     .willAnswer(invocation -> {
                         Runnable task = invocation.getArgument(0);
@@ -97,7 +99,6 @@ class DelayedRoomRemovalServiceTest {
         @Test
         @SuppressWarnings("unchecked")
         void RoomCommandService에서_예외_발생해도_안전하게_처리한다() {
-            JoinCode joinCode = new JoinCode("ABCDE");
             willThrow(new RuntimeException("방 삭제 실패"))
                     .given(roomCommandService)
                     .delete(any(JoinCode.class));

--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -2,7 +2,6 @@ package coffeeshout.room.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 
 import coffeeshout.fixture.MenuFixture;
 import coffeeshout.fixture.MiniGameDummy;
@@ -490,18 +489,5 @@ class RoomServiceTest extends ServiceTest {
 
         // then
         assertThat(roomService.roomExists(joinCode.getValue())).isTrue();
-    }
-
-    @Test
-    void 방_생성_시_방_삭제_스케줄러가_호출된다() {
-        // given
-        String hostName = "호스트";
-        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.ICE);
-
-        // when
-        Room room = roomService.createRoom(hostName, selectedMenuRequest);
-
-        // then
-        verify(delayedRoomRemovalService).scheduleRemoveRoom(room.getJoinCode());
     }
 }

--- a/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/application/RoomServiceTest.java
@@ -21,6 +21,7 @@ import coffeeshout.room.domain.menu.SelectedMenu;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.player.Winner;
+import coffeeshout.room.domain.service.JoinCodeGenerator;
 import coffeeshout.room.ui.request.SelectedMenuRequest;
 import coffeeshout.room.ui.response.ProbabilityResponse;
 import java.util.List;
@@ -41,6 +42,9 @@ class RoomServiceTest extends ServiceTest {
 
     @MockitoSpyBean
     DelayedRoomRemovalService delayedRoomRemovalService;
+
+    @Autowired
+    JoinCodeGenerator joinCodeGenerator;
 
     @Test
     void 방을_생성한다() {
@@ -97,7 +101,7 @@ class RoomServiceTest extends ServiceTest {
     @Test
     void 존재하지_않는_조인코드로_입장하면_예외가_발생한다() {
         // given
-        String invalidJoinCode = "ABCDE";
+        String invalidJoinCode = "ABCD";
         String guestName = "게스트";
         SelectedMenuRequest hostSelectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.ICE);
 
@@ -109,31 +113,32 @@ class RoomServiceTest extends ServiceTest {
     @Test
     void 존재하는_방에_입장한다() {
         // given
-        String existingJoinCode = "TEST2";
-        String guestName = "더미게스트";
+        JoinCode existingJoinCode = joinCodeGenerator.generate();
+        PlayerName guestName = new PlayerName("더미게스트");
         SelectedMenuRequest hostSelectedMenuRequest = new SelectedMenuRequest(2L, null, MenuTemperature.ICE);
 
-        testDataHelper.createDummyRoom(existingJoinCode, "더미호스트");
+        testDataHelper.createDummyRoom(existingJoinCode, new PlayerName("더미호스트"));
 
         // when
-        Room room = roomService.enterRoom(existingJoinCode, guestName, hostSelectedMenuRequest);
+        Room room = roomService.enterRoom(existingJoinCode.getValue(), guestName.value(), hostSelectedMenuRequest);
 
         // then
-        assertThat(room.getJoinCode().getValue()).isEqualTo(existingJoinCode);
+        assertThat(room.getJoinCode().getValue()).isEqualTo(existingJoinCode.getValue());
         assertThat(room.getRoomState()).isEqualTo(RoomState.READY);
     }
 
     @Test
     void 게임_중인_방에_입장할_수_없다() {
         // given
-        String existingJoinCode = "TEST2";
-        String guestName = "더미게스트";
+        JoinCode existingJoinCode = joinCodeGenerator.generate();
+        PlayerName guestName = new PlayerName("더미게스트");
         SelectedMenuRequest hostSelectedMenuRequest = new SelectedMenuRequest(2L, null, MenuTemperature.ICE);
 
-        testDataHelper.createDummyPlayingRoom(existingJoinCode, "더미호스트");
+        testDataHelper.createDummyPlayingRoom(existingJoinCode, new PlayerName("더미호스트"));
 
         // when & then
-        assertThatThrownBy(() -> roomService.enterRoom(existingJoinCode, guestName, hostSelectedMenuRequest))
+        assertThatThrownBy(
+                () -> roomService.enterRoom(existingJoinCode.getValue(), guestName.value(), hostSelectedMenuRequest))
                 .isInstanceOf(InvalidArgumentException.class);
     }
 
@@ -184,9 +189,11 @@ class RoomServiceTest extends ServiceTest {
         String joinCode = createdRoom.getJoinCode().getValue();
         roomService.enterRoom(joinCode, "게스트", new SelectedMenuRequest(2L, null, MenuTemperature.ICE));
 
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(3L, null, MenuTemperature.ICE);
+
         // when & then
         assertThatThrownBy(
-                () -> roomService.enterRoom(joinCode, "게스트", new SelectedMenuRequest(3L, null, MenuTemperature.ICE)))
+                () -> roomService.enterRoom(joinCode, "게스트", selectedMenuRequest))
                 .isInstanceOf(InvalidArgumentException.class);
     }
 
@@ -198,9 +205,11 @@ class RoomServiceTest extends ServiceTest {
         Room createdRoom = roomService.createRoom(hostName, hostSelectedMenuRequest);
         String joinCode = createdRoom.getJoinCode().getValue();
 
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(999L, null, MenuTemperature.ICE);
+
         // when & then
         assertThatThrownBy(
-                () -> roomService.enterRoom(joinCode, "게스트", new SelectedMenuRequest(999L, null, MenuTemperature.ICE)))
+                () -> roomService.enterRoom(joinCode, "게스트",selectedMenuRequest))
                 .isInstanceOf(NotExistElementException.class);
     }
 
@@ -245,7 +254,6 @@ class RoomServiceTest extends ServiceTest {
         SelectedMenuRequest initialSelectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.ICE);
         Room createdRoom = roomService.createRoom(hostName, initialSelectedMenuRequest);
         String invalidPlayerName = "없는사람";
-        Long newMenuId = 3L;
 
         // when & then
         assertThatThrownBy(
@@ -345,7 +353,7 @@ class RoomServiceTest extends ServiceTest {
 
         // when & then
         assertThat(roomService.roomExists(joinCode.getValue())).isTrue();
-        assertThat(roomService.roomExists("TRASH")).isFalse();
+        assertThat(roomService.roomExists("TRAS")).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/coffeeshout/room/domain/JoinCodeTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/JoinCodeTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class JoinCodeTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"ABCDE", "A2B2C"})
+    @ValueSource(strings = {"ABCD", "AXBC"})
     void 조인코드는_규칙에_맞게_생성된다(String address) {
         // given
         JoinCode result = new JoinCode(address);
@@ -20,7 +20,7 @@ class JoinCodeTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"ABCDEF", "A1LB2", "#ABCD"})
+    @ValueSource(strings = {"ABCDE", "A1LB2", "#ABCD", "EXSD"})
     void 조인코드가_규칙에_맞지_않는다면_예외를_발생한다(String address) {
         // given
         // when & then

--- a/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/RoomTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class RoomTest {
 
-    private final JoinCode joinCode = new JoinCode("ABCDF");
+    private final JoinCode joinCode = new JoinCode("ABCD");
     private final Roulette roulette = RouletteFixture.고정_끝값_반환();
     private final PlayerName 호스트_한스 = new PlayerName("한스");
     private final PlayerName 게스트_루키 = new PlayerName("루키");

--- a/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
@@ -1,0 +1,125 @@
+package coffeeshout.room.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.fixture.MenuFixture;
+import coffeeshout.global.ServiceTest;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.menu.MenuTemperature;
+import coffeeshout.room.domain.player.PlayerName;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RoomCommandServiceTest extends ServiceTest {
+
+    @Autowired
+    JoinCodeGenerator joinCodeGenerator;
+
+    @Autowired
+    RoomCommandService roomCommandService;
+
+    @Autowired
+    RoomQueryService roomQueryService;
+
+    JoinCode joinCode;
+
+    @BeforeEach
+    void setUp() {
+        joinCode = joinCodeGenerator.generate();
+    }
+
+    @Nested
+    class 방_생성 {
+
+        @Test
+        void 방을_생성한다() {
+            // given
+            PlayerName hostName = new PlayerName("호스트");
+            String qrCodeUrl = "https://example.com/qr";
+
+            // when
+            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, qrCodeUrl);
+
+            // then
+            Room room = roomQueryService.getByJoinCode(joinCode);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(room.getJoinCode()).isEqualTo(joinCode);
+                softly.assertThat(room.getPlayers()).hasSize(1);
+                softly.assertThat(room.getPlayers().get(0).getName()).isEqualTo(hostName);
+                softly.assertThat(room.getPlayers().get(0).getSelectedMenu().menu().getName()).isEqualTo("아메리카노");
+                softly.assertThat(room.getPlayers().get(0).getSelectedMenu().menuTemperature())
+                        .isEqualTo(MenuTemperature.HOT);
+                softly.assertThat(room.getJoinCode().getQrCodeUrl()).isEqualTo(qrCodeUrl);
+            });
+        }
+
+        @Test
+        void 이미_존재하는_조인코드로_방을_생성하면_저장하지_않는다() {
+            // given
+            PlayerName hostName1 = new PlayerName("호스트1");
+            PlayerName hostName2 = new PlayerName("호스트2");
+
+            // when
+            roomCommandService.createRoom(joinCode, hostName1, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr1");
+            roomCommandService.createRoom(joinCode, hostName2, MenuFixture.라떼(), MenuTemperature.ICE, "qr2");
+
+            // then
+            Room room = roomQueryService.getByJoinCode(joinCode);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(room.getPlayers()).hasSize(1);
+                softly.assertThat(room.getPlayers().get(0).getName()).isEqualTo(hostName1);
+            });
+        }
+    }
+
+    @Nested
+    class 게스트_입장 {
+
+        @Test
+        void 게스트가_방에_입장한다() {
+            // given
+            PlayerName hostName = new PlayerName("호스트");
+            PlayerName guestName = new PlayerName("게스트");
+
+            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
+
+            // when
+            Room room = roomCommandService.joinGuest(joinCode, guestName, MenuFixture.라떼(), MenuTemperature.ICE);
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(room.getPlayers()).hasSize(2);
+                softly.assertThat(room.getPlayers().get(1).getName()).isEqualTo(guestName);
+                softly.assertThat(room.getPlayers().get(1).getSelectedMenu().menu().getName()).isEqualTo("라떼");
+                softly.assertThat(room.getPlayers().get(1).getSelectedMenu().menuTemperature())
+                        .isEqualTo(MenuTemperature.ICE);
+            });
+        }
+
+        @Test
+        void 여러_게스트가_순차적으로_방에_입장한다() {
+            // given
+            PlayerName hostName = new PlayerName("호스트");
+            PlayerName guest1 = new PlayerName("게스트1");
+            PlayerName guest2 = new PlayerName("게스트2");
+            PlayerName guest3 = new PlayerName("게스트3");
+
+            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
+
+            // when
+            roomCommandService.joinGuest(joinCode, guest1, MenuFixture.라떼(), MenuTemperature.ICE);
+            roomCommandService.joinGuest(joinCode, guest2, MenuFixture.아이스티(), MenuTemperature.ICE);
+            Room room = roomCommandService.joinGuest(joinCode, guest3, MenuFixture.아메리카노(), MenuTemperature.ICE);
+
+            // then
+            assertThat(room.getPlayers()).hasSize(4);
+            assertThat(room.getPlayers())
+                    .extracting(player -> player.getName().value())
+                    .containsExactly("호스트", "게스트1", "게스트2", "게스트3");
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
@@ -42,10 +42,10 @@ class RoomCommandServiceTest extends ServiceTest {
             String qrCodeUrl = "https://example.com/qr";
 
             // when
-            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, qrCodeUrl);
+            Room room = roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT,
+                    qrCodeUrl);
 
             // then
-            Room room = roomQueryService.getByJoinCode(joinCode);
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(room.getJoinCode()).isEqualTo(joinCode);
                 softly.assertThat(room.getPlayers()).hasSize(1);

--- a/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
@@ -1,11 +1,13 @@
 package coffeeshout.room.domain.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coffeeshout.fixture.MenuFixture;
 import coffeeshout.global.ServiceTest;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.exception.RoomDuplicationException;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.player.PlayerName;
 import org.assertj.core.api.SoftAssertions;
@@ -58,21 +60,18 @@ class RoomCommandServiceTest extends ServiceTest {
         }
 
         @Test
-        void 이미_존재하는_조인코드로_방을_생성하면_저장하지_않는다() {
+        void 이미_존재하는_조인코드로_방을_생성하면_예외가_발생한다() {
             // given
             PlayerName hostName1 = new PlayerName("호스트1");
             PlayerName hostName2 = new PlayerName("호스트2");
 
-            // when
             roomCommandService.createRoom(joinCode, hostName1, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr1");
-            roomCommandService.createRoom(joinCode, hostName2, MenuFixture.라떼(), MenuTemperature.ICE, "qr2");
 
-            // then
-            Room room = roomQueryService.getByJoinCode(joinCode);
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(room.getPlayers()).hasSize(1);
-                softly.assertThat(room.getPlayers().get(0).getName()).isEqualTo(hostName1);
-            });
+            // when & then
+            assertThatThrownBy(() ->
+                    roomCommandService.createRoom(joinCode, hostName2, MenuFixture.라떼(), MenuTemperature.ICE, "qr2"))
+                    .isInstanceOf(RoomDuplicationException.class)
+                    .hasMessage("이미 존재하는 방입니다.");
         }
     }
 

--- a/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
+++ b/backend/src/test/java/coffeeshout/room/domain/service/RoomCommandServiceTest.java
@@ -1,13 +1,11 @@
 package coffeeshout.room.domain.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coffeeshout.fixture.MenuFixture;
 import coffeeshout.global.ServiceTest;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
-import coffeeshout.room.domain.exception.RoomDuplicationException;
 import coffeeshout.room.domain.menu.MenuTemperature;
 import coffeeshout.room.domain.player.PlayerName;
 import org.assertj.core.api.SoftAssertions;
@@ -44,7 +42,7 @@ class RoomCommandServiceTest extends ServiceTest {
             String qrCodeUrl = "https://example.com/qr";
 
             // when
-            Room room = roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT,
+            Room room = roomCommandService.saveIfAbsentRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT,
                     qrCodeUrl);
 
             // then
@@ -60,18 +58,21 @@ class RoomCommandServiceTest extends ServiceTest {
         }
 
         @Test
-        void 이미_존재하는_조인코드로_방을_생성하면_예외가_발생한다() {
+        void 이미_존재하는_조인코드로_방을_생성하면_저장하지_않는다() {
             // given
             PlayerName hostName1 = new PlayerName("호스트1");
             PlayerName hostName2 = new PlayerName("호스트2");
 
-            roomCommandService.createRoom(joinCode, hostName1, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr1");
+            // when
+            roomCommandService.saveIfAbsentRoom(joinCode, hostName1, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr1");
+            roomCommandService.saveIfAbsentRoom(joinCode, hostName2, MenuFixture.라떼(), MenuTemperature.ICE, "qr2");
 
-            // when & then
-            assertThatThrownBy(() ->
-                    roomCommandService.createRoom(joinCode, hostName2, MenuFixture.라떼(), MenuTemperature.ICE, "qr2"))
-                    .isInstanceOf(RoomDuplicationException.class)
-                    .hasMessage("이미 존재하는 방입니다.");
+            // then
+            Room room = roomQueryService.getByJoinCode(joinCode);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(room.getPlayers()).hasSize(1);
+                softly.assertThat(room.getPlayers().get(0).getName()).isEqualTo(hostName1);
+            });
         }
     }
 
@@ -84,7 +85,7 @@ class RoomCommandServiceTest extends ServiceTest {
             PlayerName hostName = new PlayerName("호스트");
             PlayerName guestName = new PlayerName("게스트");
 
-            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
+            roomCommandService.saveIfAbsentRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
 
             // when
             Room room = roomCommandService.joinGuest(joinCode, guestName, MenuFixture.라떼(), MenuTemperature.ICE);
@@ -107,7 +108,7 @@ class RoomCommandServiceTest extends ServiceTest {
             PlayerName guest2 = new PlayerName("게스트2");
             PlayerName guest3 = new PlayerName("게스트3");
 
-            roomCommandService.createRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
+            roomCommandService.saveIfAbsentRoom(joinCode, hostName, MenuFixture.아메리카노(), MenuTemperature.HOT, "qr");
 
             // when
             roomCommandService.joinGuest(joinCode, guest1, MenuFixture.라떼(), MenuTemperature.ICE);

--- a/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
@@ -1,0 +1,116 @@
+package coffeeshout.room.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.service.JoinCodeGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+class RedisJoinCodeRepositoryTest extends ServiceTest {
+
+    @Autowired
+    JoinCodeGenerator joinCodeGenerator;
+
+    @Autowired
+    RedisJoinCodeRepository redisJoinCodeRepository;
+
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+
+    private static final String JOIN_CODE_SET_KEY = "room:joinCodes";
+
+    JoinCode joinCode;
+
+    @BeforeEach
+    void setUp() {
+        joinCode = joinCodeGenerator.generate();
+    }
+
+
+    @AfterEach
+    void tearDown() {
+        // 각 테스트 후 Redis 데이터 정리
+        redisTemplate.delete(JOIN_CODE_SET_KEY);
+    }
+
+    @Test
+    void 조인코드를_저장한다() {
+        // given & then
+        redisJoinCodeRepository.save(joinCode);
+
+        // then
+        Boolean isMember = redisTemplate.opsForSet().isMember(JOIN_CODE_SET_KEY, joinCode.getValue());
+        assertThat(isMember).isTrue();
+    }
+
+    @Test
+    void 저장된_조인코드가_존재하는지_확인한다() {
+        // given
+        redisJoinCodeRepository.save(joinCode);
+
+        // when
+        boolean exists = redisJoinCodeRepository.existsByJoinCode(joinCode);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 저장되지_않은_조인코드는_존재하지_않는다() {
+        // given & then
+
+        boolean exists = redisJoinCodeRepository.existsByJoinCode(joinCode);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @Test
+    void 중복된_조인코드를_저장해도_Set에는_하나만_존재한다() {
+        // given & then
+        redisJoinCodeRepository.save(joinCode);
+        redisJoinCodeRepository.save(joinCode);
+        redisJoinCodeRepository.save(joinCode);
+
+        // then
+        Long size = redisTemplate.opsForSet().size(JOIN_CODE_SET_KEY);
+        assertThat(size).isEqualTo(1);
+    }
+
+    @Test
+    void 여러_조인코드를_저장할_수_있다() {
+        // given
+        JoinCode joinCode1 = new JoinCode("TEST4");
+        JoinCode joinCode2 = new JoinCode("TEST5");
+        JoinCode joinCode3 = new JoinCode("TEST6");
+
+        // when
+        redisJoinCodeRepository.save(joinCode1);
+        redisJoinCodeRepository.save(joinCode2);
+        redisJoinCodeRepository.save(joinCode3);
+
+        // then
+        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode1)).isTrue();
+        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode2)).isTrue();
+        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode3)).isTrue();
+
+        Long size = redisTemplate.opsForSet().size(JOIN_CODE_SET_KEY);
+        assertThat(size).isEqualTo(3);
+    }
+
+    @Test
+    void 저장_시_TTL이_설정된다() {
+        // given & then
+        redisJoinCodeRepository.save(joinCode);
+
+        // then
+        Long ttl = redisTemplate.getExpire(JOIN_CODE_SET_KEY);
+        assertThat(ttl).isNotNull()
+                .isGreaterThan(0);
+    }
+}

--- a/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
@@ -27,7 +27,7 @@ class RedisJoinCodeRepositoryTest extends ServiceTest {
 
     private static final String JOIN_CODE_KEY_PREFIX = "room:joinCode:";
 
-    JoinCode joinCode = new JoinCode("ABCDE");
+    JoinCode joinCode = new JoinCode("ABCD");
 
     @AfterEach
     void tearDown() {

--- a/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/RedisJoinCodeRepositoryTest.java
@@ -5,9 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import coffeeshout.global.ServiceTest;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.service.JoinCodeGenerator;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -25,73 +27,41 @@ class RedisJoinCodeRepositoryTest extends ServiceTest {
 
     private static final String JOIN_CODE_KEY_PREFIX = "room:joinCode:";
 
-    JoinCode joinCode;
-
-    @BeforeEach
-    void setUp() {
-        joinCode = joinCodeGenerator.generate();
-    }
+    JoinCode joinCode = new JoinCode("ABCDE");
 
     @AfterEach
     void tearDown() {
         // 각 테스트 후 Redis 데이터 정리 - 패턴 매칭으로 모든 조인코드 키 삭제
         Set<String> keys = redisTemplate.keys(JOIN_CODE_KEY_PREFIX + "*");
-        if (keys != null && !keys.isEmpty()) {
+        if (!keys.isEmpty()) {
             redisTemplate.delete(keys);
         }
     }
 
     @Test
     void 조인코드를_저장한다() {
-        // given & when
-        redisJoinCodeRepository.save(joinCode);
+        // given
+        // when
+        boolean saved = redisJoinCodeRepository.save(joinCode);
 
         // then
+        assertThat(saved).isTrue();
         String key = JOIN_CODE_KEY_PREFIX + joinCode.getValue();
         Boolean hasKey = redisTemplate.hasKey(key);
         assertThat(hasKey).isTrue();
     }
 
     @Test
-    void 저장된_조인코드가_존재하는지_확인한다() {
+    void 중복된_조인코드를_저장하면_실패한다() {
         // given
-        redisJoinCodeRepository.save(joinCode);
+        boolean firstSave = redisJoinCodeRepository.save(joinCode);
+        assertThat(firstSave).isTrue();
 
-        // when
-        boolean exists = redisJoinCodeRepository.existsByJoinCode(joinCode);
+        // when - 동일한 조인코드로 다시 저장 시도
+        boolean secondSave = redisJoinCodeRepository.save(joinCode);
 
-        // then
-        assertThat(exists).isTrue();
-    }
-
-    @Test
-    void 저장되지_않은_조인코드는_존재하지_않는다() {
-        // given & when
-        boolean exists = redisJoinCodeRepository.existsByJoinCode(joinCode);
-
-        // then
-        assertThat(exists).isFalse();
-    }
-
-    @Test
-    void 여러_조인코드를_저장할_수_있다() {
-        // given
-        JoinCode joinCode1 = joinCodeGenerator.generate();
-        JoinCode joinCode2 = joinCodeGenerator.generate();
-        JoinCode joinCode3 = joinCodeGenerator.generate();
-
-        // when
-        redisJoinCodeRepository.save(joinCode1);
-        redisJoinCodeRepository.save(joinCode2);
-        redisJoinCodeRepository.save(joinCode3);
-
-        // then
-        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode1)).isTrue();
-        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode2)).isTrue();
-        assertThat(redisJoinCodeRepository.existsByJoinCode(joinCode3)).isTrue();
-
-        Set<String> keys = redisTemplate.keys(JOIN_CODE_KEY_PREFIX + "*");
-        assertThat(keys).hasSize(3);
+        // then - 실패해야 함 (SETNX는 키가 이미 존재하면 false 반환)
+        assertThat(secondSave).isFalse();
     }
 
     @Test
@@ -100,9 +70,7 @@ class RedisJoinCodeRepositoryTest extends ServiceTest {
         JoinCode joinCode1 = joinCodeGenerator.generate();
         JoinCode joinCode2 = joinCodeGenerator.generate();
 
-        // when
-        redisJoinCodeRepository.save(joinCode1);
-        redisJoinCodeRepository.save(joinCode2);
+        // when - generate()가 이미 저장까지 함
 
         // then - 각 키마다 TTL이 설정되어 있어야 함
         String key1 = JOIN_CODE_KEY_PREFIX + joinCode1.getValue();
@@ -117,7 +85,9 @@ class RedisJoinCodeRepositoryTest extends ServiceTest {
 
     @Test
     void 저장_시_TTL이_설정된다() {
-        // given & when
+        // given
+
+        // when
         redisJoinCodeRepository.save(joinCode);
 
         // then
@@ -125,5 +95,44 @@ class RedisJoinCodeRepositoryTest extends ServiceTest {
         Long ttl = redisTemplate.getExpire(key);
         assertThat(ttl).isNotNull()
                 .isGreaterThan(0);
+    }
+
+    @Test
+    void SETNX로_원자성이_보장된다() {
+        // given
+
+        // when - 동시에 저장 시도하는 것을 시뮬레이션
+        boolean firstSave = redisJoinCodeRepository.save(joinCode);
+        boolean secondSave = redisJoinCodeRepository.save(joinCode);
+
+        // then - 하나만 성공해야 함
+        assertThat(firstSave).isTrue();
+        assertThat(secondSave).isFalse();
+    }
+
+    @Test
+    void 동시에_여러_스레드가_같은_코드를_저장하면_하나만_성공한다() throws Exception {
+        // given
+
+        int threadCount = 10;
+
+        // when - 10개의 스레드가 동시에 같은 코드를 저장 시도
+        List<CompletableFuture<Boolean>> futures = IntStream.range(0, threadCount)
+                .mapToObj(i -> CompletableFuture.supplyAsync(
+                        () -> redisJoinCodeRepository.save(joinCode)
+                ))
+                .toList();
+
+        // 모든 작업 완료 대기
+        CompletableFuture<Void> allOf = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        allOf.get();
+
+        // then - 성공한 개수는 정확히 1개여야 함
+        long successCount = futures.stream()
+                .map(CompletableFuture::join)
+                .filter(result -> result)
+                .count();
+
+        assertThat(successCount).isEqualTo(1);
     }
 }

--- a/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
@@ -113,7 +113,7 @@ class RoomCreateEventHandlerTest extends ServiceTest {
     }
 
     @Test
-    void 동일_joinCode로_이벤트가_중복_발행되어도_방은_한_번만_생성된다() {
+    void 동일_joinCode로_이벤트가_중복_발행되어도_방은_한_번만_생성되고_스케줄러는_두_번_호출된다() {
         // given
         String hostName = "호스트";
         SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.HOT);
@@ -132,6 +132,9 @@ class RoomCreateEventHandlerTest extends ServiceTest {
 
         // then
         Room room = roomQueryService.getByJoinCode(joinCode);
-        assertThat(room.getPlayers()).hasSize(1); // 호스트 한 명만 존재
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(room.getPlayers()).hasSize(1); // 호스트 한 명만 존재
+        });
+        verify(delayedRoomRemovalService, org.mockito.Mockito.times(2)).scheduleRemoveRoom(joinCode);
     }
 }

--- a/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
@@ -111,4 +111,27 @@ class RoomCreateEventHandlerTest extends ServiceTest {
         Room room = roomQueryService.getByJoinCode(joinCode);
         assertThat(room.getPlayers().get(0).getSelectedMenu().menu().getName()).isEqualTo(customMenuName);
     }
+
+    @Test
+    void 동일_joinCode로_이벤트가_중복_발행되어도_방은_한_번만_생성된다() {
+        // given
+        String hostName = "호스트";
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.HOT);
+        String qrCodeUrl = "https://example.com/qr";
+
+        RoomCreateEvent event = new RoomCreateEvent(
+                hostName,
+                selectedMenuRequest,
+                joinCode.getValue(),
+                qrCodeUrl
+        );
+
+        // when
+        roomCreateEventHandler.handle(event);
+        roomCreateEventHandler.handle(event); // 중복 호출
+
+        // then
+        Room room = roomQueryService.getByJoinCode(joinCode);
+        assertThat(room.getPlayers()).hasSize(1); // 호스트 한 명만 존재
+    }
 }

--- a/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
@@ -113,7 +113,7 @@ class RoomCreateEventHandlerTest extends ServiceTest {
     }
 
     @Test
-    void 동일_joinCode로_이벤트가_중복_발행되어도_방은_한_번만_생성되고_스케줄러는_두_번_호출된다() {
+    void 동일_joinCode로_이벤트가_중복_발행되어도_방은_한_번만_생성된다() {
         // given
         String hostName = "호스트";
         SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.HOT);
@@ -132,9 +132,6 @@ class RoomCreateEventHandlerTest extends ServiceTest {
 
         // then
         Room room = roomQueryService.getByJoinCode(joinCode);
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(room.getPlayers()).hasSize(1); // 호스트 한 명만 존재
-        });
-        verify(delayedRoomRemovalService, org.mockito.Mockito.times(2)).scheduleRemoveRoom(joinCode);
+        assertThat(room.getPlayers()).hasSize(1); // 호스트 한 명만 존재
     }
 }

--- a/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/messaging/handler/RoomCreateEventHandlerTest.java
@@ -1,0 +1,114 @@
+package coffeeshout.room.infra.messaging.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.room.application.DelayedRoomRemovalService;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.event.RoomCreateEvent;
+import coffeeshout.room.domain.menu.MenuTemperature;
+import coffeeshout.room.domain.service.JoinCodeGenerator;
+import coffeeshout.room.domain.service.RoomQueryService;
+import coffeeshout.room.ui.request.SelectedMenuRequest;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+class RoomCreateEventHandlerTest extends ServiceTest {
+
+    @Autowired
+    RoomCreateEventHandler roomCreateEventHandler;
+
+    @Autowired
+    RoomQueryService roomQueryService;
+
+    @Autowired
+    JoinCodeGenerator joinCodeGenerator;
+
+    @MockitoSpyBean
+    DelayedRoomRemovalService delayedRoomRemovalService;
+
+    JoinCode joinCode;
+
+    @BeforeEach
+    void setUp() {
+        joinCode = joinCodeGenerator.generate();
+    }
+
+    @Test
+    void 방_생성_이벤트를_처리하면_방이_생성된다() {
+        // given
+        String hostName = "호스트";
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.HOT);
+        String qrCodeUrl = "https://example.com/qr";
+
+        RoomCreateEvent event = new RoomCreateEvent(
+                hostName,
+                selectedMenuRequest,
+                joinCode.getValue(),
+                qrCodeUrl
+        );
+
+        // when
+        roomCreateEventHandler.handle(event);
+
+        // then
+        Room room = roomQueryService.getByJoinCode(joinCode);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(room.getJoinCode()).isEqualTo(joinCode);
+            softly.assertThat(room.getPlayers()).hasSize(1);
+            softly.assertThat(room.getPlayers().get(0).getName().value()).isEqualTo(hostName);
+            softly.assertThat(room.getPlayers().get(0).getSelectedMenu().menuTemperature())
+                    .isEqualTo(MenuTemperature.HOT);
+            softly.assertThat(room.getJoinCode().getQrCodeUrl()).isEqualTo(qrCodeUrl);
+        });
+    }
+
+    @Test
+    void 방_생성_이벤트_처리_시_방_삭제_스케줄러가_호출된다() {
+        // given
+        String hostName = "호스트";
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(1L, null, MenuTemperature.HOT);
+        String qrCodeUrl = "https://example.com/qr";
+
+        RoomCreateEvent event = new RoomCreateEvent(
+                hostName,
+                selectedMenuRequest,
+                joinCode.getValue(),
+                qrCodeUrl
+        );
+
+        // when
+        roomCreateEventHandler.handle(event);
+
+        // then
+        verify(delayedRoomRemovalService).scheduleRemoveRoom(joinCode);
+    }
+
+    @Test
+    void 커스텀_메뉴로_방_생성_이벤트를_처리할_수_있다() {
+        // given
+        String hostName = "호스트";
+        String customMenuName = "커스텀아메리카노";
+        SelectedMenuRequest selectedMenuRequest = new SelectedMenuRequest(0L, customMenuName, MenuTemperature.ICE);
+        String qrCodeUrl = "https://example.com/qr";
+
+        RoomCreateEvent event = new RoomCreateEvent(
+                hostName,
+                selectedMenuRequest,
+                joinCode.getValue(),
+                qrCodeUrl
+        );
+
+        // when
+        roomCreateEventHandler.handle(event);
+
+        // then
+        Room room = roomQueryService.getByJoinCode(joinCode);
+        assertThat(room.getPlayers().get(0).getSelectedMenu().menu().getName()).isEqualTo(customMenuName);
+    }
+}

--- a/backend/src/test/java/coffeeshout/room/ui/RoomRestControllerTest.java
+++ b/backend/src/test/java/coffeeshout/room/ui/RoomRestControllerTest.java
@@ -37,7 +37,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("RoomRestController 통합 테스트")
 class RoomRestControllerTest {
 
-    private static final String INVALID_JOIN_CODE = "XXXXX";
+    private static final String INVALID_JOIN_CODE = "XXXX";
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/src/test/java/coffeeshout/room/ui/RoomRestControllerTest.java
+++ b/backend/src/test/java/coffeeshout/room/ui/RoomRestControllerTest.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 
 @IntegrationTest
 @AutoConfigureMockMvc
@@ -59,15 +58,10 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest request = new RoomEnterRequest("테스트유저", menuRequest);
 
-            // when & then - 비동기 테스트
-            MvcResult result = mockMvc.perform(post("/rooms")
+            // when & then
+            String response = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String response = mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.joinCode").exists())
                     .andExpect(jsonPath("$.qrCodeUrl").exists())
@@ -87,14 +81,9 @@ class RoomRestControllerTest {
             RoomEnterRequest request = new RoomEnterRequest(null, menuRequest);
 
             // when & then
-            MvcResult result = mockMvc.perform(post("/rooms")
+            mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isBadRequest());
         }
     }
@@ -140,14 +129,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest hostMenuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest createRequest = new RoomEnterRequest("호스트", hostMenuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(createRequest)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -209,14 +193,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest createRequest = new RoomEnterRequest("호스트", menuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(createRequest)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -247,14 +226,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest createRequest = new RoomEnterRequest("호스트", menuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(createRequest)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -303,14 +277,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest request = new RoomEnterRequest("테스트유저", menuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -358,14 +327,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest request = new RoomEnterRequest("호스트", menuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -395,14 +359,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest request = new RoomEnterRequest("호스트", menuRequest);
 
-            MvcResult createResult = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(createResult))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()
@@ -454,14 +413,9 @@ class RoomRestControllerTest {
             SelectedMenuRequest menuRequest = new SelectedMenuRequest(1L, "아메리카노", MenuTemperature.HOT);
             RoomEnterRequest request = new RoomEnterRequest("호스트", menuRequest);
 
-            MvcResult result = mockMvc.perform(post("/rooms")
+            String createResponse = mockMvc.perform(post("/rooms")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(request().asyncStarted())
-                    .andReturn();
-
-            String createResponse = mockMvc.perform(asyncDispatch(result))
                     .andExpect(status().isOk())
                     .andReturn()
                     .getResponse()


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #804

# 🚀 작업 내용

1. 방 생성 처리 방식을 수정하였습니다. 해당 인스턴스에서 먼저 QR 코드 생성 후 먼저 방을 만든 후에 이벤트를 날려서 처리합니다.
2. 이벤트를 받은 서버는 해당 인스턴스에 Room이 있다면 해당 처리를 무시합니다. 
3. 이벤트 Handler에서 성공적으로 처리했다면 (무시한 Room도 성공적으로 처리한 것으로 간주하고 이 때 RoomRemovalDelay가 동작합니다.)
4. JoinCode 4자리로 수정했습니다


# 💬 리뷰 중점사항

중점사항

해결되지 않은 부분은 방 생성 시에 동시에 같은 조인코드가 나오면 데이터 일관성이 깨질 수 있습니다. 이를 해결하기 위해 JoinCodeGenerator 시에는 Redis를 통해서 처리해줘야 할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  - 방 생성 시 QR 코드가 즉시 제공됩니다.
* 개선
  - 방 생성이 동기 처리로 전환되어 응답 속도와 예측 가능성이 향상되었습니다.
  - 중복 방 입장 코드에 대한 원자적 검증으로 충돌이 줄고 안정성이 높아졌습니다.
  - 예약 삭제 동작의 안정성과 오류 로깅이 강화되었습니다.
* 변경
  - 방 입장 코드가 5자리에서 4자리로 변경되었으며 사용 문자가 일부 조정되었습니다. 클라이언트는 새 형식에 맞춘 표시/검증이 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->