### PR TITLE
[fix] 카드게임 재구독 방지

### DIFF
--- a/frontend/src/contexts/CardGame/hooks/useSelectedCard.ts
+++ b/frontend/src/contexts/CardGame/hooks/useSelectedCard.ts
@@ -20,18 +20,20 @@ export const useSelectedCard = (myName: string) => {
       const myCardInfo = cardInfoMessages.find((card) => card.playerName === myName);
       if (!myCardInfo) return;
 
-      if (shouldCheckAlreadySelected && selectedCardInfo[round].isSelected) return;
+      setSelectedCardInfo((prev) => {
+        if (shouldCheckAlreadySelected && prev[round].isSelected) return prev;
 
-      setSelectedCardInfo((prev) => ({
-        ...prev,
-        [round]: {
-          isSelected: true,
-          type: myCardInfo.cardType,
-          value: myCardInfo.value,
-        },
-      }));
+        return {
+          ...prev,
+          [round]: {
+            isSelected: true,
+            type: myCardInfo.cardType,
+            value: myCardInfo.value,
+          },
+        };
+      });
     },
-    [myName, selectedCardInfo]
+    [myName]
   );
 
   return {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #967 
- close #962 

# 🚀 작업 내용

## 문제 상황
카드 게임에서 카드를 선택할 때, CardGameProvider가 구독 중인 토픽이 재구독되는 현상이 발생했습니다.
이로 인해 다른 사용자가 카드를 클릭했을 때 전달되는 브로드캐스트 응답이 재구독 과정에서 유실되는 문제가 생겼습니다.

결과적으로, 여러 사용자가 동시에 카드를 뒤집을 경우 재구독이 발생하면서 다른 사용자의 카드 선택 정보가 정상적으로 업데이트되지 않는 상황이 있었습니다.

## 카드게임에서 재구독이 발생했던 이유
- useSelectedCard 훅의 updateSelectedCardInfo 함수가 selectedCardInfo 상태를 의존성 배열에 포함하고 있었습니다.
- 따라서, 카드 선택 시 selectedCardInfo 상태가 변경되면 → updateSelectedCardInfo 함수가 재생성 → handleCardGameState 함수가 재생성 → useWebSocketSubscription이 재구독

## 해결 방안

선택한 카드가 이미 다른 사람에 의해 선택된 카드이거나, 해당 사용자가 이미 다른 카드를 선택한 경우를 판별하는 조건문을 setSelectedCardInfo 내부로 넣어주었습니다.
대신 selectedCardInfo 이 상태를 그대로 사용하는 것이 아닌, prev 상태로 가져와서 검증해주었습니다.


## 결론

구독을 처리하는 handler 함수를 useCallback으로 감쌀 때는, 의존성 배열에 어떤 값을 넣을지 신중하게 결정하자.