### PR TITLE
[refactor] BlockingTraffic 시 선제적으로 서버 종료하기

### DIFF
--- a/backend/appspec-prod.yml
+++ b/backend/appspec-prod.yml
@@ -15,7 +15,7 @@ files:
 
 # 파일 권한 설정
 permissions:
-  - object: /opt/coffee-shout/appㅠ
+  - object: /opt/coffee-shout/app
     pattern: "**"
     owner: ubuntu
     group: ubuntu

--- a/backend/appspec-prod.yml
+++ b/backend/appspec-prod.yml
@@ -46,15 +46,21 @@ hooks:
       timeout: 300
       runas: ubuntu
 
-  # 애플리케이션 시작 전 검증
+  # 애플리케이션 강제 종료 (Graceful Shutdown 실패 시)
+  ApplicationStop:
+    - location: scripts/application_stop.sh
+      timeout: 60
+      runas: ubuntu
+
+  # 애플리케이션 시작
   ApplicationStart:
     - location: scripts/application_start-prod.sh
       timeout: 600
       runas: ubuntu
 
-  # 애플리케이션 시작 후 상태 검증
-  ApplicationStop:
-    - location: scripts/application_stop.sh
+  # 트래픽 차단 및 Graceful Shutdown
+  BlockTraffic:
+    - location: scripts/block_traffic.sh
       timeout: 300
       runas: ubuntu
 

--- a/backend/appspec-prod.yml
+++ b/backend/appspec-prod.yml
@@ -15,7 +15,7 @@ files:
 
 # 파일 권한 설정
 permissions:
-  - object: /opt/coffee-shout/app
+  - object: /opt/coffee-shout/appㅠ
     pattern: "**"
     owner: ubuntu
     group: ubuntu
@@ -61,7 +61,7 @@ hooks:
   # 트래픽 차단 및 Graceful Shutdown
   BlockTraffic:
     - location: scripts/block_traffic.sh
-      timeout: 300
+      timeout: 360
       runas: ubuntu
 
   # 배포 성공 검증

--- a/backend/scripts/application_stop.sh
+++ b/backend/scripts/application_stop.sh
@@ -1,58 +1,51 @@
 #!/bin/bash
 export PATH="/usr/bin:/bin:$PATH"
 
-echo "=== [APPLICATION_STOP] 커피빵 게임 서버 종료 ==="
+echo "=== [APPLICATION_STOP] 커피빵 게임 서버 강제 종료 ==="
 
 cd /opt/coffee-shout
 
 # ==========================================
-# 1단계: Spring Boot 애플리케이션 종료
+# ApplicationStop 단계: 강제 종료
+# Graceful Shutdown은 BlockTraffic 단계에서 이미 시도됨
+# 이 단계에서는 남아있는 프로세스를 강제로 정리
 # ==========================================
+
 echo ""
-echo "☕ 1. Spring Boot 애플리케이션 종료 중..."
+echo "☕ 1. Spring Boot 애플리케이션 강제 종료 중..."
 
 if [ -f "app/coffee-shout.pid" ]; then
     PID=$(cat app/coffee-shout.pid)
 
     if ps -p $PID > /dev/null 2>&1; then
-        echo "   🛑 Spring Boot 애플리케이션을 안전하게 종료합니다 (PID: $PID)"
-        kill -SIGTERM $PID
+        echo "   ⚠️  Graceful Shutdown이 완료되지 않은 프로세스 발견 (PID: $PID)"
+        echo "   🔫 SIGKILL 신호 전송 - 강제 종료 진행"
+        kill -SIGKILL $PID 2>/dev/null || true
+        sleep 2
 
-        # 최대 360초 (6분) 대기 - Graceful Shutdown 5분 + 여유 1분
-        echo "   ⏳ 정상 종료 대기 중... (최대 6분 - WebSocket Graceful Shutdown 포함)"
-        for _ in {1..360}; do
-            if ! ps -p $PID > /dev/null 2>&1; then
-                echo "   ✅ Spring Boot 애플리케이션이 정상 종료되었습니다"
-                break
-            fi
-            sleep 1
-        done
-
-        # 강제 종료가 필요한 경우
         if ps -p $PID > /dev/null 2>&1; then
-            echo "   ⚠️ 강제 종료를 진행합니다"
-            kill -SIGKILL $PID
-            sleep 2
-
-            if ps -p $PID > /dev/null 2>&1; then
-                echo "   ❌ 애플리케이션 종료 실패"
-            else
-                echo "   ✅ 애플리케이션 강제 종료 완료"
-            fi
+            echo "   ❌ 애플리케이션 강제 종료 실패"
+            exit 1
+        else
+            echo "   ✅ 애플리케이션 강제 종료 완료"
         fi
     else
-        echo "   ℹ️ Spring Boot 애플리케이션이 이미 종료되어 있습니다"
+        echo "   ✅ Spring Boot 애플리케이션이 이미 종료되어 있습니다"
     fi
 
     # PID 파일 제거
     rm -f app/coffee-shout.pid
 else
