### PR TITLE
[fix] 미니게임 2개 이상 실행할 수 있도록 로직 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
+++ b/backend/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
@@ -35,14 +35,16 @@ public class MiniGamePersistenceService {
         final MiniGameEntity miniGameEntity = new MiniGameEntity(roomEntity, miniGameType);
         miniGameJpaRepository.save(miniGameEntity);
 
-        room.getPlayers().forEach(player -> {
-            final PlayerEntity playerEntity = new PlayerEntity(
-                    roomEntity,
-                    player.getName().value(),
-                    player.getPlayerType()
-            );
-            playerJpaRepository.save(playerEntity);
-        });
+        if (room.isFirstStarted()) {
+            room.getPlayers().forEach(player -> {
+                final PlayerEntity playerEntity = new PlayerEntity(
+                        roomEntity,
+                        player.getName().value(),
+                        player.getPlayerType()
+                );
+                playerJpaRepository.save(playerEntity);
+            });
+        }
     }
 
     private RoomEntity getRoomEntity(String joinCode) {

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -76,6 +76,7 @@ public class Room {
                 players.getPlayerCount(),
                 calculateMiniGameCount()
         );
+        this.roomState = RoomState.SCORE_BOARD;
         players.adjustProbabilities(miniGameResult, probabilityCalculator);
     }
 
@@ -147,7 +148,7 @@ public class Room {
         state(players.isAllReady(), "모든 플레이어가 준비완료해야합니다.");
         state(players.getPlayerCount() >= 2, "게임을 시작하려면 플레이어가 2명 이상이어야 합니다.");
         state(!miniGames.isEmpty(), "시작할 게임이 없습니다.");
-        state(roomState == RoomState.READY, "게임을 시작할 수 있는 상태가 아닙니다.");
+        state(isPlayableState(), "게임을 시작할 수 있는 상태가 아닙니다.");
 
         Playable currentGame = miniGames.poll();
 
@@ -158,6 +159,18 @@ public class Room {
         finishedGames.add(currentGame);
 
         return currentGame;
+    }
+
+    private boolean isPlayableState() {
+        return roomState == RoomState.READY || roomState == RoomState.ROULETTE;
+    }
+
+    public void updateRouletteState() {
+        this.roomState = RoomState.ROULETTE;
+    }
+
+    public void updateDoneState() {
+        this.roomState = RoomState.DONE;
     }
 
     public void clearMiniGames() {
@@ -197,6 +210,10 @@ public class Room {
 
     public void showRoulette() {
         this.roomState = RoomState.ROULETTE;
+    }
+
+    public boolean isFirstStarted() {
+        return finishedGames.size() == 1;
     }
 
     private boolean hasEnoughPlayers() {

--- a/backend/src/main/java/coffeeshout/room/domain/RoomState.java
+++ b/backend/src/main/java/coffeeshout/room/domain/RoomState.java
@@ -4,6 +4,7 @@ public enum RoomState {
 
     READY,
     PLAYING,
+    SCORE_BOARD,
     ROULETTE,
     DONE,
 }

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RouletteShowEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RouletteShowEventHandler.java
@@ -41,6 +41,8 @@ public class RouletteShowEventHandler implements RoomEventHandler<RouletteShowEv
             
             final RoomStatusResponse response = RoomStatusResponse.of(room.getJoinCode(), room.getRoomState());
 
+            room.updateRouletteState();
+
             messagingTemplate.convertAndSend("/topic/room/" + event.joinCode() + "/roulette",
                     WebSocketResponse.success(response));
             

--- a/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RouletteSpinEventHandler.java
+++ b/backend/src/main/java/coffeeshout/room/infra/messaging/handler/RouletteSpinEventHandler.java
@@ -4,9 +4,12 @@ import coffeeshout.global.lock.RedisLock;
 import coffeeshout.global.ui.WebSocketResponse;
 import coffeeshout.global.websocket.LoggingSimpMessagingTemplate;
 import coffeeshout.room.application.RouletteService;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.event.RoomEventType;
 import coffeeshout.room.domain.event.RouletteSpinEvent;
 import coffeeshout.room.domain.player.Winner;
+import coffeeshout.room.domain.service.RoomQueryService;
 import coffeeshout.room.ui.response.WinnerResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +22,7 @@ public class RouletteSpinEventHandler implements RoomEventHandler<RouletteSpinEv
 
     private final LoggingSimpMessagingTemplate messagingTemplate;
     private final RouletteService rouletteService;
+    private final RoomQueryService roomQueryService;
 
     @Override
     @RedisLock(
@@ -34,6 +38,9 @@ public class RouletteSpinEventHandler implements RoomEventHandler<RouletteSpinEv
                     event.eventId(), event.joinCode(), event.hostName());
 
             final Winner winner = event.winner();
+
+            Room room = roomQueryService.getByJoinCode(new JoinCode(event.joinCode()));
+            room.updateDoneState();
 
             broadcastWinner(event.joinCode(), winner);
             


### PR DESCRIPTION
# ✅ 체크리스트

- [X] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #907

# 🚀 작업 내용

1. 여러 게임을 할 수 있도록 수정했습니다.
2. 게임을 시작할 때 READY상태에서만 실행되는 구조였음. but, 첫 미니게임을 시작하면 PLAYING임 → 게임이 끝나면 SCORE_BOARD, 룰렛 화면으로 가면 ROULETTE이 되도록 수정 → ROULETTE, READY일때만 START_GAME이 되도록 수정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 방 상태 관리 개선
  * 스코어보드 상태 추가

* **버그 수정**
  * 게임 시작 시 불필요한 데이터 저장 최적화
  * 룰렛 및 완료 상태 전환 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->