### PR TITLE
[feat] RedisRoomRepository 기능 확장 및 Room 상태 부분 업데이트 로직 추가

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,11 +9,3 @@ services:
       - type: tmpfs
         target: /data
     command: valkey-server --appendonly yes
-    deploy:
-      resources:
-        limits:
-          cpus: '2'           # t4g.micro vCPU
-          memory: 1G          # t4g.micro 메모리
-        reservations:
-          cpus: '1'
-          memory: 512M

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,4 +9,11 @@ services:
       - type: tmpfs
         target: /data
     command: valkey-server --appendonly yes
-
+    deploy:
+      resources:
+        limits:
+          cpus: '2'           # t4g.micro vCPU
+          memory: 1G          # t4g.micro 메모리
+        reservations:
+          cpus: '1'
+          memory: 512M

--- a/backend/src/main/java/coffeeshout/global/config/RedisConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/RedisConfig.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
@@ -70,6 +71,17 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(serializer);
 
         return redisTemplate;
+    }
+
+    @Bean(name = "redisObjectMapper")
+    public ObjectMapper redisObjectMapper() {
+        return getRedisObjectMapper();
+    }
+    
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 
     private static ObjectMapper getRedisObjectMapper() {

--- a/backend/src/main/java/coffeeshout/room/domain/Room.java
+++ b/backend/src/main/java/coffeeshout/room/domain/Room.java
@@ -53,6 +53,25 @@ public class Room {
         return new Room(joinCode, hostName, selectedMenu);
     }
 
+    // Redis 재구성용 정적 팩토리 메서드
+    public static Room reconstruct(
+            JoinCode joinCode,
+            Players players,
+            Queue<MiniGameType> miniGames,
+            List<MiniGameType> finishedGames,
+            Player host,
+            RoomState roomState
+    ) {
+        Room room = new Room();
+        room.joinCode = joinCode;
+        room.players = players;
+        room.miniGames = miniGames;
+        room.finishedGames = finishedGames;
+        room.host = host;
+        room.roomState = roomState;
+        return room;
+    }
+
     public void joinGuest(PlayerName guestName, SelectedMenu selectedMenu) {
         validateRoomReady();
         validateCanJoin();
@@ -122,6 +141,10 @@ public class Room {
 
     public List<MiniGameType> getAllMiniGames() {
         return List.copyOf(miniGames);
+    }
+
+    public List<MiniGameType> getFinishedGames() {
+        return List.copyOf(finishedGames);
     }
 
     public MiniGameType startNextGame(PlayerName hostName) {

--- a/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
@@ -4,10 +4,10 @@ import static org.springframework.util.Assert.notNull;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.stereotype.Repository;
 
 //@Repository
 public class MemoryRoomRepository implements RoomRepository {
@@ -37,7 +37,33 @@ public class MemoryRoomRepository implements RoomRepository {
     @Override
     public void deleteByJoinCode(JoinCode joinCode) {
         notNull(joinCode, "JoinCode는 null일 수 없습니다.");
-
         rooms.remove(joinCode);
+    }
+
+    @Override
+    public void updatePlayerReadyState(JoinCode joinCode, PlayerName playerName, Boolean isReady) {
+        // 메모리 방식에서는 save()와 동일
+        Room room = rooms.get(joinCode);
+        if (room != null) {
+            room.findPlayer(playerName).updateReadyState(isReady);
+        }
+    }
+
+    @Override
+    public void updatePlayers(JoinCode joinCode, Room room) {
+        // 메모리 방식에서는 save()와 동일
+        save(room);
+    }
+
+    @Override
+    public void updateRoomState(JoinCode joinCode, String state) {
+        // 메모리 방식에서는 객체 참조라 자동 반영됨
+        // 별도 작업 불필요
+    }
+
+    @Override
+    public void updateMiniGames(JoinCode joinCode, Room room) {
+        // 메모리 방식에서는 save()와 동일
+        save(room);
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/repository/RedisRoomRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/RedisRoomRepository.java
@@ -2,57 +2,286 @@ package coffeeshout.room.domain.repository;
 
 import static org.springframework.util.Assert.notNull;
 
+import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.RoomState;
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.player.Players;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import java.util.Queue;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@RequiredArgsConstructor
 public class RedisRoomRepository implements RoomRepository {
 
-    private static final String ROOM_KEY = "room:%s";
+    private static final String ROOM_META_KEY = "room:%s:meta";
+    private static final String ROOM_PLAYERS_KEY = "room:%s:players";
+    private static final String ROOM_MINI_GAMES_KEY = "room:%s:miniGames";
+    private static final String ROOM_FINISHED_GAMES_KEY = "room:%s:finishedGames";
     private static final Duration ROOM_DEFAULT_TTL = Duration.ofHours(1);
-    private static final String FIELD_INFO = "info";
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
+    public RedisRoomRepository(
+            RedisTemplate<String, Object> redisTemplate,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public Optional<Room> findByJoinCode(JoinCode joinCode) {
-        final Object room = redisTemplate.opsForHash().get(String.format(ROOM_KEY, joinCode.getValue()), FIELD_INFO);
-        if (room == null) {
-            return Optional.empty();
-        }
-        if (!(room instanceof Room)) {
-            throw new IllegalStateException("저장된 객체의 타입이 Room이 아닙니다.");
-        }
+        try {
+            String joinCodeValue = joinCode.getValue();
 
-        return Optional.of((Room) room);
+            // 1. meta 정보 읽기
+            Map<Object, Object> metaMap = redisTemplate.opsForHash()
+                    .entries(String.format(ROOM_META_KEY, joinCodeValue));
+
+            if (metaMap.isEmpty()) {
+                return Optional.empty();
+            }
+
+            // 2. players 읽기
+            Map<Object, Object> playersMap = redisTemplate.opsForHash()
+                    .entries(String.format(ROOM_PLAYERS_KEY, joinCodeValue));
+
+            // 3. miniGames 읽기
+            List<Object> miniGamesList = redisTemplate.opsForList()
+                    .range(String.format(ROOM_MINI_GAMES_KEY, joinCodeValue), 0, -1);
+
+            // 4. finishedGames 읽기
+            List<Object> finishedGamesList = redisTemplate.opsForList()
+                    .range(String.format(ROOM_FINISHED_GAMES_KEY, joinCodeValue), 0, -1);
+
+            // 5. Room 객체 재구성
+            return Optional.of(reconstructRoom(joinCode, metaMap, playersMap,
+                    miniGamesList != null ? miniGamesList : new ArrayList<>(),
+                    finishedGamesList != null ? finishedGamesList : new ArrayList<>()));
+
+        } catch (Exception e) {
+            throw new IllegalStateException("Room 조회 중 오류 발생", e);
+        }
     }
 
     @Override
     public boolean existsByJoinCode(JoinCode joinCode) {
-        return redisTemplate.opsForHash().hasKey(String.format(ROOM_KEY, joinCode.getValue()), FIELD_INFO);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(
+                String.format(ROOM_META_KEY, joinCode.getValue())
+        ));
     }
 
     @Override
     public Room save(Room room) {
-        redisTemplate.opsForHash().put(createRedisKey(room.getJoinCode()), FIELD_INFO, room);
-        redisTemplate.expire(String.format(ROOM_KEY, room.getJoinCode().getValue()), ROOM_DEFAULT_TTL);
-        return room;
+        String joinCodeValue = room.getJoinCode().getValue();
+
+        try {
+            // 1. meta 저장
+            saveMetaData(joinCodeValue, room);
+
+            // 2. players 저장
+            savePlayers(joinCodeValue, room);
+
+            // 3. miniGames 저장
+            saveMiniGames(joinCodeValue, room);
+
+            // 4. finishedGames 저장
+            saveFinishedGames(joinCodeValue, room);
+
+            // 5. TTL 설정
+            setExpiration(joinCodeValue);
+
+            return room;
+
+        } catch (Exception e) {
+            throw new IllegalStateException("Room 저장 중 오류 발생", e);
+        }
     }
 
     @Override
     public void deleteByJoinCode(JoinCode joinCode) {
         notNull(joinCode, "JoinCode는 null일 수 없습니다.");
-        redisTemplate.opsForHash().delete(String.format(ROOM_KEY, joinCode.getValue()), FIELD_INFO);
+        String joinCodeValue = joinCode.getValue();
+
+        redisTemplate.delete(String.format(ROOM_META_KEY, joinCodeValue));
+        redisTemplate.delete(String.format(ROOM_PLAYERS_KEY, joinCodeValue));
+        redisTemplate.delete(String.format(ROOM_MINI_GAMES_KEY, joinCodeValue));
+        redisTemplate.delete(String.format(ROOM_FINISHED_GAMES_KEY, joinCodeValue));
     }
 
-    private String createRedisKey(JoinCode joinCode) {
-        return String.format(ROOM_KEY, joinCode.getValue());
+    @Override
+    public void updatePlayerReadyState(JoinCode joinCode, PlayerName playerName, Boolean isReady) {
+        try {
+            String playersKey = String.format(ROOM_PLAYERS_KEY, joinCode.getValue());
+            String playerJson = (String) redisTemplate.opsForHash().get(playersKey, playerName.value());
+
+            if (playerJson != null) {
+                Player player = objectMapper.readValue(playerJson, Player.class);
+                player.updateReadyState(isReady);
+
+                redisTemplate.opsForHash().put(
+                        playersKey,
+                        playerName.value(),
+                        objectMapper.writeValueAsString(player)
+                );
+
+                redisTemplate.expire(playersKey, ROOM_DEFAULT_TTL);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Player ready 상태 업데이트 중 오류", e);
+        }
+    }
+
+    @Override
+    public void updatePlayers(JoinCode joinCode, Room room) {
+        savePlayers(joinCode.getValue(), room);
+        redisTemplate.expire(
+                String.format(ROOM_PLAYERS_KEY, joinCode.getValue()),
+                ROOM_DEFAULT_TTL
+        );
+    }
+
+    @Override
+    public void updateRoomState(JoinCode joinCode, String state) {
+        String metaKey = String.format(ROOM_META_KEY, joinCode.getValue());
+        redisTemplate.opsForHash().put(metaKey, "state", state);
+        redisTemplate.expire(metaKey, ROOM_DEFAULT_TTL);
+    }
+
+    @Override
+    public void updateMiniGames(JoinCode joinCode, Room room) {
+        saveMiniGames(joinCode.getValue(), room);
+        saveFinishedGames(joinCode.getValue(), room);
+
+        redisTemplate.expire(
+                String.format(ROOM_MINI_GAMES_KEY, joinCode.getValue()),
+                ROOM_DEFAULT_TTL
+        );
+        redisTemplate.expire(
+                String.format(ROOM_FINISHED_GAMES_KEY, joinCode.getValue()),
+                ROOM_DEFAULT_TTL
+        );
+    }
+
+    private void saveMetaData(String joinCodeValue, Room room) {
+        String metaKey = String.format(ROOM_META_KEY, joinCodeValue);
+
+        redisTemplate.opsForHash().put(metaKey, "hostName", room.getHost().getName().value());
+        redisTemplate.opsForHash().put(metaKey, "state", room.getRoomState().name());
+
+        if (room.getJoinCode().getQrCodeUrl() != null) {
+            redisTemplate.opsForHash().put(metaKey, "qrCodeUrl", room.getJoinCode().getQrCodeUrl());
+        }
+    }
+
+    private void savePlayers(String joinCodeValue, Room room) {
+        String playersKey = String.format(ROOM_PLAYERS_KEY, joinCodeValue);
+
+        // 기존 players 삭제
+        redisTemplate.delete(playersKey);
+
+        // 새로운 players 저장
+        for (Player player : room.getPlayers()) {
+            try {
+                redisTemplate.opsForHash().put(
+                        playersKey,
+                        player.getName().value(),
+                        objectMapper.writeValueAsString(player)
+                );
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Player 직렬화 중 오류", e);
+            }
+        }
+    }
+
+    private void saveMiniGames(String joinCodeValue, Room room) {
+        String miniGamesKey = String.format(ROOM_MINI_GAMES_KEY, joinCodeValue);
+
+        // 기존 miniGames 삭제
+        redisTemplate.delete(miniGamesKey);
+
+        // 새로운 miniGames 저장
+        for (MiniGameType gameType : room.getAllMiniGames()) {
+            redisTemplate.opsForList().rightPush(miniGamesKey, gameType.name());
+        }
+    }
+
+    private void saveFinishedGames(String joinCodeValue, Room room) {
+        String finishedGamesKey = String.format(ROOM_FINISHED_GAMES_KEY, joinCodeValue);
+
+        // 기존 finishedGames 삭제
+        redisTemplate.delete(finishedGamesKey);
+
+        // 새로운 finishedGames 저장
+        for (MiniGameType gameType : room.getFinishedGames()) {
+            redisTemplate.opsForList().rightPush(finishedGamesKey, gameType.name());
+        }
+    }
+
+    private void setExpiration(String joinCodeValue) {
+        redisTemplate.expire(String.format(ROOM_META_KEY, joinCodeValue), ROOM_DEFAULT_TTL);
+        redisTemplate.expire(String.format(ROOM_PLAYERS_KEY, joinCodeValue), ROOM_DEFAULT_TTL);
+        redisTemplate.expire(String.format(ROOM_MINI_GAMES_KEY, joinCodeValue), ROOM_DEFAULT_TTL);
+        redisTemplate.expire(String.format(ROOM_FINISHED_GAMES_KEY, joinCodeValue), ROOM_DEFAULT_TTL);
+    }
+
+    private Room reconstructRoom(
+            JoinCode joinCode,
+            Map<Object, Object> metaMap,
+            Map<Object, Object> playersMap,
+            List<Object> miniGamesList,
+            List<Object> finishedGamesList
+    ) {
+        try {
+            // Players 재구성
+            Players players = new Players();
+            for (Map.Entry<Object, Object> entry : playersMap.entrySet()) {
+                Player player = objectMapper.readValue((String) entry.getValue(), Player.class);
+                players.join(player);
+            }
+
+            // Host 설정
+            String hostName = (String) metaMap.get("hostName");
+            Player host = players.getPlayer(new PlayerName(hostName));
+
+            // RoomState 설정
+            RoomState roomState = RoomState.valueOf((String) metaMap.get("state"));
+
+            // MiniGames 재구성
+            Queue<MiniGameType> miniGames = new LinkedList<>();
+            for (Object gameObj : miniGamesList) {
+                miniGames.add(MiniGameType.valueOf((String) gameObj));
+            }
+
+            // FinishedGames 재구성
+            List<MiniGameType> finishedGames = new ArrayList<>();
+            for (Object gameObj : finishedGamesList) {
+                finishedGames.add(MiniGameType.valueOf((String) gameObj));
+            }
+
+            // QR Code URL 설정
+            if (metaMap.containsKey("qrCodeUrl")) {
+                joinCode.assignQrCodeUrl((String) metaMap.get("qrCodeUrl"));
+            }
+
+            // Room 재구성
+            return Room.reconstruct(joinCode, players, miniGames, finishedGames, host, roomState);
+
+        } catch (Exception e) {
+            throw new IllegalStateException("Room 재구성 중 오류 발생", e);
+        }
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/repository/RoomRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/RoomRepository.java
@@ -2,6 +2,7 @@ package coffeeshout.room.domain.repository;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
 import java.util.Optional;
 
 public interface RoomRepository {
@@ -13,4 +14,13 @@ public interface RoomRepository {
     Room save(Room room);
 
     void deleteByJoinCode(JoinCode joinCode);
+    
+    // 부분 업데이트용 메서드들
+    void updatePlayerReadyState(JoinCode joinCode, PlayerName playerName, Boolean isReady);
+    
+    void updatePlayers(JoinCode joinCode, Room room);
+    
+    void updateRoomState(JoinCode joinCode, String state);
+    
+    void updateMiniGames(JoinCode joinCode, Room room);
 }

--- a/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
+++ b/backend/src/main/java/coffeeshout/room/domain/service/RoomCommandService.java
@@ -2,6 +2,7 @@ package coffeeshout.room.domain.service;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.repository.RoomRepository;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,22 @@ public class RoomCommandService {
 
     public void delete(@NonNull JoinCode joinCode) {
         roomRepository.deleteByJoinCode(joinCode);
+    }
+    
+    // 부분 업데이트 메서드들
+    public void updatePlayerReadyState(JoinCode joinCode, PlayerName playerName, Boolean isReady) {
+        roomRepository.updatePlayerReadyState(joinCode, playerName, isReady);
+    }
+    
+    public void updatePlayers(JoinCode joinCode, Room room) {
+        roomRepository.updatePlayers(joinCode, room);
+    }
+    
+    public void updateRoomState(JoinCode joinCode, String state) {
+        roomRepository.updateRoomState(joinCode, state);
+    }
+    
+    public void updateMiniGames(JoinCode joinCode, Room room) {
+        roomRepository.updateMiniGames(joinCode, room);
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [ ] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

- `RedisRoomRepository` 리팩토링 및 Redis 키 구조 변경
  - 방 메타데이터, 플레이어, 미니게임 정보를 별도 키로 분리 저장
- Room 저장 및 조회 로직 확장
  - `Room.reconstruct`로 Redis 상태에서 Room 객체 재구성 지원
  - `saveMetaData`, `savePlayers`, `saveMiniGames` 등 세부 저장 메서드 추가
- Room 상태 부분 업데이트 로직 추가
  - `updatePlayerReadyState`, `updatePlayers`, `updateRoomState`, `updateMiniGames` 지원
  - 전체 저장 대신 필요한 부분만 갱신 가능

# 💬 리뷰 중점사항

중점사항
