### PR TITLE
[feat] 카드게임에서 카드 눌렀을 때 효과 추가

### DIFF
--- a/frontend/src/components/@common/Flip/Flip.styled.ts
+++ b/frontend/src/components/@common/Flip/Flip.styled.ts
@@ -2,12 +2,15 @@ import styled from '@emotion/styled';
 
 type FlipperProps = {
   flipped: boolean;
+  $duration?: number;
 };
 
 type FlipWrapperProps = {
   $width?: string;
   $height?: string;
 };
+
+const DEFAULT_DURATION = 0.8;
 
 export const FlipWrapper = styled.div<FlipWrapperProps>`
   position: relative;
@@ -21,7 +24,7 @@ export const Flipper = styled.div<FlipperProps>`
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transition: transform 0.8s ease-in-out;
+  transition: transform ${({ $duration }) => $duration ?? DEFAULT_DURATION}s ease-in-out;
   transform-origin: center;
   transform: ${({ flipped }) => (flipped ? 'rotateY(180deg)' : 'rotateY(0deg)')};
 `;

--- a/frontend/src/components/@common/Flip/Flip.styled.ts
+++ b/frontend/src/components/@common/Flip/Flip.styled.ts
@@ -1,17 +1,22 @@
 import styled from '@emotion/styled';
 
-type Props = {
+type FlipperProps = {
   flipped: boolean;
 };
 
-export const FlipWrapper = styled.div`
+type FlipWrapperProps = {
+  $width?: string;
+  $height?: string;
+};
+
+export const FlipWrapper = styled.div<FlipWrapperProps>`
   position: relative;
   perspective: 1000px;
-  width: 100%;
-  height: 100%;
+  width: ${({ $width }) => $width || '100%'};
+  height: ${({ $height }) => $height || '100%'};
 `;
 
-export const Flipper = styled.div<Props>`
+export const Flipper = styled.div<FlipperProps>`
   position: absolute;
   width: 100%;
   height: 100%;

--- a/frontend/src/components/@common/Flip/Flip.tsx
+++ b/frontend/src/components/@common/Flip/Flip.tsx
@@ -5,11 +5,13 @@ type Props = {
   flipped: boolean;
   initialView: ReactNode;
   flippedView: ReactNode;
+  width?: string;
+  height?: string;
 };
 
