### PR TITLE
fix : useTouchInteraction 에서 preventDefault가 안되는 오류

### DIFF
--- a/frontend/src/hooks/useTouchInteraction.ts
+++ b/frontend/src/hooks/useTouchInteraction.ts
@@ -13,22 +13,17 @@ export const useTouchInteraction = ({ onClick, isDisabled = false }: UseTouchTra
   const [touchState, setTouchState] = useState<TouchState>('idle');
   const isTouchDevice = checkIsTouchDevice();
 
-  const handleTouchStart = useCallback(
-    (e: TouchEvent<HTMLButtonElement>) => {
-      if (!isTouchDevice) return;
-      if (isDisabled) return;
+  const handleTouchStart = useCallback(() => {
+    if (!isTouchDevice) return;
+    if (isDisabled) return;
 
-      e.preventDefault();
-      setTouchState('pressing');
-    },
-    [isTouchDevice, isDisabled]
-  );
+    setTouchState('pressing');
+  }, [isTouchDevice, isDisabled]);
 
   const handleTouchEnd = useCallback(
     (e: TouchEvent<HTMLButtonElement>) => {
       if (!isTouchDevice || isDisabled) return;
 
-      e.preventDefault();
       setTouchState('releasing');
       setTimeout(() => {
         setTouchState('idle');


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #799 
# 🚀 작업 내용
## 문제

모바일 기기에서 아래와 같은 오류가 떴었습니다. 
<img width="778" height="55" alt="image" src="https://github.com/user-attachments/assets/4b8acb78-ddc7-4e3d-b97f-43330252f001" />

원인은 모바일 환경에서 브라우저가 최적화를 위해 자동으로 터치 이벤트에 `passive : true` 를 설정해주기 때문입니다. 

## passive : true 속성이란?

['passive : true' mdn 설명](https://developer.mozilla.org/ko/docs/Web/API/EventTarget/addEventListener#passive)
true일 경우, 이 수신기 내에서 [preventDefault()](https://developer.mozilla.org/ko/docs/Web/API/Event/preventDefault)를 절대 호출하지 않을 것임을 나타내는 불리언 값입니다. 이 값이 true인데 수신기가 preventDefault()를 호출하는 경우, 사용자 에이전트는 콘솔에 경고를 출력하는 것 외에 아무런 동작도 하지 않습니다.

-> 브라우저가 이벤트에 preventDefault() 가 있나 살펴보지 않고 기본 이벤트(스크롤)을 바로 실행하게 되서 성능이 대폭 향상됨

## 해결방법 
useTouchInteraction 훅에서 터치이벤트에 혹시 모를 상황을 대비해 preventDefault를 사용하고 있었는데 이를 삭제해 주었습니다. 

# 💬 리뷰 중점사항

중점사항
