### PR TITLE
[fix] 영어 닉네임인 경우 밑에 짤리는 문제 해결

### DIFF
--- a/frontend/src/components/@composition/PlayerCard/PlayerCard.styled.ts
+++ b/frontend/src/components/@composition/PlayerCard/PlayerCard.styled.ts
@@ -11,6 +11,7 @@ export const NameWrapper = styled.div`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: 2;
   }
 `;
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #397 

# 🚀 작업 내용

### 영어 이름 짤리는 이슈

<img width="368" height="155" alt="image" src="https://github.com/user-attachments/assets/351a93b4-af8d-4a32-abdb-5fd9c192ebff" />


### 원인

- 텍스트에 적용되어 있는 `overflow: hidden` 속성 때문에 넘치는 부분이 짤리는 문제였습니다.

```css
h4 {
    white-space: nowrap;
    overflow: hidden; 
    text-overflow: ellipsis;
  }
```

### 해결

- 글씨의 높이를 늘려서 숨겨지지 않도록 했습니다.

```css
line-height: 2;
```

<img width="387" height="99" alt="image" src="https://github.com/user-attachments/assets/26a5e998-ee32-4ea6-ad51-4a385013ee66" />



# 💬 리뷰 중점사항

중점사항
