### PR TITLE
[fix] 중복 닉네임 유효성 검사 오류

### DIFF
--- a/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
+++ b/frontend/src/features/entry/pages/EntryNamePage/EntryNamePage.tsx
@@ -37,7 +37,7 @@ const EntryNamePage = () => {
     if (playerType === 'GUEST') {
       const response = await checkGuestName();
       if (!response) return;
-      if (!response.exist) {
+      if (response.exist) {
         showToast({
           type: 'error',
           message: '중복된 닉네임이 존재합니다. 새로운 닉네임을 입력해주세요.',


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #890 

# 🚀 작업 내용

중복 닉네임 검사 부분이 반대로 되어있어서 현재 dev에서 EntryNamePage에서 같은 이름이 들어가지고, 다른 이름은 오류가 뜨면서 안들어가지는 이슈가 있었습니다. 이 부분 수정했습니다!