### PR TITLE
[refactor] 웹소켓 사용자 큐 구현

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -74,16 +74,20 @@ jobs:
         with:
           java-version: '21'
           distribution: 'corretto'
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/be/dev' && github.ref != 'refs/heads/be/prod' }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Compile Check
-        run: ./gradlew compileJava compileTestJava
+        run: ./gradlew compileJava compileTestJava --build-cache
 
       - name: Run Tests
-        run: ./gradlew test
+        run: ./gradlew test --build-cache
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -93,7 +97,7 @@ jobs:
           check_name: "Backend Test Results"
 
       - name: Build JAR
-        run: ./gradlew bootJar
+        run: ./gradlew bootJar --build-cache
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -74,20 +74,16 @@ jobs:
         with:
           java-version: '21'
           distribution: 'corretto'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/be/dev' && github.ref != 'refs/heads/be/prod' }}
+          cache: gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Compile Check
-        run: ./gradlew compileJava compileTestJava --build-cache
+        run: ./gradlew compileJava compileTestJava
 
       - name: Run Tests
-        run: ./gradlew test --build-cache
+        run: ./gradlew test
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -97,7 +93,7 @@ jobs:
           check_name: "Backend Test Results"
 
       - name: Build JAR
-        run: ./gradlew bootJar --build-cache
+        run: ./gradlew bootJar
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4

--- a/backend/src/main/java/coffeeshout/global/config/WebSocketMessageBrokerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/WebSocketMessageBrokerConfig.java
@@ -2,6 +2,7 @@ package coffeeshout.global.config;
 
 
 import coffeeshout.global.websocket.interceptor.ShutdownAwareHandshakeInterceptor;
+import coffeeshout.global.websocket.interceptor.StompPrincipalInterceptor;
 import coffeeshout.global.websocket.interceptor.WebSocketInboundMetricInterceptor;
 import coffeeshout.global.websocket.interceptor.WebSocketOutboundMetricInterceptor;
 import io.micrometer.context.ContextSnapshot;
@@ -23,6 +24,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final StompPrincipalInterceptor stompPrincipalInterceptor;
     private final WebSocketInboundMetricInterceptor webSocketInboundMetricInterceptor;
     private final WebSocketOutboundMetricInterceptor webSocketOutboundMetricInterceptor;
     private final ShutdownAwareHandshakeInterceptor shutdownAwareHandshakeInterceptor;
@@ -53,7 +55,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(webSocketInboundMetricInterceptor)
+        registration.interceptors(stompPrincipalInterceptor, webSocketInboundMetricInterceptor)
                 .taskExecutor()
                 .corePoolSize(32)
                 .maxPoolSize(32)

