### PR TITLE
[feat] 초대 코드 모달의 입력 제한 추가

### DIFF
--- a/frontend/src/constants/joinCode.ts
+++ b/frontend/src/constants/joinCode.ts
@@ -1,0 +1,1 @@
+export const JOIN_CODE_LENGTH = 4;

--- a/frontend/src/features/entry/pages/EntryMenuPage/utils/roomApiHelpers.ts
+++ b/frontend/src/features/entry/pages/EntryMenuPage/utils/roomApiHelpers.ts
@@ -1,8 +1,7 @@
 import { Menu, TemperatureOption } from '@/types/menu';
 import { PlayerType } from '@/types/player';
 import { RoomRequest } from '../hooks/useRoomManagement';
-
-const JOIN_CODE_LENGTH = 4;
+import { JOIN_CODE_LENGTH } from '@/constants/joinCode';
 
 export const createRoomRequestBody = (
   playerName: string,

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
@@ -47,7 +47,16 @@ const EnterRoomModal = ({ onClose }: Props) => {
   };
 
   const handleJoinCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setJoinCode(e.target.value.toUpperCase());
+    const value = e.target.value;
+
+    if (
+      value.length > 4 ||
+      (value.length > 0 && !/^[A-Z0-9]$/.test(value[value.length - 1].toUpperCase()))
+    ) {
+      return;
+    }
+
+    setJoinCode(value.toUpperCase());
   };
 
   return (
@@ -55,7 +64,7 @@ const EnterRoomModal = ({ onClose }: Props) => {
       <Paragraph>초대코드를 입력해주세요</Paragraph>
       <Input
         type="text"
-        placeholder="ex) ABCD"
+        placeholder="4자리 영문과 숫자 조합 ex) AB12"
         value={joinCode}
         onClear={() => setJoinCode('')}
         onChange={handleJoinCodeChange}

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
@@ -6,6 +6,7 @@ import { ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import * as S from './EnterRoomModal.styled';
 import useLazyFetch from '@/apis/rest/useLazyFetch';
+import { JOIN_CODE_LENGTH } from '@/constants/joinCode';
 
 type JoinCodeCheckResponse = {
   exist: boolean;
@@ -51,7 +52,7 @@ const EnterRoomModal = ({ onClose }: Props) => {
     const upperValue = value.toUpperCase();
     const lastChar = upperValue.slice(-1);
 
-    const isTooLong = upperValue.length > 4;
+    const isTooLong = upperValue.length > JOIN_CODE_LENGTH;
     const isNotEmpty = upperValue.length > 0;
     const isInvalidChar = isNotEmpty && !/^[A-Z0-9]$/.test(lastChar);
 
@@ -65,7 +66,7 @@ const EnterRoomModal = ({ onClose }: Props) => {
       <Paragraph>초대코드를 입력해주세요</Paragraph>
       <Input
         type="text"
-        placeholder="4자리 영문과 숫자 조합 ex) AB12"
+        placeholder={`${JOIN_CODE_LENGTH}자리 영문과 숫자 조합 ex) AB12`}
         value={joinCode}
         onClear={() => setJoinCode('')}
         onChange={handleJoinCodeChange}

--- a/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
+++ b/frontend/src/features/home/components/EnterRoomModal/EnterRoomModal.tsx
@@ -48,13 +48,14 @@ const EnterRoomModal = ({ onClose }: Props) => {
 
   const handleJoinCodeChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+    const upperValue = value.toUpperCase();
+    const lastChar = upperValue.slice(-1);
 
-    if (
-      value.length > 4 ||
-      (value.length > 0 && !/^[A-Z0-9]$/.test(value[value.length - 1].toUpperCase()))
-    ) {
-      return;
-    }
+    const isTooLong = upperValue.length > 4;
+    const isNotEmpty = upperValue.length > 0;
+    const isInvalidChar = isNotEmpty && !/^[A-Z0-9]$/.test(lastChar);
+
+    if (isTooLong || isInvalidChar) return;
 
     setJoinCode(value.toUpperCase());
   };


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #755 

# 🚀 작업 내용

초대 코드의 길이가 4를 넘지 않도록 하고
최근 입력한 내용이 숫자나 영문이 아니면 state를 업데이트하지 않는 방식으로 수정했습니다.

```tsx
 if (
      value.length > 4 ||
      (value.length > 0 && !/^[A-Z0-9]$/.test(value[value.length - 1].toUpperCase()))
    ) {
      return;
    }
```

# 💬 리뷰 중점사항

중점사항
