### PR TITLE
[design] 룰렛 화면 중앙으로 보이게 하기

### DIFF
--- a/frontend/src/features/room/lobby/components/RouletteSection/RouletteSection.styled.ts
+++ b/frontend/src/features/room/lobby/components/RouletteSection/RouletteSection.styled.ts
@@ -15,7 +15,7 @@ export const IconButtonWrapper = styled.div`
 export const RouletteWheelWrapper = styled.div`
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   flex: 1;
-  padding-top: 6rem;
+  margin-bottom: calc(1rem + 42px);
 `;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #906 

# 🚀 작업 내용

토글바의 높이 42px + 토글바의 margin-botton : 1rem 을 합쳐서 룰렛 래퍼에 margin-bottom을 주었습니다. 
```css
 margin-bottom: calc(1rem + 42px);
```

<img width="380" height="665" alt="image" src="https://github.com/user-attachments/assets/d77621eb-2dc8-47dc-a7c4-fb8b38cd9c62" />

# 💬 리뷰 중점사항

중점사항
