### PR TITLE
[fix] 참여코드 기반 조회 시 가장 최근 room 찾을 수 있도록 수정

### DIFF
--- a/backend/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
+++ b/backend/src/main/java/coffeeshout/minigame/application/MiniGamePersistenceService.java
@@ -48,7 +48,7 @@ public class MiniGamePersistenceService {
     }
 
     private RoomEntity getRoomEntity(String joinCode) {
-        return roomJpaRepository.findByJoinCode(joinCode)
+        return roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(joinCode)
                 .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다: " + joinCode));
     }
 }

--- a/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
+++ b/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
@@ -46,7 +46,7 @@ public class MiniGameResultSaveEventListener {
             leaseTime = 5000
     )
     public void handle(MiniGameFinishedEvent event) {
-        final RoomEntity roomEntity = roomJpaRepository.findByJoinCode(event.joinCode())
+        final RoomEntity roomEntity = roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(event.joinCode())
                 .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다: " + event.joinCode()));
         final MiniGameType miniGameType = MiniGameType.valueOf(event.miniGameType());
 

--- a/backend/src/main/java/coffeeshout/room/application/RouletteService.java
+++ b/backend/src/main/java/coffeeshout/room/application/RouletteService.java
@@ -26,7 +26,7 @@ public class RouletteService {
     public void updateRoomStatusToRoulette(String joinCode) {
         final RoomEntity roomEntity = getRoomEntity(joinCode);
         roomEntity.updateRoomStatus(RoomState.ROULETTE);
-        
+
         log.info("RoomEntity 상태 업데이트 완료: joinCode={}, status=ROULETTE", joinCode);
     }
 
@@ -53,7 +53,7 @@ public class RouletteService {
     }
 
     private RoomEntity getRoomEntity(String joinCode) {
-        return roomJpaRepository.findByJoinCode(joinCode)
+        return roomJpaRepository.findFirstByJoinCodeOrderByCreatedAtDesc(joinCode)
                 .orElseThrow(() -> new IllegalArgumentException("RoomEntity를 찾을 수 없습니다: " + joinCode));
     }
 

--- a/backend/src/main/java/coffeeshout/room/infra/persistence/RoomJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/persistence/RoomJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.repository.Repository;
 public interface RoomJpaRepository extends Repository<RoomEntity, Long> {
     RoomEntity save(RoomEntity roomEntity);
 
-    Optional<RoomEntity> findByJoinCode(String joinCode);
+    Optional<RoomEntity> findFirstByJoinCodeOrderByCreatedAtDesc(String joinCode);
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #934

# 🚀 작업 내용

1. findByJoinCode -> findFirstByJoinCodeOrderByCreatedAtDesc

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동일한 참여 코드를 가진 여러 방이 존재할 경우, 가장 최근에 생성된 방을 선택하도록 개선했습니다. 이를 통해 방 선택의 일관성과 정확성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->