-    echo "   ℹ️ PID 파일이 없습니다. 애플리케이션이 실행 중이 아닐 수 있습니다"
+    echo "   ℹ️  PID 파일이 없습니다"
 fi
 
 # 포트 8080 사용 프로세스 강제 종료 (혹시 모를 좀비 프로세스)
 JAVA_PROCESS=$(lsof -ti:8080 2>/dev/null || true)
 if [ ! -z "$JAVA_PROCESS" ]; then
-    echo "   🔫 포트 8080을 사용하는 프로세스 강제 종료 (PID: $JAVA_PROCESS)"
+    echo "   🔫 포트 8080을 사용하는 좀비 프로세스 강제 종료 (PID: $JAVA_PROCESS)"
     kill -9 $JAVA_PROCESS 2>/dev/null || true
+    sleep 1
 fi
+
+echo ""
+echo "=== [APPLICATION_STOP] 완료 ==="

--- a/backend/scripts/block_traffic.sh
+++ b/backend/scripts/block_traffic.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+export PATH="/usr/bin:/bin:$PATH"
+
+echo "=== [BLOCK_TRAFFIC] 트래픽 차단 및 Graceful Shutdown ==="
+
+cd /opt/coffee-shout
+
+# ==========================================
+# BlockTraffic 단계: 로드밸런서에서 트래픽 차단 시 실행됨
+# 1. ALB가 타겟 등록 취소 (등록 취소 지연 시간 동안 기존 연결 유지)
+# 2. 이 스크립트에서 SIGTERM으로 Graceful Shutdown 수행
+# 3. ApplicationStop에서 남은 프로세스 강제 종료
+# ==========================================
+
+echo ""
+echo "☕ 1. Spring Boot 애플리케이션 Graceful Shutdown 시작..."
+
+if [ -f "app/coffee-shout.pid" ]; then
+    PID=$(cat app/coffee-shout.pid)
+
+    if ps -p $PID > /dev/null 2>&1; then
+        echo "   🛑 SIGTERM 신호 전송 - Graceful Shutdown 시작 (PID: $PID)"
+        kill -SIGTERM $PID
+
+        # 최대 300초 (5분) 대기
+        echo "   ⏳ Graceful Shutdown 대기 중... (최대 6분 - WebSocket 연결 종료 포함)"
+        for i in {1..300}; do
+            if ! ps -p $PID > /dev/null 2>&1; then
+                echo "   ✅ Spring Boot 애플리케이션이 정상 종료되었습니다 (${i}초 소요)"
+                break
+            fi
+
+            # 매 30초마다 진행 상황 출력
+            if [ $((i % 30)) -eq 0 ]; then
+                echo "   ⏱️  대기 중... (${i}초 경과)"
+            fi
+
+            sleep 1
+        done
+
+        # 여전히 실행 중이면 경고만 출력 (강제 종료는 ApplicationStop에서 수행)
+        if ps -p $PID > /dev/null 2>&1; then
+            echo "   ⚠️  Graceful Shutdown이 완료되지 않았습니다 (6분 초과)"
+            echo "   ℹ️  ApplicationStop 단계에서 강제 종료를 진행합니다"
+        fi
+    else
+        echo "   ℹ️  Spring Boot 애플리케이션이 이미 종료되어 있습니다"
+        # PID 파일 제거
+        rm -f app/coffee-shout.pid
+    fi
+else
+    echo "   ℹ️  PID 파일이 없습니다. 애플리케이션이 실행 중이 아닐 수 있습니다"
+fi
+
+echo ""
+echo "=== [BLOCK_TRAFFIC] 완료 ==="

--- a/backend/scripts/block_traffic.sh
+++ b/backend/scripts/block_traffic.sh
@@ -23,7 +23,7 @@ if [ -f "app/coffee-shout.pid" ]; then
         kill -SIGTERM $PID
 
         # 최대 300초 (5분) 대기
-        echo "   ⏳ Graceful Shutdown 대기 중... (최대 6분 - WebSocket 연결 종료 포함)"
+        echo "   ⏳ Graceful Shutdown 대기 중... (최대 5분 - WebSocket 연결 종료 포함)"
         for i in {1..300}; do
             if ! ps -p $PID > /dev/null 2>&1; then
                 echo "   ✅ Spring Boot 애플리케이션이 정상 종료되었습니다 (${i}초 소요)"
@@ -40,7 +40,7 @@ if [ -f "app/coffee-shout.pid" ]; then
 
         # 여전히 실행 중이면 경고만 출력 (강제 종료는 ApplicationStop에서 수행)
         if ps -p $PID > /dev/null 2>&1; then
-            echo "   ⚠️  Graceful Shutdown이 완료되지 않았습니다 (6분 초과)"
+            echo "   ⚠️  Graceful Shutdown이 완료되지 않았습니다 (5분 초과)"
             echo "   ℹ️  ApplicationStop 단계에서 강제 종료를 진행합니다"
         fi
     else


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #908 

# 🚀 작업 내용

1. BlockingTraffic 시에 Graceful shutdown을 실행하여 서버 종료를 빠르게 처리하는 로직으로 변경했습니다.

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **Chores**
  * 배포 생명주기 프로세스를 재구조화하여 애플리케이션 정지 및 트래픽 관리 신뢰성 향상
  * 애플리케이션 종료 절차 개선으로 배포 안정성 강화
  * 트래픽 차단 및 우아한 종료 메커니즘 도입으로 배포 중 서비스 연속성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->