### PR TITLE
[feat] Grafana DB, Redis 모니터링 추가하기

### DIFF
--- a/backend/docker/dev/docker-compose.yml
+++ b/backend/docker/dev/docker-compose.yml
@@ -120,9 +120,9 @@ services:
   # ============================================
   # Dev MySQL Exporter (for Prometheus)
   # ============================================
-  mysql-exporter:
+  dev-mysql-exporter:
     image: prom/mysqld-exporter
-    container_name: mysql-exporter
+    container_name: dev-mysql-exporter
     restart: unless-stopped
     environment:
       - DATA_SOURCE_NAME=root:${DB_PASSWORD}@(dev-mysql:3306)/
@@ -151,9 +151,9 @@ services:
   # ============================================
   # Dev Redis Exporter (for Prometheus)
   # ============================================
-  redis-exporter:
+  dev-redis-exporter:
     image: oliver006/redis_exporter
-    container_name: redis-exporter
+    container_name: dev-redis-exporter
     restart: unless-stopped
     environment:
       - REDIS_ADDR=redis://dev-redis:6379

--- a/backend/docker/dev/docker-compose.yml
+++ b/backend/docker/dev/docker-compose.yml
@@ -143,7 +143,7 @@ services:
           cpus: '0.05'       # 최소 0.05 vCPU
           memory: 64M        # 최소 64MB
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9104/metrics"]
+      test: ["CMD-SHELL", "command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:9104/metrics || command -v wget >/dev/null 2>&1 && wget --quiet --tries=1 --spider http://localhost:9104/metrics"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/backend/docker/dev/docker-compose.yml
+++ b/backend/docker/dev/docker-compose.yml
@@ -17,11 +17,6 @@ services:
       - MYSQL_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=dev-redis
       - REDIS_PORT=6379
-      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
-      - S3_QR_KEY_PREFIX=${S3_QR_KEY_PREFIX}
-      - AWS_REGION=${AWS_REGION:-ap-northeast-2}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - TEMPO_URL=${TEMPO_URL:-http://tempo:4318/v1/traces}
       - TRACE_SAMPLING_PROBABILITY=${TRACE_SAMPLING_PROBABILITY:-1.0}
       - TZ=Asia/Seoul
@@ -120,6 +115,68 @@ services:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
       timeout: 3s
+      retries: 3
+
+  # ============================================
+  # Dev MySQL Exporter (for Prometheus)
+  # ============================================
+  mysql-exporter:
+    image: prom/mysqld-exporter
+    container_name: mysql-exporter
+    restart: unless-stopped
+    environment:
+      - DATA_SOURCE_NAME=root:${DB_PASSWORD}@(dev-mysql:3306)/
+    ports:
+      - "9104:9104"
+    networks:
+      - dev-network
+    depends_on:
+      dev-mysql:
+        condition: service_healthy
+    # 자원 제한 (MySQL Exporter)
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'        # 최대 0.1 vCPU
+          memory: 128M       # 최대 128MB
+        reservations:
+          cpus: '0.05'       # 최소 0.05 vCPU
+          memory: 64M        # 최소 64MB
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9104/metrics"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # ============================================
+  # Dev Redis Exporter (for Prometheus)
+  # ============================================
+  redis-exporter:
+    image: oliver006/redis_exporter
+    container_name: redis-exporter
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis://dev-redis:6379
+    ports:
+      - "9121:9121"
+    networks:
+      - dev-network
+    depends_on:
+      dev-redis:
+        condition: service_healthy
+    # 자원 제한 (Redis Exporter)
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'        # 최대 0.1 vCPU
+          memory: 128M       # 최대 128MB
+        reservations:
+          cpus: '0.05'       # 최소 0.05 vCPU
+          memory: 64M        # 최소 64MB
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9121/metrics"]
+      interval: 30s
+      timeout: 5s
       retries: 3
 
 # ============================================


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1062

# 🚀 작업 내용

1. DB와 Redis 성능 모니터링을 하기 위한 Exporter를 추가했습니다. prod의 경우 코드가 문제가 없는 지 확인 후 재PR 예정입니다.
2.  해당 설정 merge 후  프로메테우스 설정 변경 예정입니다.

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 개발 환경에서 다섯 개의 공개 AWS S3 관련 환경 변수 제거
  * MySQL 모니터링 서비스 추가(포트 9104)
  * Redis 모니링 서비스 추가(포트 9121)
  * 두 모니터링 서비스에 헬스체크, 의존성 조건 및 리소스 제한/예약 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->