-const Flip = ({ flipped, initialView, flippedView }: Props) => {
+const Flip = ({ flipped, initialView, flippedView, width, height }: Props) => {
   return (
-    <S.FlipWrapper>
+    <S.FlipWrapper $width={width} $height={height}>
       <S.Flipper flipped={flipped}>
         <S.InitialView>{initialView}</S.InitialView>
         <S.FlippedView>{flippedView}</S.FlippedView>

--- a/frontend/src/components/@common/Flip/Flip.tsx
+++ b/frontend/src/components/@common/Flip/Flip.tsx
@@ -7,12 +7,13 @@ type Props = {
   flippedView: ReactNode;
   width?: string;
   height?: string;
+  duration?: number;
 };
 
-const Flip = ({ flipped, initialView, flippedView, width, height }: Props) => {
+const Flip = ({ flipped, initialView, flippedView, width, height, duration }: Props) => {
   return (
     <S.FlipWrapper $width={width} $height={height}>
-      <S.Flipper flipped={flipped}>
+      <S.Flipper flipped={flipped} $duration={duration}>
         <S.InitialView>{initialView}</S.InitialView>
         <S.FlippedView>{flippedView}</S.FlippedView>
       </S.Flipper>

--- a/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
+++ b/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
@@ -58,7 +58,7 @@ export const useCardGameHandlers = (
 
         case 'DONE':
           dispatch({ type: 'DONE' });
-          navigate(`/room/${joinCode}/${miniGameType}/result`);
+          // navigate(`/room/${joinCode}/${miniGameType}/result`);
           break;
       }
     },

--- a/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
+++ b/frontend/src/contexts/CardGame/hooks/useCardGameHandlers.ts
@@ -58,7 +58,7 @@ export const useCardGameHandlers = (
 
         case 'DONE':
           dispatch({ type: 'DONE' });
-          // navigate(`/room/${joinCode}/${miniGameType}/result`);
+          navigate(`/room/${joinCode}/${miniGameType}/result`);
           break;
       }
     },

--- a/frontend/src/features/miniGame/cardGame/components/GameCardGrid/GameCardGrid.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/GameCardGrid/GameCardGrid.tsx
@@ -4,6 +4,9 @@ import { Card, CardInfo } from '@/types/miniGame/cardGame';
 import CardBack from '../CardBack/CardBack';
 import CardFront from '../CardFront/CardFront';
 import * as S from './GameCardGrid.styled';
+import Flip from '@/components/@common/Flip/Flip';
+
+import { DESIGN_TOKENS } from '@/constants/design';
 
 type Props = {
   cardInfos: CardInfo[];
@@ -13,30 +16,31 @@ type Props = {
 const GameCardGrid = ({ cardInfos, onCardClick }: Props) => {
   const { getParticipantColorIndex } = useParticipants();
 
-  const renderCard = (cardInfo: CardInfo, index: number) => {
-    if (cardInfo.selected) {
-      const playerColor = cardInfo.playerName
-        ? colorList[getParticipantColorIndex(cardInfo.playerName)]
-        : null;
+  return (
+    <S.Container>
+      {cardInfos.map((cardInfo, index) => {
+        const playerColor = cardInfo.playerName
+          ? colorList[getParticipantColorIndex(cardInfo.playerName)]
+          : null;
 
-      return (
-        <CardFront
-          key={index}
-          card={
-            {
-              type: cardInfo.cardType,
-              value: cardInfo.value,
-            } as Card
-          }
-          playerColor={playerColor}
-        />
-      );
-    }
-
-    return <CardBack key={index} onClick={() => onCardClick(index)} />;
-  };
-
-  return <S.Container>{cardInfos.map(renderCard)}</S.Container>;
+        return (
+          <Flip
+            key={index}
+            flipped={cardInfo.selected}
+            width={DESIGN_TOKENS.card.large.width}
+            height={DESIGN_TOKENS.card.large.height}
+            initialView={<CardBack onClick={() => onCardClick(index)} />}
+            flippedView={
+              <CardFront
+                card={{ type: cardInfo.cardType, value: cardInfo.value } as Card}
+                playerColor={playerColor}
+              />
+            }
+          />
+        );
+      })}
+    </S.Container>
+  );
 };
 
 export default GameCardGrid;

--- a/frontend/src/features/miniGame/cardGame/components/GameCardGrid/GameCardGrid.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/GameCardGrid/GameCardGrid.tsx
@@ -29,6 +29,7 @@ const GameCardGrid = ({ cardInfos, onCardClick }: Props) => {
             flipped={cardInfo.selected}
             width={DESIGN_TOKENS.card.large.width}
             height={DESIGN_TOKENS.card.large.height}
+            duration={0.5}
             initialView={<CardBack onClick={() => onCardClick(index)} />}
             flippedView={
               <CardFront

--- a/frontend/src/features/miniGame/cardGame/components/PlayerCardDisplay/PlayerCardDisplay.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/PlayerCardDisplay/PlayerCardDisplay.tsx
@@ -2,6 +2,8 @@ import { Card, CardGameRound, SelectedCardInfo } from '@/types/miniGame/cardGame
 import CardBack from '../CardBack/CardBack';
 import CardFront from '../CardFront/CardFront';
 import * as S from './PlayerCardDisplay.styled';
+import Flip from '@/components/@common/Flip/Flip';
+import { DESIGN_TOKENS } from '@/constants/design';
 
 type Props = {
   selectedCardInfo: SelectedCardInfo;
@@ -11,21 +13,25 @@ const PlayerCardDisplay = ({ selectedCardInfo }: Props) => {
   const renderPlayerCard = (round: CardGameRound) => {
     const cardInfo = selectedCardInfo[round];
 
-    if (cardInfo.isSelected) {
-      return (
-        <CardFront
-          size="medium"
-          card={
-            {
-              type: cardInfo.type,
-              value: cardInfo.value,
-            } as Card
-          }
-        />
-      );
-    }
-
-    return <CardBack size="medium" disabled={true} />;
+    return (
+      <Flip
+        flipped={cardInfo.isSelected}
+        width={DESIGN_TOKENS.card.medium.width}
+        height={DESIGN_TOKENS.card.medium.height}
+        initialView={<CardBack size="medium" disabled={true} />}
+        flippedView={
+          <CardFront
+            size="medium"
+            card={
+              {
+                type: cardInfo.type,
+                value: cardInfo.value,
+              } as Card
+            }
+          />
+        }
+      />
+    );
   };
 
   return (

--- a/frontend/src/features/miniGame/cardGame/components/PlayerCardDisplay/PlayerCardDisplay.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/PlayerCardDisplay/PlayerCardDisplay.tsx
@@ -18,6 +18,7 @@ const PlayerCardDisplay = ({ selectedCardInfo }: Props) => {
         flipped={cardInfo.isSelected}
         width={DESIGN_TOKENS.card.medium.width}
         height={DESIGN_TOKENS.card.medium.height}
+        duration={0.5}
         initialView={<CardBack size="medium" disabled={true} />}
         flippedView={
           <CardFront


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #725 

# 🚀 작업 내용

Flip 효과를 카드에도 적용하였습니다

https://github.com/user-attachments/assets/e4ca90da-cd43-4460-a5b1-cba090761450




## 변경 사항
1. Flip 컴포넌트를 모든 카드에 적용하면서 Fron/Back 카드를 분리해서 렌더링 해주던 render 함수는 삭제하였습니다
2. Flip 컴포넌트의 width.heigth를 props로 받을 수 있게 하였습니다
3. Flip 컴포넌트의 뒤집히는 시간을 props로 받아 조절할 수 있게 하였습니다. 
# 💬 리뷰 중점사항

중점사항