--- a/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
+++ b/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
@@ -19,7 +19,7 @@ public class WebSocketExceptionHandler {
     @MessageExceptionHandler(CoffeeShoutException.class)
     public void handleBusinessException(
             CoffeeShoutException e,
-            @Header(value = "simpUser", required = false) Principal user,
+            Principal user,
             @Header("simpDestination") String destination
     ) {
         log.warn("WebSocket BusinessException: destination={}, errorCode={}, message={}",
@@ -34,7 +34,7 @@ public class WebSocketExceptionHandler {
     @MessageExceptionHandler(Exception.class)
     public void handleException(
             Exception e,
-            @Header("simpUser") Principal user,
+            Principal user,
             @Header("simpDestination") String destination
     ) {
         log.error("WebSocket Exception: destination={}, message={}", destination, e.getMessage(), e);

--- a/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
+++ b/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
@@ -19,7 +19,7 @@ public class WebSocketExceptionHandler {
     @MessageExceptionHandler(CoffeeShoutException.class)
     public void handleBusinessException(
             CoffeeShoutException e,
-            @Header("simpUser") Principal user,
+            @Header(value = "simpUser", required = false) Principal user,
             @Header("simpDestination") String destination
     ) {
         log.warn("WebSocket BusinessException: destination={}, errorCode={}, message={}",

--- a/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
+++ b/backend/src/main/java/coffeeshout/global/exception/WebSocketExceptionHandler.java
@@ -1,29 +1,47 @@
 package coffeeshout.global.exception;
 
-import coffeeshout.global.websocket.ui.WebSocketResponse;
+import coffeeshout.global.exception.custom.CoffeeShoutException;
+import coffeeshout.global.websocket.LoggingSimpMessagingTemplate;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
 @ControllerAdvice
 @RequiredArgsConstructor
+@Slf4j
 public class WebSocketExceptionHandler {
 
-    private final SimpMessagingTemplate messagingTemplate;
+    private final LoggingSimpMessagingTemplate messagingTemplate;
+
+    @MessageExceptionHandler(CoffeeShoutException.class)
+    public void handleBusinessException(
+            CoffeeShoutException e,
+            @Header("simpUser") Principal user,
+            @Header("simpDestination") String destination
+    ) {
+        log.warn("WebSocket BusinessException: destination={}, errorCode={}, message={}",
+                destination, e.getErrorCode().getCode(), e.getMessage());
+
+        messagingTemplate.convertAndSendError(
+                user.getName(),
+                e.getErrorCode().getMessage()
+        );
+    }
 
     @MessageExceptionHandler(Exception.class)
     public void handleException(
             Exception e,
-            @Header("simpSessionId") String sessionId,
+            @Header("simpUser") Principal user,
             @Header("simpDestination") String destination
     ) {
+        log.error("WebSocket Exception: destination={}, message={}", destination, e.getMessage(), e);
 
-        messagingTemplate.convertAndSendToUser(
-                sessionId,
-                "/queue/errors",
-                WebSocketResponse.error("처리 중 오류가 발생했습니다.")
+        messagingTemplate.convertAndSendError(
+                user.getName(),
+                "처리 중 오류가 발생했습니다."
         );
     }
 }

--- a/backend/src/main/java/coffeeshout/global/exception/custom/CoffeeShoutException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/CoffeeShoutException.java
@@ -1,0 +1,20 @@
+package coffeeshout.global.exception.custom;
+
+import coffeeshout.global.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public abstract class CoffeeShoutException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected CoffeeShoutException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    protected CoffeeShoutException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/exception/custom/InvalidArgumentException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/InvalidArgumentException.java
@@ -1,15 +1,10 @@
 package coffeeshout.global.exception.custom;
 
 import coffeeshout.global.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class InvalidArgumentException extends RuntimeException {
-
-    private final ErrorCode errorCode;
+public class InvalidArgumentException extends CoffeeShoutException {
 
     public InvalidArgumentException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        super(errorCode, message);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/exception/custom/InvalidStateException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/InvalidStateException.java
@@ -1,15 +1,10 @@
 package coffeeshout.global.exception.custom;
 
 import coffeeshout.global.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class InvalidStateException extends RuntimeException {
-
-    private final ErrorCode errorCode;
+public class InvalidStateException extends CoffeeShoutException {
 
     public InvalidStateException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        super(errorCode, message);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/exception/custom/NotExistElementException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/NotExistElementException.java
@@ -1,15 +1,10 @@
 package coffeeshout.global.exception.custom;
 
 import coffeeshout.global.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class NotExistElementException extends RuntimeException {
-
-    private final ErrorCode errorCode;
+public class NotExistElementException extends CoffeeShoutException {
 
     public NotExistElementException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        super(errorCode, message);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/exception/custom/QRCodeGenerationException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/QRCodeGenerationException.java
@@ -1,15 +1,10 @@
 package coffeeshout.global.exception.custom;
 
 import coffeeshout.global.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class QRCodeGenerationException extends RuntimeException {
-
-    private final ErrorCode errorCode;
+public class QRCodeGenerationException extends CoffeeShoutException {
 
     public QRCodeGenerationException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
+        super(errorCode, message, cause);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/exception/custom/StorageServiceException.java
+++ b/backend/src/main/java/coffeeshout/global/exception/custom/StorageServiceException.java
@@ -1,20 +1,14 @@
 package coffeeshout.global.exception.custom;
 
 import coffeeshout.global.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class StorageServiceException extends RuntimeException {
-
-    private final ErrorCode errorCode;
+public class StorageServiceException extends CoffeeShoutException {
 
     public StorageServiceException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        super(errorCode, message);
     }
 
     public StorageServiceException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
+        super(errorCode, message, cause);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/LoggingSimpMessagingTemplate.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/LoggingSimpMessagingTemplate.java
@@ -46,15 +46,15 @@ public class LoggingSimpMessagingTemplate {
     }
 
     @Observed(name = "websocket.send.toUser")
-    public void convertAndSendToUser(String sessionId, String destination, Object payload) {
+    public void convertAndSendToUser(String userName, String destination, Object payload) {
         // 개인 메시지는 복구 대상 제외
-        messagingTemplate.convertAndSendToUser(sessionId, destination, payload);
+        messagingTemplate.convertAndSendToUser(userName, destination, payload);
     }
 
     @Observed(name = "websocket.send.error")
-    public void convertAndSendError(String sessionId, String errorMessage) {
+    public void convertAndSendError(String userName, String errorMessage) {
         // 에러 메시지는 복구 대상 제외
-        messagingTemplate.convertAndSendToUser(sessionId, "/queue/errors", WebSocketResponse.error(errorMessage));
+        messagingTemplate.convertAndSendToUser(userName, "/queue/errors", WebSocketResponse.error(errorMessage));
     }
 
     /**

--- a/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/PlayerDisconnectionService.java
@@ -17,39 +17,36 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlayerDisconnectionService {
 
-    private final StompSessionManager sessionManager;
     private final RoomCommandService roomCommandService;
     private final ApplicationEventPublisher eventPublisher;
 
-    public void cancelReady(String playerKey) {
-        final String joinCode = sessionManager.extractJoinCode(playerKey);
-        final String playerName = sessionManager.extractPlayerName(playerKey);
+    public void cancelReady(String playerKeyStr) {
+        final PlayerKey playerKey = PlayerKey.parse(playerKeyStr);
 
-        roomCommandService.readyPlayer(new JoinCode(joinCode), new PlayerName(playerName), false);
+        roomCommandService.readyPlayer(new JoinCode(playerKey.joinCode()), new PlayerName(playerKey.playerName()), false);
 
-        eventPublisher.publishEvent(new RoomStateUpdateEvent(joinCode, "PLAYER_SET_READY_FALSE"));
-        log.info("삭제 대기된 플레이어 ready 상태 변경 완료: joinCode={}, playerName={}", joinCode, playerName);
+        eventPublisher.publishEvent(new RoomStateUpdateEvent(playerKey.joinCode(), "PLAYER_SET_READY_FALSE"));
+        log.info("삭제 대기된 플레이어 ready 상태 변경 완료: joinCode={}, playerName={}", playerKey.joinCode(), playerKey.playerName());
     }
 
     /**
      * 플레이어 연결 해제 처리
      */
-    public void handlePlayerDisconnection(String playerKey, String sessionId, String reason) {
+    public void handlePlayerDisconnection(String playerKeyStr, String sessionId, String reason) {
         try {
-            if (!sessionManager.isValidPlayerKey(playerKey)) {
-                log.warn("잘못된 플레이어 키 형식: {}", playerKey);
+            if (!PlayerKey.isValid(playerKeyStr)) {
+                log.warn("잘못된 플레이어 키 형식: {}", playerKeyStr);
                 return;
             }
 
-            final String joinCode = sessionManager.extractJoinCode(playerKey);
-            final String playerName = sessionManager.extractPlayerName(playerKey);
+            final PlayerKey playerKey = PlayerKey.parse(playerKeyStr);
 
-            log.info("플레이어 연결 해제 처리: joinCode={}, playerName={}, reason={}", joinCode, playerName, reason);
+            log.info("플레이어 연결 해제 처리: joinCode={}, playerName={}, reason={}", playerKey.joinCode(), playerKey.playerName(), reason);
 
-            removePlayerFromRoom(joinCode, playerName);
+            removePlayerFromRoom(playerKey.joinCode(), playerKey.playerName());
 
         } catch (Exception e) {
-            log.error("플레이어 연결 해제 처리 실패: playerKey={}, sessionId={}, reason={}", playerKey, sessionId, reason, e);
+            log.error("플레이어 연결 해제 처리 실패: playerKey={}, sessionId={}, reason={}", playerKeyStr, sessionId, reason, e);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/global/websocket/PlayerKey.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/PlayerKey.java
@@ -1,0 +1,48 @@
+package coffeeshout.global.websocket;
+
+import lombok.NonNull;
+
+/**
+ * 플레이어 식별 키 (joinCode:playerName)
+ * <p>웹소켓 세션 매핑, Principal 설정 등에서 공통으로 사용</p>
+ */
+public record PlayerKey(@NonNull String joinCode, @NonNull String playerName) {
+
+    private static final String DELIMITER = ":";
+
+    public PlayerKey {
+        if (joinCode.isEmpty() || playerName.isEmpty()) {
+            throw new IllegalArgumentException("joinCode와 playerName은 비어있을 수 없습니다");
+        }
+        if (joinCode.contains(DELIMITER) || playerName.contains(DELIMITER)) {
+            throw new IllegalArgumentException(
+                    "joinCode와 playerName에 구분자('" + DELIMITER + "')가 포함될 수 없습니다");
+        }
+    }
+
+    public static PlayerKey of(@NonNull String joinCode, @NonNull String playerName) {
+        return new PlayerKey(joinCode, playerName);
+    }
+
+    public static PlayerKey parse(@NonNull String playerKey) {
+        String[] parts = playerKey.split(DELIMITER);
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            throw new IllegalArgumentException(
+                    "플레이어 키 형식이 잘못되었습니다. 예상: joinCode" + DELIMITER + "playerName, 실제: " + playerKey);
+        }
+        return new PlayerKey(parts[0], parts[1]);
+    }
+
+    public static boolean isValid(String playerKey) {
+        if (playerKey == null || !playerKey.contains(DELIMITER)) {
+            return false;
+        }
+        String[] parts = playerKey.split(DELIMITER);
+        return parts.length == 2 && !parts[0].isEmpty() && !parts[1].isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return joinCode + DELIMITER + playerName;
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/websocket/PlayerKey.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/PlayerKey.java
@@ -33,6 +33,10 @@ public record PlayerKey(@NonNull String joinCode, @NonNull String playerName) {
         return new PlayerKey(parts[0], parts[1]);
     }
 
+    public static String prefix(@NonNull String joinCode) {
+        return joinCode + DELIMITER;
+    }
+
     public static boolean isValid(String playerKey) {
         if (playerKey == null || !playerKey.contains(DELIMITER)) {
             return false;

--- a/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
@@ -12,9 +12,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class StompSessionManager {
 
-    private static final String PLAYER_KEY_DELIMITER = ":";
-    private static final int EXPECTED_PLAYER_KEY_PARTS = 2;
-
     // 중복 처리 방지용
     private final Set<String> processedDisconnections = ConcurrentHashMap.newKeySet();
 
@@ -31,12 +28,12 @@ public class StompSessionManager {
      * 플레이어 세션 매핑 등록
      */
     public void registerPlayerSession(@NonNull String joinCode, @NonNull String playerName, @NonNull String sessionId) {
-        final String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = PlayerKey.of(joinCode, playerName).toString();
         upsertSessionMapping(playerKey, sessionId);
     }
 
     public void registerPlayerSession(@NonNull String playerKey, @NonNull String sessionId) {
-        validatePlayerKey(playerKey);
+        PlayerKey.parse(playerKey); // 유효성 검증
         upsertSessionMapping(playerKey, sessionId);
     }
 
@@ -57,7 +54,7 @@ public class StompSessionManager {
      * 플레이어의 기존 세션 ID 조회
      */
     public boolean hasSessionId(@NonNull String joinCode, @NonNull String playerName) {
-        final String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = PlayerKey.of(joinCode, playerName).toString();
         return playerSessionMap.containsKey(playerKey);
     }
 
@@ -69,7 +66,7 @@ public class StompSessionManager {
     }
 
     public String getSessionId(@NonNull String joinCode, @NonNull String playerName) {
-        final String playerKey = createPlayerKey(joinCode, playerName);
+        final String playerKey = PlayerKey.of(joinCode, playerName).toString();
 
         isTrue(playerSessionMap.containsKey(playerKey),
                 "플레이어 세션이 존재하지 않습니다: joinCode=%s, playerName=%s".formatted(joinCode, playerName));
@@ -89,24 +86,6 @@ public class StompSessionManager {
                 "세션 ID가 존재하지 않습니다: sessionId=%s".formatted(sessionId));
 
         return sessionPlayerMap.get(sessionId);
-    }
-
-    /**
-     * 플레이어 키에서 조인 코드 추출
-     */
-    public String extractJoinCode(@NonNull String playerKey) {
-        validatePlayerKey(playerKey);
-        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
-        return parts[0];
-    }
-
-    /**
-     * 플레이어 키에서 플레이어 이름 추출
-     */
-    public String extractPlayerName(@NonNull String playerKey) {
-        validatePlayerKey(playerKey);
-        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
-        return parts[1];
     }
 
     /**
@@ -134,8 +113,9 @@ public class StompSessionManager {
      * 특정 방의 연결된 플레이어 수 조회
      */
     public long getConnectedPlayerCountByJoinCode(@NonNull String joinCode) {
+        final String prefix = joinCode + ":";
         return playerSessionMap.keySet().stream()
-                .filter(playerKey -> playerKey.startsWith(joinCode + PLAYER_KEY_DELIMITER))
+                .filter(playerKey -> playerKey.startsWith(prefix))
                 .count();
     }
 
@@ -144,44 +124,5 @@ public class StompSessionManager {
      */
     public int getTotalConnectedClientCount() {
         return sessionPlayerMap.size();
-    }
-
-    /**
-     * 플레이어 키 생성 (public 메서드)
-     */
-    public String createPlayerKey(@NonNull String joinCode, @NonNull String playerName) {
-        if (joinCode.contains(PLAYER_KEY_DELIMITER) || playerName.contains(PLAYER_KEY_DELIMITER)) {
-            throw new IllegalArgumentException("joinCode와 playerName에 구분자('" + PLAYER_KEY_DELIMITER + "')가 포함될 수 없습니다");
-        }
-        return joinCode + PLAYER_KEY_DELIMITER + playerName;
-    }
-
-    /**
-     * 플레이어 키 유효성 검증
-     */
-    public boolean isValidPlayerKey(String playerKey) {
-        if (playerKey == null || !playerKey.contains(PLAYER_KEY_DELIMITER)) {
-            return false;
-        }
-        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
-        return parts.length == EXPECTED_PLAYER_KEY_PARTS &&
-                !parts[0].isEmpty() && !parts[1].isEmpty();
-    }
-
-    /**
-     * 플레이어 키 유효성 검증 및 예외 발생
-     */
-    private void validatePlayerKey(@NonNull String playerKey) {
-        if (!playerKey.contains(PLAYER_KEY_DELIMITER)) {
-            throw new IllegalArgumentException("플레이어 키에 구분자('" + PLAYER_KEY_DELIMITER + "')가 없습니다: " + playerKey);
-        }
-        final String[] parts = playerKey.split(PLAYER_KEY_DELIMITER);
-        if (parts.length != EXPECTED_PLAYER_KEY_PARTS) {
-            throw new IllegalArgumentException(
-                    "플레이어 키 형식이 잘못되었습니다. 예상: joinCode" + PLAYER_KEY_DELIMITER + "playerName, 실제: " + playerKey);
-        }
-        if (parts[0].isEmpty() || parts[1].isEmpty()) {
-            throw new IllegalArgumentException("joinCode 또는 playerName이 비어있습니다: " + playerKey);
-        }
     }
 }

--- a/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/StompSessionManager.java
@@ -33,7 +33,9 @@ public class StompSessionManager {
     }
 
     public void registerPlayerSession(@NonNull String playerKey, @NonNull String sessionId) {
-        PlayerKey.parse(playerKey); // 유효성 검증
+        if (!PlayerKey.isValid(playerKey)) {
+            throw new IllegalArgumentException("잘못된 플레이어 키 형식: " + playerKey);
+        }
         upsertSessionMapping(playerKey, sessionId);
     }
 
@@ -113,7 +115,7 @@ public class StompSessionManager {
      * 특정 방의 연결된 플레이어 수 조회
      */
     public long getConnectedPlayerCountByJoinCode(@NonNull String joinCode) {
-        final String prefix = joinCode + ":";
+        final String prefix = PlayerKey.prefix(joinCode);
         return playerSessionMap.keySet().stream()
                 .filter(playerKey -> playerKey.startsWith(prefix))
                 .count();

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
@@ -4,6 +4,7 @@ import coffeeshout.global.metric.WebSocketMetricService;
 import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.redis.stream.StreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.global.websocket.PlayerKey;
 import coffeeshout.global.websocket.StompSessionManager;
 import coffeeshout.global.websocket.event.session.SessionRegisteredEvent;
 import coffeeshout.room.domain.JoinCode;
@@ -83,7 +84,7 @@ public class SessionConnectEventListener {
     }
 
     private void publishSessionRegisteredEvent(String sessionId, String joinCode, String playerName) {
-        final String playerKey = sessionManager.createPlayerKey(joinCode, playerName);
+        final String playerKey = PlayerKey.of(joinCode, playerName).toString();
         final BaseEvent event = SessionRegisteredEvent.create(playerKey, sessionId);
         streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
 

--- a/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
@@ -25,12 +25,14 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
         String joinCode = accessor.getFirstNativeHeader("joinCode");
         String playerName = accessor.getFirstNativeHeader("playerName");
 
+        String userName;
         if (joinCode == null || playerName == null) {
-            log.warn("STOMP CONNECT 헤더 누락: joinCode={}, playerName={}", joinCode, playerName);
-            return message;
+            log.warn("STOMP CONNECT 헤더 누락으로 sessionId를 Principal로 사용: sessionId={}", accessor.getSessionId());
+            userName = accessor.getSessionId();
+        } else {
+            userName = PlayerKey.of(joinCode, playerName).toString();
         }
 
-        String userName = PlayerKey.of(joinCode, playerName).toString();
         accessor.setUser(() -> userName);
         log.debug("STOMP Principal 설정: {}", userName);
 

--- a/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
@@ -1,5 +1,6 @@
 package coffeeshout.global.websocket.interceptor;
 
+import coffeeshout.global.websocket.PlayerKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -24,11 +25,14 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
         String joinCode = accessor.getFirstNativeHeader("joinCode");
         String playerName = accessor.getFirstNativeHeader("playerName");
 
-        if (joinCode != null && playerName != null) {
-            String userName = joinCode + ":" + playerName;
-            accessor.setUser(() -> userName);
-            log.debug("STOMP Principal 설정: {}", userName);
+        if (joinCode == null || playerName == null) {
+            log.warn("STOMP CONNECT 헤더 누락: joinCode={}, playerName={}", joinCode, playerName);
+            return message;
         }
+
+        String userName = PlayerKey.of(joinCode, playerName).toString();
+        accessor.setUser(() -> userName);
+        log.debug("STOMP Principal 설정: {}", userName);
 
         return message;
     }

--- a/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
@@ -1,0 +1,35 @@
+package coffeeshout.global.websocket.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class StompPrincipalInterceptor implements ChannelInterceptor {
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || accessor.getCommand() != StompCommand.CONNECT) {
+            return message;
+        }
+
+        String joinCode = accessor.getFirstNativeHeader("joinCode");
+        String playerName = accessor.getFirstNativeHeader("playerName");
+
+        if (joinCode != null && playerName != null) {
+            String userName = joinCode + ":" + playerName;
+            accessor.setUser(() -> userName);
+            log.debug("STOMP Principal 설정: {}", userName);
+        }
+
+        return message;
+    }
+}

--- a/backend/src/test/java/coffeeshout/fixture/WebSocketIntegrationTestSupport.java
+++ b/backend/src/test/java/coffeeshout/fixture/WebSocketIntegrationTestSupport.java
@@ -30,6 +30,7 @@ import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
@@ -62,6 +63,11 @@ public abstract class WebSocketIntegrationTestSupport {
     }
 
     protected TestStompSession createSession() throws InterruptedException, ExecutionException, TimeoutException {
+        return createSession(null, null);
+    }
+
+    protected TestStompSession createSession(String joinCode, String playerName)
+            throws InterruptedException, ExecutionException, TimeoutException {
         SockJsClient sockJsClient = new SockJsClient(List.of(
                 new WebSocketTransport(new StandardWebSocketClient())
         ));
@@ -71,9 +77,16 @@ public abstract class WebSocketIntegrationTestSupport {
         messageConverter.setStrictContentTypeMatch(false);
         stompClient.setMessageConverter(messageConverter);
         String url = String.format(WEBSOCKET_BASE_URL_FORMAT, port);
+
+        StompHeaders connectHeaders = new StompHeaders();
+        if (joinCode != null && playerName != null) {
+            connectHeaders.add("joinCode", joinCode);
+            connectHeaders.add("playerName", playerName);
+        }
+
         StompSession session = stompClient
                 .connectAsync(
-                        url, new StompSessionHandlerAdapter() {
+                        url, new WebSocketHttpHeaders(), connectHeaders, new StompSessionHandlerAdapter() {
 
                             @Override
                             public void handleTransportError(StompSession session, Throwable exception) {
@@ -122,9 +135,7 @@ public abstract class WebSocketIntegrationTestSupport {
     }
 
     protected void assertMessageContains(MessageResponse response, String expected) {
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.payload()).contains(expected);
-        });
+        SoftAssertions.assertSoftly(softly -> softly.assertThat(response.payload()).contains(expected));
     }
 
     protected void assertMessage(MessageResponse response, long duration, String payload) throws JSONException {

--- a/backend/src/test/java/coffeeshout/global/websocket/PlayerDisconnectionServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/PlayerDisconnectionServiceTest.java
@@ -1,6 +1,5 @@
 package coffeeshout.global.websocket;
 
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import coffeeshout.room.domain.JoinCode;
@@ -34,9 +33,6 @@ class PlayerDisconnectionServiceTest {
         String playerKey = "ABC4:김철수";
         String joinCode = "ABC4";
         String playerName = "김철수";
-        
-        given(sessionManager.extractJoinCode(playerKey)).willReturn(joinCode);
-        given(sessionManager.extractPlayerName(playerKey)).willReturn(playerName);
 
         // when
         playerDisconnectionService.cancelReady(playerKey);

--- a/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/StompSessionManagerTest.java
@@ -22,7 +22,7 @@ class StompSessionManagerTest {
         String playerName = "player1";
 
         // when
-        String playerKey = sessionManager.createPlayerKey(joinCode, playerName);
+        String playerKey = PlayerKey.of(joinCode, playerName).toString();
 
         // then
         assertThat(playerKey).isEqualTo("ABC23:player1");
@@ -31,86 +31,86 @@ class StompSessionManagerTest {
     @Test
     void joinCode가_null인_경우_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey(null, "player1"))
+        assertThatThrownBy(() -> PlayerKey.of(null, "player1"))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void playerName이_null인_경우_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", null))
+        assertThatThrownBy(() -> PlayerKey.of("ABC23", null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void joinCode에_구분자가_포함된_경우_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC:23", "player1"))
+        assertThatThrownBy(() -> PlayerKey.of("ABC:23", "player1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("joinCode와 playerName에 구분자(':')가 포함될 수 없습니다");
+                .hasMessageContaining("구분자");
     }
 
     @Test
     void playerName에_구분자가_포함된_경우_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.createPlayerKey("ABC23", "play:er1"))
+        assertThatThrownBy(() -> PlayerKey.of("ABC23", "play:er1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("joinCode와 playerName에 구분자(':')가 포함될 수 없습니다");
+                .hasMessageContaining("구분자");
     }
 
     @Test
     void 정상적인_joinCode_추출() {
         // given
-        String playerKey = "ABC23:player1";
+        String playerKeyStr = "ABC23:player1";
 
         // when
-        String joinCode = sessionManager.extractJoinCode(playerKey);
+        PlayerKey playerKey = PlayerKey.parse(playerKeyStr);
 
         // then
-        assertThat(joinCode).isEqualTo("ABC23");
+        assertThat(playerKey.joinCode()).isEqualTo("ABC23");
     }
 
     @Test
     void 정상적인_playerName_추출() {
         // given
-        String playerKey = "ABC23:player1";
+        String playerKeyStr = "ABC23:player1";
 
         // when
-        String playerName = sessionManager.extractPlayerName(playerKey);
+        PlayerKey playerKey = PlayerKey.parse(playerKeyStr);
 
         // then
-        assertThat(playerName).isEqualTo("player1");
+        assertThat(playerKey.playerName()).isEqualTo("player1");
     }
 
     @Test
-    void null_플레이어_키로_joinCode_추출_시_예외_발생() {
+    void null_플레이어_키로_parse_시_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractJoinCode(null))
+        assertThatThrownBy(() -> PlayerKey.parse(null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void 구분자가_없는_플레이어_키로_joinCode_추출_시_예외_발생() {
+    void 구분자가_없는_플레이어_키로_parse_시_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractJoinCode("ABC23player1"))
+        assertThatThrownBy(() -> PlayerKey.parse("ABC23player1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("플레이어 키에 구분자(':')가 없습니다: ABC23player1");
+                .hasMessageContaining("형식이 잘못되었습니다");
     }
 
     @Test
-    void 잘못된_형식의_플레이어_키로_playerName_추출_시_예외_발생() {
+    void 잘못된_형식의_플레이어_키로_parse_시_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractPlayerName("ABC23:player1:extra"))
+        assertThatThrownBy(() -> PlayerKey.parse("ABC23:player1:extra"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("플레이어 키 형식이 잘못되었습니다. 예상: joinCode:playerName, 실제: ABC23:player1:extra");
+                .hasMessageContaining("형식이 잘못되었습니다");
     }
 
     @Test
-    void 빈_joinCode가_있는_플레이어_키_검증_시_예외_발생() {
+    void 빈_joinCode가_있는_플레이어_키_parse_시_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> sessionManager.extractJoinCode(":player1"))
+        assertThatThrownBy(() -> PlayerKey.parse(":player1"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("joinCode 또는 playerName이 비어있습니다: :player1");
+                .hasMessageContaining("형식이 잘못되었습니다");
     }
 
     @Test
@@ -119,25 +119,25 @@ class StompSessionManagerTest {
         String validPlayerKey = "ABC23:player1";
 
         // when & then
-        assertThat(sessionManager.isValidPlayerKey(validPlayerKey)).isTrue();
+        assertThat(PlayerKey.isValid(validPlayerKey)).isTrue();
     }
 
     @Test
     void 플레이어_키_유효성_검증_null() {
         // when & then
-        assertThat(sessionManager.isValidPlayerKey(null)).isFalse();
+        assertThat(PlayerKey.isValid(null)).isFalse();
     }
 
     @Test
     void 플레이어_키_유효성_검증_구분자_없음() {
         // when & then
-        assertThat(sessionManager.isValidPlayerKey("ABC23player1")).isFalse();
+        assertThat(PlayerKey.isValid("ABC23player1")).isFalse();
     }
 
     @Test
     void 플레이어_키_유효성_검증_빈_joinCode() {
         // when & then
-        assertThat(sessionManager.isValidPlayerKey(":player1")).isFalse();
+        assertThat(PlayerKey.isValid(":player1")).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/coffeeshout/websocket/UserQueueIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/websocket/UserQueueIntegrationTest.java
@@ -1,0 +1,61 @@
+package coffeeshout.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+
+import coffeeshout.fixture.TestStompSession;
+import coffeeshout.fixture.TestStompSession.MessageCollector;
+import coffeeshout.fixture.WebSocketIntegrationTestSupport;
+import coffeeshout.global.MessageResponse;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.ui.request.ReadyChangeMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class UserQueueIntegrationTest extends WebSocketIntegrationTestSupport {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StreamPublisher streamPublisher;
+
+    @Test
+    void CoffeeShoutException_발생_시_ErrorCode_메시지를_수신한다() throws Exception {
+        // given
+        TestStompSession session = createSession("TEST_CODE", "testPlayer");
+        MessageCollector errorCollector = session.subscribe("/user/queue/errors");
+
+        // when - 존재하지 않는 방에 룰렛 스핀 요청 → NotExistElementException(GlobalErrorCode.NOT_EXIST)
+        session.send("/app/room/ABCD/spin-roulette", "{\"hostName\": \"testPlayer\"}");
+
+        // then - ErrorCode.getMessage()인 "해당 데이터가 존재하지 않습니다."가 반환되어야 함
+        MessageResponse response = errorCollector.get();
+        assertThat(response.payload()).contains("\"success\":false");
+        assertThat(response.payload()).contains("해당 데이터가 존재하지 않습니다.");
+    }
+
+    @Test
+    void 일반_Exception_발생_시_기본_에러_메시지를_수신한다() throws Exception {
+        // given
+        willThrow(new RuntimeException("예상치 못한 서버 오류"))
+                .given(streamPublisher).publish(any(), any());
+
+        TestStompSession session = createSession("TEST_CODE", "testPlayer");
+        MessageCollector errorCollector = session.subscribe("/user/queue/errors");
+
+        ReadyChangeMessage readyChangeMessage = new ReadyChangeMessage("ABCD", "testPlayer", true);
+        String body = objectMapper.writeValueAsString(readyChangeMessage);
+
+        // when - streamPublisher.publish()에서 RuntimeException 발생
+        session.send("/app/room/ABCD/update-ready", body);
+
+        // then - CoffeeShoutException이 아니므로 기본 에러 메시지가 반환되어야 함
+        MessageResponse response = errorCollector.get();
+        assertThat(response.payload()).contains("\"success\":false");
+        assertThat(response.payload()).contains("처리 중 오류가 발생했습니다.");
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #884

# 🚀 작업 내용

1. 사용자 큐를 사용할 수 있도록 수정하였습니다.
2. 한스의 PR처럼 비즈니스 Exception을 따로 파서 상속으로 하여서 ErrorCode 반복을 삭제했습니다.
3. StompPrincipalInterceptor 를 통해서  사용자 정보를 주입하도록 하였습니다.
4. 테스트를 통해 동작하는 지 확인하도록 하였습니다
 
# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * WebSocket 연결 시 클라이언트 식별 방식 추가로 사용자별 메시징 정확도 향상

* **개선 사항**
  * 에러 전송 흐름 통합으로 사용자에게 일관된 오류 응답 제공
  * 예외 계층 정비로 오류 코드와 메시지 처리 일관성 강화
  * 플레이어 연결/해제 처리 로직 개선으로 안정성 향상

* **테스트**
  * WebSocket 사용자 오류 처리 통합 테스트 추가 및 관련 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->