### PR TITLE
[fix] 키보드 이동 버튼 클릭하면 키보드 내려가게 수정

### DIFF
--- a/frontend/src/components/@common/Input/Input.tsx
+++ b/frontend/src/components/@common/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, KeyboardEvent } from 'react';
 import CloseIcon from '../CloseIcon/CloseIcon';
 import * as S from './Input.styled';
 import { useTouchInteraction } from '@/hooks/useTouchInteraction';
@@ -13,10 +13,15 @@ const Input = ({ height = '32px', onClear, value, onChange, ref, ...rest }: Prop
   const { touchState, handleTouchStart, handleTouchEnd } = useTouchInteraction({
     onClick: onClear,
   });
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur();
+    }
+  };
 
   return (
     <S.Container $height={height} $hasValue={hasValue}>
-      <S.Input ref={ref} value={value} onChange={onChange} {...rest} />
+      <S.Input ref={ref} value={value} onChange={onChange} onKeyDown={handleKeyDown} {...rest} />
       <S.ClearButton
         type="button"
         onClick={onClear}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #726 


https://github.com/user-attachments/assets/c7981270-60ff-46ea-8dee-701b6f996245


# 🚀 작업 내용

모바일 웹에서 키보드 이동 버튼은 Enter랑 역할이 똑같다고 하더라고요!
그래서 Input 컴포넌트에 onKeyDown 이벤트를 등록해주고  Enter가 등록되면 e.currentTarget.blur()를 호출했습니다. 

## blur() 호출시 키보드가 내려가는 이유
모바일 브라우저에서 가상 키보드는 <input> 또는 <textarea>에 포커스가 생길 때 자동으로 올라옵니다. 
반대로 포커스가 해제(blur())되면 자동으로 내려갑니다. 
# 💬 리뷰 중점사항

중점사항
