### PR TITLE
[feat] ObjectMapperConfig에 FAIL_ON_UNKNOWN_PROPERTIES 비활성화 설정 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/redis/ObjectMapperConfig.java
+++ b/backend/src/main/java/coffeeshout/global/redis/ObjectMapperConfig.java
@@ -1,5 +1,6 @@
 package coffeeshout.global.redis;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Set;
@@ -18,6 +19,7 @@ public class ObjectMapperConfig {
     public ObjectMapper redisObjectMapper() {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         registerBaseEventSubtypes(mapper);
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1051

# 🚀 작업 내용

stream에 남아있던 이벤트들을 처음부터 읽어오는 과정에서 예전 스키마로 발행된 메시지가 남아있으면 필드 불일치로 에러가 남.

우리도 메뉴가 남아있던 예전 이벤트를 읽을 때 에러가 나서 방 참가가 안됐음

어떻게 해결을 하냐

ObjectMapper에 모르는 필드 무시 옵션을 추가함
이렇게 하면 스키마가 변경된 오래된 이벤트가 남아있다가 읽어오는 과정에서 모르는 필드가 있다면 무시함

다른 방법으로는 이벤트 클래스에 `@JsonIgnoreProperties`을 추가하면 되긴하지만 모든 이벤트에 다 붙여야해서 안함

또 다른 방법으로는 배포 스크립트에 stream 메시지들 초괴화하는 스크립트를 넣어도 되긴함.
이것도 혹시 몰라서 추가하면 좋을 것 같긴한데 여러분의 의견은 어떤가요?
일단 ObjectMapper에 옵션 추가하면 문제해결은 돼서 적용은 안했음.


# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 데이터 처리 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->