### PR TITLE
[fix]  카테고리 아이템이 겹쳐서 보이는 현상

### DIFF
--- a/frontend/src/components/@composition/CafeCategoryCard/CafeCategoryCard.styled.ts
+++ b/frontend/src/components/@composition/CafeCategoryCard/CafeCategoryCard.styled.ts
@@ -12,6 +12,7 @@ export const Container = styled.button<Props>`
   cursor: pointer;
   background-color: ${({ theme }) => theme.color.white};
   width: 100%;
+  min-height: 81px;
 
   ${({ theme, $touchState }) =>
     buttonHoverPress({


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #818 
# 🚀 작업 내용

## 문제
화면이 작을때 카테고리 각 아이템이 겹쳐보이는 현상이 있었습니다
<img width="412" height="548" alt="image" src="https://github.com/user-attachments/assets/283d1399-37d3-4e61-b535-0b5f6fd4b0c3" />

## 해결 방법 
CafeCategoryCard 에 min-height를 적용하여 겹치지 않게 했습니다


https://github.com/user-attachments/assets/72afa64b-ea8a-409a-b9b4-2cb93a9002a5



# 💬 리뷰 중점사항

중점사항
