### PR TITLE
[refactor] 레이싱 애니메이션 시간 줄이기

### DIFF
--- a/frontend/src/features/miniGame/racingGame/components/RacingLine/RacingLine.styled.ts
+++ b/frontend/src/features/miniGame/racingGame/components/RacingLine/RacingLine.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { RACING_Z_INDEX } from '../../constants/zIndex';
 
-const TRANSITION_DURATION = 300;
+const TRANSITION_DURATION = 100;
 
 type Props = {
   $position: number;
@@ -14,7 +14,7 @@ export const Container = styled.div<Props>`
   width: 30px;
   height: 100%;
   transform: translateX(${({ $position }) => $position}px);
-  transition: transform ${TRANSITION_DURATION}ms ease-in-out;
+  transition: transform ${TRANSITION_DURATION}ms linear;
   z-index: ${RACING_Z_INDEX.LINE};
 `;
 

--- a/frontend/src/features/miniGame/racingGame/components/RacingPlayer/RacingPlayer.styled.ts
+++ b/frontend/src/features/miniGame/racingGame/components/RacingPlayer/RacingPlayer.styled.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { RACING_Z_INDEX } from '../../constants/zIndex';
 
-const TRANSITION_DURATION_MS = 300;
+const TRANSITION_DURATION_MS = 100;
 
 type Props = {
   $isMe: boolean;
@@ -15,7 +15,7 @@ export const Container = styled.div<Props>`
     const relativeX = $position - $myPosition;
     return `translateX(${relativeX}px)`;
   }};
-  transition: transform ${TRANSITION_DURATION_MS}ms ease-in-out;
+  transition: transform ${TRANSITION_DURATION_MS}ms linear;
   z-index: ${RACING_Z_INDEX.PLAYER};
 `;
 

--- a/frontend/src/features/miniGame/racingGame/components/RacingProgressBar/RacingProgressBar.styled.ts
+++ b/frontend/src/features/miniGame/racingGame/components/RacingProgressBar/RacingProgressBar.styled.ts
@@ -7,7 +7,7 @@ type Props = {
   $isMe: boolean;
 };
 
-const FILL_TRANSITION_DURATION = 300;
+const FILL_TRANSITION_DURATION = 100;
 
 export const Container = styled.div`
   width: 100%;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #880 

# 🚀 작업 내용

현재 레이싱 게임에서는 100ms 마다 응답을 받고 있습니다. 이에 맞춰 레이싱 게임 애니메이션 TRANSITION_DURATION 을 100ms 로 바꿔주었습니다. 

# 💬 리뷰 중점사항

중점사항
