### PR TITLE
[feat] 스켈레톤 컴포넌트 구현 및 적용

### DIFF
--- a/frontend/src/components/@common/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/@common/Skeleton/Skeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import Skeleton from './Skeleton';
 
 const meta = {
-  title: 'Components/Common/Skeleton',
+  title: 'Common/Skeleton',
   component: Skeleton,
   parameters: {
     layout: 'padded',

--- a/frontend/src/components/@common/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/@common/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,189 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import Skeleton from './Skeleton';
+
+const meta = {
+  title: 'Components/Common/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    width: {
+      control: 'text',
+      description: '스켈레톤의 너비 (px 숫자 또는 문자열)',
+    },
+    height: {
+      control: 'text',
+      description: '스켈레톤의 높이 (px 숫자 또는 문자열)',
+    },
+    borderRadius: {
+      control: 'text',
+      description: '스켈레톤의 border radius (px 숫자 또는 문자열)',
+    },
+  },
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    width: '100%',
+    height: '20px',
+    borderRadius: '4px',
+  },
+};
+
+export const Text: Story = {
+  args: {
+    width: '200px',
+    height: '16px',
+    borderRadius: '4px',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '텍스트 로딩을 표현하는 스켈레톤입니다.',
+      },
+    },
+  },
+};
+
+export const Circle: Story = {
+  args: {
+    width: 50,
+    height: 50,
+    borderRadius: '50%',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '원형 아이콘이나 아바타 로딩을 표현하는 스켈레톤입니다.',
+      },
+    },
+  },
+};
+
+export const Button: Story = {
+  args: {
+    width: 120,
+    height: 40,
+    borderRadius: '8px',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '버튼 로딩을 표현하는 스켈레톤입니다.',
+      },
+    },
+  },
+};
+
+export const Card: Story = {
+  args: {
+    width: '300px',
+    height: '200px',
+    borderRadius: '12px',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '카드 컴포넌트 로딩을 표현하는 스켈레톤입니다.',
+      },
+    },
+  },
+};
+
+export const MultipleLines: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '400px' }}>
+      <Skeleton width="100%" height={20} />
+      <Skeleton width="90%" height={20} />
+      <Skeleton width="95%" height={20} />
+      <Skeleton width="85%" height={20} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '여러 줄의 텍스트 로딩을 표현하는 스켈레톤입니다.',
+      },
+    },
+  },
+};
+
+export const ProfileCard: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '16px', padding: '16px' }}>
+      <Skeleton width={60} height={60} borderRadius="50%" />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <Skeleton width="60%" height={18} />
+        <Skeleton width="40%" height={14} />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '프로필 카드 형태의 스켈레톤 조합 예시입니다.',
+      },
+    },
+  },
+};
+
+export const ListItems: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', maxWidth: '500px' }}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div key={index} style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <Skeleton width={40} height={40} borderRadius="8px" />
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            <Skeleton width="70%" height={16} />
+            <Skeleton width="50%" height={12} />
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '리스트 아이템 형태의 스켈레톤 조합 예시입니다.',
+      },
+    },
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'flex-start' }}
+    >
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '14px', color: '#666' }}>Small (12px)</p>
+        <Skeleton width="200px" height={12} />
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '14px', color: '#666' }}>Medium (16px)</p>
+        <Skeleton width="200px" height={16} />
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '14px', color: '#666' }}>Large (20px)</p>
+        <Skeleton width="200px" height={20} />
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '14px', color: '#666' }}>Extra Large (24px)</p>
+        <Skeleton width="200px" height={24} />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '다양한 크기의 스켈레톤입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/components/@common/Skeleton/Skeleton.styled.ts
+++ b/frontend/src/components/@common/Skeleton/Skeleton.styled.ts
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/react';
+
+type Props = {
+  $width: string | number;
+  $height: string | number;
+  $borderRadius: string | number;
+};
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+const formatValue = (value: string | number) => {
+  return typeof value === 'number' ? `${value}px` : value;
+};
+
+export const Container = styled.div<Props>`
+  width: ${({ $width }) => formatValue($width)};
+  height: ${({ $height }) => formatValue($height)};
+  border-radius: ${({ $borderRadius }) => formatValue($borderRadius)};
+  background: linear-gradient(
+    90deg,
+    ${({ theme }) => theme.color.gray[200]} 0%,
+    ${({ theme }) => theme.color.gray[100]} 50%,
+    ${({ theme }) => theme.color.gray[200]} 100%
+  );
+  background-size: 200% 100%;
+  animation: ${shimmer} 1.5s ease-in-out infinite;
+`;

