### PR TITLE
[feat] 레이싱 게임 TOP 플레이어 조회 API 추가 

### DIFF
--- a/backend/src/main/java/coffeeshout/dashboard/application/DashboardService.java
+++ b/backend/src/main/java/coffeeshout/dashboard/application/DashboardService.java
@@ -2,6 +2,7 @@ package coffeeshout.dashboard.application;
 
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import coffeeshout.dashboard.domain.repository.DashboardStatisticsRepository;
 import java.time.LocalDate;
@@ -38,6 +39,13 @@ public class DashboardService {
         final LocalDateTime endOfMonth = getEndOfMonth();
 
         return dashboardStatisticsRepository.findGamePlayCountByMonth(startOfMonth, endOfMonth);
+    }
+
+    public List<RacingGameTopPlayerResponse> getRacingGameTopPlayers() {
+        final LocalDateTime startOfMonth = getStartOfMonth();
+        final LocalDateTime endOfMonth = getEndOfMonth();
+
+        return dashboardStatisticsRepository.findRacingGameTopPlayers(startOfMonth, endOfMonth, 5);
     }
 
     private LocalDateTime getStartOfMonth() {

--- a/backend/src/main/java/coffeeshout/dashboard/domain/RacingGameTopPlayerResponse.java
+++ b/backend/src/main/java/coffeeshout/dashboard/domain/RacingGameTopPlayerResponse.java
@@ -1,0 +1,8 @@
+package coffeeshout.dashboard.domain;
+
+public record RacingGameTopPlayerResponse(
+        String playerName,
+        double avgRank,
+        long totalScore
+) {
+}

--- a/backend/src/main/java/coffeeshout/dashboard/domain/repository/DashboardStatisticsRepository.java
+++ b/backend/src/main/java/coffeeshout/dashboard/domain/repository/DashboardStatisticsRepository.java
@@ -2,6 +2,7 @@ package coffeeshout.dashboard.domain.repository;
 
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,4 +23,10 @@ public interface DashboardStatisticsRepository {
     );
 
     List<GamePlayCountResponse> findGamePlayCountByMonth(LocalDateTime startDate, LocalDateTime endDate);
+
+    List<RacingGameTopPlayerResponse> findRacingGameTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    );
 }

--- a/backend/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
+++ b/backend/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
@@ -2,9 +2,12 @@ package coffeeshout.dashboard.infra.persistence;
 
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import coffeeshout.dashboard.domain.repository.DashboardStatisticsRepository;
+import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.infra.persistence.QMiniGameEntity;
+import coffeeshout.minigame.infra.persistence.QMiniGameResultEntity;
 import coffeeshout.room.infra.persistence.QPlayerEntity;
 import coffeeshout.room.infra.persistence.QRoomEntity;
 import coffeeshout.room.infra.persistence.QRouletteResultEntity;
@@ -23,6 +26,7 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
     private static final QRouletteResultEntity ROULETTE_RESULT = QRouletteResultEntity.rouletteResultEntity;
     private static final QPlayerEntity PLAYER = QPlayerEntity.playerEntity;
     private static final QMiniGameEntity MINI_GAME = QMiniGameEntity.miniGameEntity;
+    private static final QMiniGameResultEntity MINI_GAME_RESULT = QMiniGameResultEntity.miniGameResultEntity;
     private static final QRoomEntity ROOM = QRoomEntity.roomEntity;
 
     private final JPAQueryFactory queryFactory;
@@ -103,6 +107,32 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                 .where(ROOM.createdAt.between(startDate, endDate))
                 .groupBy(MINI_GAME.miniGameType)
                 .orderBy(MINI_GAME.count().desc())
+                .fetch();
+    }
+
+    @Override
+    public List<RacingGameTopPlayerResponse> findRacingGameTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    ) {
+        return queryFactory
+                .select(Projections.constructor(
+                        RacingGameTopPlayerResponse.class,
+                        PLAYER.playerName,
+                        MINI_GAME_RESULT.rank.avg(),
+                        MINI_GAME_RESULT.score.sum()
+                ))
+                .from(MINI_GAME_RESULT)
+                .join(MINI_GAME_RESULT.player, PLAYER)
+                .join(MINI_GAME_RESULT.miniGamePlay, MINI_GAME)
+                .where(
+                        MINI_GAME.miniGameType.eq(MiniGameType.RACING_GAME),
+                        MINI_GAME_RESULT.createdAt.between(startDate, endDate)
+                )
+                .groupBy(PLAYER.playerName)
+                .orderBy(MINI_GAME_RESULT.rank.avg().asc())
+                .limit(limit)
                 .fetch();
     }
 }

--- a/backend/src/main/java/coffeeshout/dashboard/ui/DashboardApi.java
+++ b/backend/src/main/java/coffeeshout/dashboard/ui/DashboardApi.java
@@ -2,6 +2,7 @@ package coffeeshout.dashboard.ui;
 
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,4 +20,7 @@ public interface DashboardApi {
 
     @Operation(summary = "게임 실행 횟수 조회", description = "이번 달 제일 많이 실행된 게임 통계를 조회합니다.")
     ResponseEntity<List<GamePlayCountResponse>> getGamePlayCounts();
+
+    @Operation(summary = "레이싱 게임 TOP 플레이어 조회", description = "이번 달 레이싱 게임 평균 순위 기준 상위 5명을 조회합니다.")
+    ResponseEntity<List<RacingGameTopPlayerResponse>> getRacingGameTopPlayers();
 }

--- a/backend/src/main/java/coffeeshout/dashboard/ui/DashboardController.java
+++ b/backend/src/main/java/coffeeshout/dashboard/ui/DashboardController.java
@@ -3,6 +3,7 @@ package coffeeshout.dashboard.ui;
 import coffeeshout.dashboard.application.DashboardService;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +32,10 @@ public class DashboardController implements DashboardApi {
     @GetMapping("/game-play-counts")
     public ResponseEntity<List<GamePlayCountResponse>> getGamePlayCounts() {
         return ResponseEntity.ok(dashboardService.getGamePlayCounts());
+    }
+
+    @GetMapping("/racing-game-top-players")
+    public ResponseEntity<List<RacingGameTopPlayerResponse>> getRacingGameTopPlayers() {
+        return ResponseEntity.ok(dashboardService.getRacingGameTopPlayers());
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1066

# 🚀 작업 내용
- 레이싱 게임 플레이어 순위 응답을 위한 RacingGameTopPlayerResponse 레코드 추가
- DashboardService에 레이싱 게임 TOP 플레이어 조회 로직 구현
- QueryDslDashboardStatisticsRepository에 레이싱 게임 관련 쿼리 추가
- DashboardController 및 DashboardApi에 레이싱 게임 TOP 플레이어 조회 엔드포인트 추가
- Swagger를 통한 API 문서화 포함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대시보드에 이번 달 레이싱 게임 상위 플레이어 5명을 평균 순위 기준으로 조회할 수 있는 기능 추가
  * 새로운 API 엔드포인트를 통해 상위 플레이어 정보(플레이어명, 평균 순위, 총점수) 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->