### PR TITLE
[chore] buildspec 린트 및 테스트 검증 로직 추가

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -6,7 +6,12 @@ phases:
       nodejs: 22
     commands:
       - cd frontend
-      - npm install
+      - npm ci
+
+  pre_build:
+    commands:
+      - npm run lint
+      - npm run test:jest
 
   build:
     commands:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #984 

# 🚀 작업 내용

현재 CodeBuild에서 테스트와 린트 검증 없이 빌드만 하고 있습니다.

물론, frontend-ci.yml을 통해, PR 생성 및 업데이트 하는 과정에서 린트와 테스트 검증을 진행하고 있지만, 

만약 PR을 올리지 않고 직접 dev, prod에 직접 push 할 경우에는 린트와 테스트 검증 없이 바로 build되어 배포됩니다.
이렇게 되면, 제대로 된 코드 품질 검증이 불가능하다고 판단하였고, 

이에 따라, buildspec.yml에도 테스트와 린트 검증 로직을 추가하고자 했습니다.

---

추가로, `npm install` 을 `npm ci` 로 변경해주었습니다.
두 가지 차이점을 비교하여 변경한 이유를 설명드리겠습니다.

### `npm install`

**동작 방식:**
1. `package.json`을 읽음
2. `package-lock.json`이 있으면 참고하되, **충돌 시 업데이트 가능**
3. `node_modules`가 이미 있으면 **병합/업데이트**
4. `package-lock.json` 수정 가능

**특징:**
- 로컬 개발에 적합
- 유연함 (버전 범위 내에서 최신 버전 설치 가능)
- 재현성 낮음 (환경마다 다른 버전이 설치될 수 있음)
- 느림 (기존 node_modules 체크)

### `npm ci`

**동작 방식:**
1. `package-lock.json` **필수**
2. `node_modules`가 있으면 **먼저 완전히 삭제**
3. `package-lock.json`을 **엄격하게 따름** (변경 불가)
4. `package.json`과 `package-lock.json`이 일치하지 않으면 **에러**

**특징:**
- CI/CD에 최적화
- **완벽한 재현성** (항상 동일한 버전 설치)
- 빠름 (병합 체크 안 함, 클린 인스톨)
- 안정적 (lock 파일 변경 불가)
- lock 파일 없으면 에러

따라서, `npm install` 같은 경우에는 로컬 개발에 훨씬 유용하고, `npm ci`는 CI/CD 파이프라인에 적합한 명령어입니다.
즉, 빠른 검증과 엄격한 동일한 버전 보장에 따른 안정성을 위해 `npm ci`를 사용하기로 판단했습니다.

PS. 이미 CodePipeline으로 변경하기 전 GitHub Action의 CI 과정에서도 이미 `npm ci`을 사용하고 있었습니다.
```yaml
- name: Install dependencies
  run: npm ci
```