--- a/frontend/src/components/@common/Skeleton/Skeleton.tsx
+++ b/frontend/src/components/@common/Skeleton/Skeleton.tsx
@@ -1,0 +1,13 @@
+import * as S from './Skeleton.styled';
+
+type Props = {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+};
+
+const Skeleton = ({ width = '100%', height = '20px', borderRadius = '4px' }: Props) => {
+  return <S.Container $width={width} $height={height} $borderRadius={borderRadius} />;
+};
+
+export default Skeleton;

--- a/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.stories.tsx
+++ b/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import CafeCategoryCardSkeleton from './CafeCategoryCardSkeleton';
+
+const meta = {
+  title: 'Components/Composition/CafeCategoryCardSkeleton',
+  component: CafeCategoryCardSkeleton,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CafeCategoryCardSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof CafeCategoryCardSkeleton>;
+
+export const Default: Story = {};
+
+export const Multiple: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0' }}>
+      <CafeCategoryCardSkeleton />
+      <CafeCategoryCardSkeleton />
+      <CafeCategoryCardSkeleton />
+      <CafeCategoryCardSkeleton />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: '여러 개의 스켈레톤이 로딩 중일 때의 모습입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.stories.tsx
+++ b/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import CafeCategoryCardSkeleton from './CafeCategoryCardSkeleton';
 
 const meta = {
-  title: 'Components/Composition/CafeCategoryCardSkeleton',
+  title: 'Composition/CafeCategoryCardSkeleton',
   component: CafeCategoryCardSkeleton,
   parameters: {
     layout: 'padded',
@@ -14,21 +14,12 @@ export default meta;
 
 type Story = StoryObj<typeof CafeCategoryCardSkeleton>;
 
-export const Default: Story = {};
-
-export const Multiple: Story = {
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '0' }}>
-      <CafeCategoryCardSkeleton />
-      <CafeCategoryCardSkeleton />
-      <CafeCategoryCardSkeleton />
-      <CafeCategoryCardSkeleton />
-    </div>
-  ),
+export const Default: Story = {
+  render: () => <CafeCategoryCardSkeleton />,
   parameters: {
     docs: {
       description: {
-        story: '여러 개의 스켈레톤이 로딩 중일 때의 모습입니다.',
+        story: '카테고리 카드가 로딩 중일 때의 모습입니다.',
       },
     },
   },

--- a/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.styled.ts
+++ b/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.styled.ts
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
+
+export const Container = styled.div`
+  position: relative;
+  background-color: ${({ theme }) => theme.color.white};
+  width: 100%;
+  min-height: 81px;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 15px 0;
+  border-bottom: 1px solid ${theme.color.gray[200]};
+`;
+
+export const IconWrapper = styled.div`
+  flex-shrink: 0;
+  margin-right: 20px;
+`;
+
+export const TextWrapper = styled.div`
+  flex: 1;
+  min-width: 0;
+  padding-right: 20px;
+`;

--- a/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.tsx
+++ b/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.tsx
@@ -2,8 +2,8 @@ import Skeleton from '@/components/@common/Skeleton/Skeleton';
 import * as S from './CafeCategoryCardSkeleton.styled';
 
 const CafeCategoryCardSkeleton = () => {
-  return (
-    <S.Container>
+  return Array.from({ length: 4 }).map((_, index) => (
+    <S.Container key={index}>
       <S.Content>
         <S.IconWrapper>
           <Skeleton width={50} height={50} borderRadius="50%" />
@@ -13,7 +13,7 @@ const CafeCategoryCardSkeleton = () => {
         </S.TextWrapper>
       </S.Content>
     </S.Container>
-  );
+  ));
 };
 
 export default CafeCategoryCardSkeleton;

--- a/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.tsx
+++ b/frontend/src/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton.tsx
@@ -1,0 +1,19 @@
+import Skeleton from '@/components/@common/Skeleton/Skeleton';
+import * as S from './CafeCategoryCardSkeleton.styled';
+
+const CafeCategoryCardSkeleton = () => {
+  return (
+    <S.Container>
+      <S.Content>
+        <S.IconWrapper>
+          <Skeleton width={50} height={50} borderRadius="50%" />
+        </S.IconWrapper>
+        <S.TextWrapper>
+          <Skeleton width="40%" height={18} />
+        </S.TextWrapper>
+      </S.Content>
+    </S.Container>
+  );
+};
+
+export default CafeCategoryCardSkeleton;

--- a/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.stories.tsx
+++ b/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import GameActionButtonSkeleton from './GameActionButtonSkeleton';
+
+const meta = {
+  title: 'Composition/GameActionButtonSkeleton',
+  component: GameActionButtonSkeleton,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof GameActionButtonSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof GameActionButtonSkeleton>;
+
+export const Default: Story = {
+  render: () => <GameActionButtonSkeleton />,
+  parameters: {
+    docs: {
+      description: {
+        story: '미니게임 버튼 목록이 로딩 중일 때의 모습입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.styled.ts
+++ b/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.styled.ts
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  background-color: ${({ theme }) => theme.color.gray[50]};
+  border-radius: 12px;
+  width: 100%;
+  height: 130px;
+  padding: 20px 18px;
+  margin-bottom: 16px;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+export const DescriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin-top: 12px;
+  gap: 4px;
+  width: 100%;
+`;
+
+export const IconWrapper = styled.div`
+  position: absolute;
+  bottom: 20px;
+  right: 18px;
+`;

--- a/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.tsx
+++ b/frontend/src/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton.tsx
@@ -1,0 +1,25 @@
+import Skeleton from '@/components/@common/Skeleton/Skeleton';
+import * as S from './GameActionButtonSkeleton.styled';
+
+const GameActionButtonSkeleton = () => {
+  return (
+    <>
+      {Array.from({ length: 2 }).map((_, index) => (
+        <S.Container key={index}>
+          <S.ContentWrapper>
+            <Skeleton width="20%" height={24} />
+            <S.DescriptionWrapper>
+              <Skeleton width="70%" height={14} />
+              <Skeleton width="60%" height={14} />
+            </S.DescriptionWrapper>
+          </S.ContentWrapper>
+          <S.IconWrapper>
+            <Skeleton width={50} height={50} borderRadius="30px" />
+          </S.IconWrapper>
+        </S.Container>
+      ))}
+    </>
+  );
+};
+
+export default GameActionButtonSkeleton;

--- a/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.stories.tsx
+++ b/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import MenuListItemSkeleton from './MenuListItemSkeleton';
+
+const meta = {
+  title: 'Composition/MenuListItemSkeleton',
+  component: MenuListItemSkeleton,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MenuListItemSkeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof MenuListItemSkeleton>;
+
+export const Default: Story = {
+  render: () => <MenuListItemSkeleton />,
+  parameters: {
+    docs: {
+      description: {
+        story: '메뉴 리스트가 로딩 중일 때의 모습입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.styled.ts
+++ b/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.styled.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 50px;
+  border-bottom: 1px solid ${({ theme }) => theme.color.gray[200]};
+  padding-left: 16px;
+  background: none;
+`;

--- a/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.tsx
+++ b/frontend/src/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton.tsx
@@ -1,0 +1,12 @@
+import Skeleton from '@/components/@common/Skeleton/Skeleton';
+import * as S from './MenuListItemSkeleton.styled';
+
+const MenuListItemSkeleton = () => {
+  return Array.from({ length: 4 }).map((_, index) => (
+    <S.Container key={index}>
+      <Skeleton width="40%" height={20} />
+    </S.Container>
+  ));
+};
+
+export default MenuListItemSkeleton;

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -45,7 +45,7 @@ const EntryMenuPage = () => {
     handleNavigateToBefore,
   } = useViewNavigation();
 
-  const { categories } = useCategories();
+  const { categories, loading: isCategoriesLoading } = useCategories();
   const { menus } = useMenus(category.value?.id ?? null);
 
   const { proceedToRoom, isLoading: isRoomLoading } = useRoomManagement();
@@ -124,7 +124,11 @@ const EntryMenuPage = () => {
       <Layout.Content>
         <S.Container>
           {currentView === 'selectCategory' ? (
-            <SelectCategory categories={categories} onClickCategory={handleCategorySelect} />
+            <SelectCategory
+              categories={categories}
+              isCategoriesLoading={isCategoriesLoading}
+              onClickCategory={handleCategorySelect}
+            />
           ) : (
             <MenuSelectionLayout
               categorySelection={categorySelection}

--- a/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/EntryMenuPage.tsx
@@ -46,7 +46,7 @@ const EntryMenuPage = () => {
   } = useViewNavigation();
 
   const { categories, loading: isCategoriesLoading } = useCategories();
-  const { menus } = useMenus(category.value?.id ?? null);
+  const { menus, loading: isMenusLoading } = useMenus(category.value?.id ?? null);
 
   const { proceedToRoom, isLoading: isRoomLoading } = useRoomManagement();
 
@@ -95,7 +95,9 @@ const EntryMenuPage = () => {
   };
 
   const viewChildren = {
-    selectMenu: <MenuList menus={menus} onClickMenu={handleMenuSelect} />,
+    selectMenu: (
+      <MenuList menus={menus} isMenusLoading={isMenusLoading} onClickMenu={handleMenuSelect} />
+    ),
     selectTemperature: (
       <SelectTemperature
         temperatureAvailability={temperatureAvailability}

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/MenuList/MenuList.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/MenuList/MenuList.tsx
@@ -1,18 +1,24 @@
 import MenuListItem from '@/components/@common/MenuListItem/MenuListItem';
+import MenuListItemSkeleton from '@/components/@composition/MenuListItemSkeleton/MenuListItemSkeleton';
 import * as S from './MenuList.styled';
 import { Menu } from '@/types/menu';
 
 type Props = {
   menus: Menu[];
+  isMenusLoading: boolean;
   onClickMenu: (menu: Menu) => void;
 };
 
-const MenuList = ({ menus, onClickMenu }: Props) => {
+const MenuList = ({ menus, isMenusLoading, onClickMenu }: Props) => {
   return (
     <S.Container>
-      {menus.map((menu) => (
-        <MenuListItem key={menu.id} text={menu.name} onClick={() => onClickMenu(menu)} />
-      ))}
+      {isMenusLoading ? (
+        <MenuListItemSkeleton />
+      ) : (
+        menus.map((menu) => (
+          <MenuListItem key={menu.id} text={menu.name} onClick={() => onClickMenu(menu)} />
+        ))
+      )}
     </S.Container>
   );
 };

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.tsx
@@ -16,17 +16,19 @@ const SelectCategory = ({ categories, isCategoriesLoading, onClickCategory }: Pr
     <>
       <Headline3>카테고리를 선택해주세요</Headline3>
       <S.CategoryList>
-        {isCategoriesLoading
-          ? Array.from({ length: 4 }).map((_, index) => <CafeCategoryCardSkeleton key={index} />)
-          : categories.map((category, index) => (
-              <CafeCategoryCard
-                key={category.id}
-                imageUrl={category.imageUrl}
-                categoryName={category.name}
-                onClick={() => onClickCategory(category)}
-                color={categoryColorList[index % categoryColorList.length]}
-              />
-            ))}
+        {isCategoriesLoading ? (
+          <CafeCategoryCardSkeleton />
+        ) : (
+          categories.map((category, index) => (
+            <CafeCategoryCard
+              key={category.id}
+              imageUrl={category.imageUrl}
+              categoryName={category.name}
+              onClick={() => onClickCategory(category)}
+              color={categoryColorList[index % categoryColorList.length]}
+            />
+          ))
+        )}
       </S.CategoryList>
     </>
   );

--- a/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.tsx
+++ b/frontend/src/features/entry/pages/EntryMenuPage/components/SelectCategory/SelectCategory.tsx
@@ -1,28 +1,32 @@
 import * as S from './SelectCategory.styled';
 import CafeCategoryCard from '@/components/@composition/CafeCategoryCard/CafeCategoryCard';
+import CafeCategoryCardSkeleton from '@/components/@composition/CafeCategoryCardSkeleton/CafeCategoryCardSkeleton';
 import Headline3 from '@/components/@common/Headline3/Headline3';
 import { CategoryWithColor } from '@/types/menu';
 import { categoryColorList } from '@/constants/color';
 
 type Props = {
   categories: CategoryWithColor[];
+  isCategoriesLoading: boolean;
   onClickCategory: (category: CategoryWithColor) => void;
 };
 
-const SelectCategory = ({ categories, onClickCategory }: Props) => {
+const SelectCategory = ({ categories, isCategoriesLoading, onClickCategory }: Props) => {
   return (
     <>
       <Headline3>카테고리를 선택해주세요</Headline3>
       <S.CategoryList>
-        {categories.map((category, index) => (
-          <CafeCategoryCard
-            key={category.id}
-            imageUrl={category.imageUrl}
-            categoryName={category.name}
-            onClick={() => onClickCategory(category)}
-            color={categoryColorList[index % categoryColorList.length]}
-          />
-        ))}
+        {isCategoriesLoading
+          ? Array.from({ length: 4 }).map((_, index) => <CafeCategoryCardSkeleton key={index} />)
+          : categories.map((category, index) => (
+              <CafeCategoryCard
+                key={category.id}
+                imageUrl={category.imageUrl}
+                categoryName={category.name}
+                onClick={() => onClickCategory(category)}
+                color={categoryColorList[index % categoryColorList.length]}
+              />
+            ))}
       </S.CategoryList>
     </>
   );

--- a/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/MiniGameSection.tsx
@@ -1,5 +1,6 @@
 import useFetch from '@/apis/rest/useFetch';
 import GameActionButton from '@/components/@common/GameActionButton/GameActionButton';
+import GameActionButtonSkeleton from '@/components/@composition/GameActionButtonSkeleton/GameActionButtonSkeleton';
 import SectionTitle from '@/components/@composition/SectionTitle/SectionTitle';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import {
@@ -21,23 +22,25 @@ export const MiniGameSection = ({ selectedMiniGames, handleMiniGameClick }: Prop
     endpoint: '/rooms/minigames',
   });
 
-  if (loading) return <div>로딩 중...</div>;
-
   return (
     <>
       <SectionTitle title="미니게임" description="미니게임을 선택해주세요" />
       <S.Wrapper>
-        {miniGames?.map((miniGame) => (
-          <GameActionButton
-            key={miniGame}
-            isSelected={selectedMiniGames.includes(miniGame)}
-            isDisabled={playerType === 'GUEST'}
-            gameName={MINI_GAME_NAME_MAP[miniGame]}
-            description={MINI_GAME_DESCRIPTION_MAP[miniGame]}
-            onClick={() => handleMiniGameClick(miniGame)}
-            icon={<S.Icon src={MINI_GAME_ICON_MAP[miniGame]} alt={miniGame} />}
-          />
-        ))}
+        {loading ? (
+          <GameActionButtonSkeleton />
+        ) : (
+          miniGames?.map((miniGame) => (
+            <GameActionButton
+              key={miniGame}
+              isSelected={selectedMiniGames.includes(miniGame)}
+              isDisabled={playerType === 'GUEST'}
+              gameName={MINI_GAME_NAME_MAP[miniGame]}
+              description={MINI_GAME_DESCRIPTION_MAP[miniGame]}
+              onClick={() => handleMiniGameClick(miniGame)}
+              icon={<S.Icon src={MINI_GAME_ICON_MAP[miniGame]} alt={miniGame} />}
+            />
+          ))
+        )}
       </S.Wrapper>
     </>
   );


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #718

# 🚀 작업 내용

총 3개의 화면에 적용해줬습니다. (메뉴, 카테고리, 미니게임 목록)
`Skeleton` 컴포넌트를 공통 컴포넌트로 구현하고, 각 페이지에서 사용하는 컴포넌트는 Skeleton을 조합하여 하나의 컴포넌트를 불러오는 방식으로 구현했습니다!

아래는 Slow 4G에서 테스트한 영상입니다.

https://github.com/user-attachments/assets/b60f348f-f849-49b9-a04f-cf062b146f24


# 💬 리뷰 중점사항

중점사항
