### PR TITLE
[feat] 플레이어 퇴장 처리

### DIFF
--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -28,6 +28,7 @@ import { ParticipantSection } from '../components/ParticipantSection/Participant
 import { RouletteSection } from '../components/RouletteSection/RouletteSection';
 import { useParticipantValidation } from '../hooks/useParticipantValidation';
 import * as S from './LobbyPage.styled';
+import { api } from '@/apis/rest/api';
 
 type SectionType = '참가자' | '룰렛' | '미니게임';
 type SectionComponents = Record<SectionType, ReactElement>;
@@ -110,8 +111,14 @@ const LobbyPage = () => {
     }
   }, [playerType, joinCode, send, isConnected]);
 
-  const handleNavigateToHome = () => {
-    navigate('/');
+  const handleNavigateToHome = async () => {
+    try {
+      await api.delete(`/rooms/${joinCode}/players/${myName}`);
+    } catch (error) {
+      console.error('플레이어 퇴장 중 에러 발생:', error);
+    } finally {
+      navigate('/');
+    }
   };
 
   const handleClickGameStartButton = () => {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #643 

# 🚀 작업 내용

**플레이어가 로비에서 '<' 버튼 누르면 방에서 퇴장 처리 되도록 수정했습니다.**

*. 여기서 '방 나가기' 버튼으로 변경되는 디자인은 이전에 의견 나누었던 브랜치인 #840 여기서 처리하도록 할게요!

- api.delete 로 [플레이어 퇴장 API](https://7iwook.notion.site/28920b265277805dbb94ff1809fa0890)를 추가해주었습니다.
- 에러 발생 상황을 대비해서 `console.error`를 찍도록 했습니다. (이 부분은 토스트 굳이 안찍어도 될 것 같아서,, 어차피 강제 퇴장 처리 안되더라도 로비에서 나가면 웹소켓 끊기기 때문에 15초 지연삭제 됩니다.)
- finally에 `navigate('/')`를 넣어주었는데요, 어쨌든 사용자 화면에서는 API가 성공하지 못했더라도 홈으로 돌아가는 것이 올바른 동작이라고 생각했기 때문입니다.