### PR TITLE
[fix] 빈 응답 파싱 오류

### DIFF
--- a/frontend/src/apis/rest/apiRequest.ts
+++ b/frontend/src/apis/rest/apiRequest.ts
@@ -89,7 +89,12 @@ export const apiRequest = async <T, TData>(
         return {} as T;
       }
 
-      return await response.json();
+      const text = await response.text();
+      if (!text) {
+        return {} as T;
+      }
+
+      return JSON.parse(text);
     } catch (error) {
       if (retryCount < retry.count) {
         console.warn(`재시도 중 (${retryCount + 1}/${retry.count})`);


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #978 

# 🚀 작업 내용
빈 응답이 올시 파싱을 하지 않고 빈 객체를 반환하도록 했습니다.

Response 객체의 body는 한 번만 읽을 수 있는 스트림(stream)이여서 `response.text(), response.json(), response.blob() `등 본문을 소비하는 메서드는 단 한 번만 호출 가능합니다.

따라서  response.json() 을 다시 쓸수 없어서 JSON.parse로 변환하도록 했습니다. 
```js
      const text = await response.text();
      if (!text) {
        return {} as T;
      }

      return JSON.parse(text);
```

# 💬 리뷰 중점사항

중점사항
