### PR TITLE
[fix] 룰렛이 당첨자 화면 보이기 직전에 원상복구 되는 현상

### DIFF
--- a/frontend/src/features/room/roulette/components/AnimatedRouletteWheel/AnimatedRouletteWheel.tsx
+++ b/frontend/src/features/room/roulette/components/AnimatedRouletteWheel/AnimatedRouletteWheel.tsx
@@ -5,13 +5,13 @@ import { useEffect } from 'react';
 
 type Props = {
   finalRotation: number;
-  isSpinning: boolean;
+  isSpinStarted: boolean;
   startAnimation: boolean;
 };
 
 const ANIMATION_DURATION = 500;
 
-const AnimatedRouletteWheel = ({ finalRotation, isSpinning, startAnimation }: Props) => {
+const AnimatedRouletteWheel = ({ finalRotation, isSpinStarted, startAnimation }: Props) => {
   const { probabilityHistory } = useProbabilityHistory();
 
   const {
@@ -35,7 +35,7 @@ const AnimatedRouletteWheel = ({ finalRotation, isSpinning, startAnimation }: Pr
     <RouletteWheel
       sectors={animatedSectors}
       finalRotation={finalRotation}
-      isSpinning={isSpinning}
+      isSpinStarted={isSpinStarted}
     />
   );
 };

--- a/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
+++ b/frontend/src/features/room/roulette/components/RoulettePlaySection/RoulettePlaySection.tsx
@@ -9,14 +9,14 @@ import Flip from '@/components/@common/Flip/Flip';
 import { useEffect, useState } from 'react';
 
 type Props = {
-  isSpinning: boolean;
+  isSpinStarted: boolean;
   winner: string | null;
   randomAngle: number;
   isProbabilitiesLoading: boolean;
 };
 
 const RoulettePlaySection = ({
-  isSpinning,
+  isSpinStarted,
   winner,
   randomAngle,
   isProbabilitiesLoading,
@@ -24,7 +24,7 @@ const RoulettePlaySection = ({
   const { probabilityHistory } = useProbabilityHistory();
   const [isFlipped, setIsFlipped] = useState(false);
 
-  const shouldComputeFinalRotation = isSpinning && winner;
+  const shouldComputeFinalRotation = isSpinStarted && winner;
   const finalRotation = shouldComputeFinalRotation
     ? calculateFinalRotation({
         finalAngles: convertProbabilitiesToAngles(probabilityHistory.current),
@@ -50,7 +50,7 @@ const RoulettePlaySection = ({
           flippedView={
             <AnimatedRouletteWheel
               finalRotation={finalRotation}
-              isSpinning={isSpinning}
+              isSpinStarted={isSpinStarted}
               startAnimation={isFlipped}
             />
           }

--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/RoulettePlayPage.tsx
@@ -19,7 +19,7 @@ const RoulettePlayPage = () => {
   const { joinCode } = useIdentifier();
   const { playerType } = usePlayerType();
   const [currentView, setCurrentView] = useState<RouletteView>('roulette');
-  const { winner, randomAngle, isSpinning, handleSpinClick, startSpinWithResult } =
+  const { winner, randomAngle, isSpinStarted, handleSpinClick, startSpinWithResult } =
     useRoulettePlay();
   const { probabilityHistory } = useProbabilityHistory();
 
@@ -42,7 +42,7 @@ const RoulettePlayPage = () => {
   const VIEW_COMPONENTS = {
     roulette: (
       <RoulettePlaySection
-        isSpinning={isSpinning}
+        isSpinStarted={isSpinStarted}
         winner={winner}
         randomAngle={randomAngle}
         isProbabilitiesLoading={isProbabilitiesLoading}
@@ -67,7 +67,7 @@ const RoulettePlayPage = () => {
         </S.Container>
       </Layout.Content>
       <Layout.ButtonBar>
-        <Button variant={getButtonVariant(isSpinning, playerType)} onClick={handleSpinClick}>
+        <Button variant={getButtonVariant(isSpinStarted, playerType)} onClick={handleSpinClick}>
           {playerType === 'HOST' ? '룰렛 돌리기' : '대기 중'}
         </Button>
       </Layout.ButtonBar>
@@ -77,8 +77,8 @@ const RoulettePlayPage = () => {
 
 export default RoulettePlayPage;
 
-const getButtonVariant = (isSpinning: boolean, playerType: PlayerType) => {
-  if (isSpinning) return 'disabled';
+const getButtonVariant = (isSpinStarted: boolean, playerType: PlayerType) => {
+  if (isSpinStarted) return 'disabled';
   if (playerType === 'GUEST') return 'loading';
   return 'primary';
 };

--- a/frontend/src/features/room/roulette/pages/RoulettePlayPage/hooks/useRoulettePlay.ts
+++ b/frontend/src/features/room/roulette/pages/RoulettePlayPage/hooks/useRoulettePlay.ts
@@ -10,12 +10,12 @@ const useRoulettePlay = () => {
   const navigate = useNavigate();
   const [winner, setWinner] = useState<string | null>(null);
   const [randomAngle, setRandomAngle] = useState(0);
-  const [isSpinning, setIsSpinning] = useState(false);
+  const [isSpinStarted, setIsSpinStarted] = useState(false);
 
   const startSpinWithResult = (data: RouletteWinnerResponse) => {
     setWinner(data.playerName);
     setRandomAngle(data.randomAngle);
-    setIsSpinning(true);
+    setIsSpinStarted(true);
   };
 
   const handleSpinClick = () => {
@@ -26,18 +26,18 @@ const useRoulettePlay = () => {
     // TODO: 당첨자가 나오지 않았을 때, 에러 처리 방식 정하기
     if (!winner || !winner.trim()) console.warn('당첨자가 추첨되지 않았습니다.');
 
-    if (isSpinning) {
+    if (isSpinStarted) {
       const timer = setTimeout(() => {
         navigate(`/room/${joinCode}/roulette/result`, { state: { winner } });
       }, 5000);
       return () => clearTimeout(timer);
     }
-  }, [isSpinning, winner, navigate, joinCode]);
+  }, [isSpinStarted, winner, navigate, joinCode]);
 
   return {
     winner,
     randomAngle,
-    isSpinning,
+    isSpinStarted,
     handleSpinClick,
     startSpinWithResult,
   };

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.stories.tsx
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.stories.tsx
@@ -12,11 +12,11 @@ export default meta;
 
 export const Interactive: StoryObj<typeof RouletteWheel> = {
   render: () => {
-    const [isSpinning, setIsSpinning] = useState(false);
+    const [isSpinStarted, setIsSpinning] = useState(false);
     const [finalRotation, setFinalRotation] = useState(0);
 
     const handleSpin = () => {
-      if (isSpinning) return;
+      if (isSpinStarted) return;
       setIsSpinning(true);
 
       // 3초 후 스피닝 완료
@@ -36,14 +36,14 @@ export const Interactive: StoryObj<typeof RouletteWheel> = {
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 24 }}>
         <RouletteWheel
           playerProbabilities={mockPlayerProbabilities}
-          isSpinning={isSpinning}
+          isSpinStarted={isSpinStarted}
           finalRotation={finalRotation}
         />
         <div style={{ display: 'flex', gap: 16 }}>
-          <button onClick={handleSpin} disabled={isSpinning}>
-            {isSpinning ? '돌아가는 중...' : '돌리기'}
+          <button onClick={handleSpin} disabled={isSpinStarted}>
+            {isSpinStarted ? '돌아가는 중...' : '돌리기'}
           </button>
-          <button onClick={handleReset} disabled={isSpinning}>
+          <button onClick={handleReset} disabled={isSpinStarted}>
             리셋
           </button>
         </div>
@@ -55,11 +55,11 @@ export const Interactive: StoryObj<typeof RouletteWheel> = {
 
 export const WithFixedRotation: StoryObj<typeof RouletteWheel> = {
   render: () => {
-    const [isSpinning, setIsSpinning] = useState(false);
+    const [isSpinStarted, setIsSpinning] = useState(false);
     const [finalRotation, setFinalRotation] = useState(90);
 
     const handleSpin = () => {
-      if (isSpinning) return;
+      if (isSpinStarted) return;
       setIsSpinning(true);
 
       setTimeout(() => {
@@ -75,12 +75,12 @@ export const WithFixedRotation: StoryObj<typeof RouletteWheel> = {
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 24 }}>
         <RouletteWheel
           playerProbabilities={mockPlayerProbabilities}
-          isSpinning={isSpinning}
+          isSpinStarted={isSpinStarted}
           finalRotation={finalRotation}
         />
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
-          <button onClick={handleSpin} disabled={isSpinning}>
-            {isSpinning ? '돌아가는 중...' : '돌리기'}
+          <button onClick={handleSpin} disabled={isSpinStarted}>
+            {isSpinStarted ? '돌아가는 중...' : '돌리기'}
           </button>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <label>Final Rotation:</label>
@@ -90,7 +90,7 @@ export const WithFixedRotation: StoryObj<typeof RouletteWheel> = {
               max="360"
               value={finalRotation}
               onChange={handleRotationChange}
-              disabled={isSpinning}
+              disabled={isSpinStarted}
             />
             <span>{finalRotation}°</span>
           </div>

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.styled.ts
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.styled.ts
@@ -2,7 +2,7 @@ import { Z_INDEX } from '@/constants/zIndex';
 import styled from '@emotion/styled';
 
 type WrapperProps = {
-  $isSpinning?: boolean;
+  $isSpinStarted?: boolean;
   $finalRotation?: number;
 };
 
@@ -24,8 +24,8 @@ export const Wrapper = styled.div<WrapperProps>`
 
   --final-rotation: ${({ $finalRotation }) => $finalRotation ?? 0}deg;
 
-  ${({ $isSpinning }) =>
-    $isSpinning &&
+  ${({ $isSpinStarted }) =>
+    $isSpinStarted &&
     `
       animation: spin 3s cubic-bezier(0.33, 1, 0.68, 1);
       animation-fill-mode: forwards;

--- a/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
+++ b/frontend/src/features/roulette/components/RouletteWheel/RouletteWheel.tsx
@@ -10,20 +10,20 @@ type Props =
   | {
       sectors: RouletteSector[];
       playerProbabilities?: never;
-      isSpinning?: boolean;
+      isSpinStarted?: boolean;
       finalRotation?: number;
     }
   | {
       sectors?: never;
       playerProbabilities: PlayerProbability[];
-      isSpinning?: boolean;
+      isSpinStarted?: boolean;
       finalRotation?: number;
     };
 
 const RouletteWheel = ({
   sectors,
   playerProbabilities,
-  isSpinning = false,
+  isSpinStarted = false,
   finalRotation = 0,
 }: Props) => {
   const { myName } = useIdentifier();
@@ -39,7 +39,7 @@ const RouletteWheel = ({
   return (
     <S.Container>
       <Pin />
-      <S.Wrapper $isSpinning={isSpinning} $finalRotation={finalRotation}>
+      <S.Wrapper $isSpinStarted={isSpinStarted} $finalRotation={finalRotation}>
         <svg
           width={WHEEL_CONFIG.SIZE}
           height={WHEEL_CONFIG.SIZE}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #807 

# 🚀 작업 내용

https://github.com/user-attachments/assets/a6166e28-995b-4027-9982-195b43d9e07b



룰렛이 당첨자 화면 보이기 직전에 원상복구 되는 현상을 해결했습니다
 
## 문제 원인
원인은 navigate 하기전에 isSpinning을 false로 set해주고 있는 것이였습니다
```js
if (isSpinning) {
      const timer = setTimeout(() => {
       //여기가 문제!
        setIsSpinning(false);
        navigate(`/room/${joinCode}/roulette/result`, { state: { winner } });
      }, 5000);
      return () => clearTimeout(timer);
    }
```

룰렛 애니메이션은 RouletteWheel 컴포넌트에서 처리해주고 있습니다
isSpinning이 true가 되면 3초동안 룰렛을 돌리고 애니메이션 끝난상태를 유지하고 있는데요
isSpinning이 false로 바뀌면 이게 취소되면서 원래 상태로 돌아가는 문제였습니다. 
```js
  ${({ $isSpinning }) =>
    $isSpinning &&
    `
     // 룰렛 돌리기
      animation: spin 3s cubic-bezier(0.33, 1, 0.68, 1);
     // 애니메이션 끝난상태를 유지
      animation-fill-mode: forwards;
    `}
```

## 해결 방법
그래서 isSpinning을 false로 바꾸는 줄을 삭제했습니다!

```js
if (isSpinning) {
      const timer = setTimeout(() => {
        navigate(`/room/${joinCode}/roulette/result`, { state: { winner } });
      }, 5000);
      return () => clearTimeout(timer);
    }
```
## isSpinning -> isSpinStarted 로 네이밍 변경
isSpinning은 초기값이 false이고 호스트가 버튼을 클릭했을때 딱 한번 true로 바뀝니다. 
그리고 룰렛 회전 애니메이션이 끝난후에도 true를 유지해야하기 때문에 isSpinning이라는 네이밍이 어색하다고 느꼈습니다. 
그래서 네이밍을 isSpinStarted라고 변경하였습니다. 

# 💬 리뷰 중점사항

중점사항
