### PR TITLE
[fix] RedisLock 수정 및 Redisson timeout 튜닝

### DIFF
--- a/backend/src/main/java/coffeeshout/global/lock/RedisLockAspect.java
+++ b/backend/src/main/java/coffeeshout/global/lock/RedisLockAspect.java
@@ -46,7 +46,7 @@ public class RedisLockAspect {
         final String lockKey = getLockKey(joinPoint, redisLock);
         final String doneKey = getDoneKey(joinPoint, redisLock);
 
-        // 이미 처리된 이벤트인지 확인
+        // 1단계: 락 획득 전 빠른 체크 (성능 최적화)
         if (isAlreadyProcessed(doneKey)) {
             log.debug("이미 처리된 이벤트 (스킵): doneKey={}", doneKey);
             return null;
@@ -65,6 +65,12 @@ public class RedisLockAspect {
 
             if (!acquired) {
                 log.warn("락 획득 실패 (스킵): lockKey={}", lockKey);
+                return null;
+            }
+
+            // 2단계: 락 획득 후 이중 체크 (Race Condition 방지)
+            if (isAlreadyProcessed(doneKey)) {
+                log.debug("락 획득 후 이중 체크 - 이미 처리됨 (스킵): doneKey={}", doneKey);
                 return null;
             }
 

--- a/backend/src/main/java/coffeeshout/global/redis/config/RedissonConfig.java
+++ b/backend/src/main/java/coffeeshout/global/redis/config/RedissonConfig.java
@@ -1,15 +1,21 @@
 package coffeeshout.global.redis.config;
 
+import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(RedissonProperties.class)
 public class RedissonConfig {
+
+    private final RedissonProperties redissonProperties;
 
     @Bean
     @ConditionalOnProperty(name = "redisson.enabled", havingValue = "true", matchIfMissing = true)
@@ -26,10 +32,10 @@ public class RedissonConfig {
         
         final var singleServerConfig = config.useSingleServer()
                 .setAddress(protocol + host + ":" + port)
-                .setTimeout(1000)
-                .setConnectTimeout(1000)
-                .setRetryAttempts(1)
-                .setRetryInterval(500);
+                .setTimeout(redissonProperties.timeout())
+                .setConnectTimeout(redissonProperties.connectTimeout())
+                .setRetryAttempts(redissonProperties.retryAttempts())
+                .setRetryInterval(redissonProperties.retryInterval());
         
         if (username != null && !username.isBlank()) {
             singleServerConfig.setUsername(username);

--- a/backend/src/main/java/coffeeshout/global/redis/config/RedissonConfig.java
+++ b/backend/src/main/java/coffeeshout/global/redis/config/RedissonConfig.java
@@ -25,7 +25,11 @@ public class RedissonConfig {
         final String protocol = sslEnabled ? "rediss://" : "redis://";
         
         final var singleServerConfig = config.useSingleServer()
-                .setAddress(protocol + host + ":" + port);
+                .setAddress(protocol + host + ":" + port)
+                .setTimeout(1000)
+                .setConnectTimeout(1000)
+                .setRetryAttempts(1)
+                .setRetryInterval(500);
         
         if (username != null && !username.isBlank()) {
             singleServerConfig.setUsername(username);

--- a/backend/src/main/java/coffeeshout/global/redis/config/RedissonProperties.java
+++ b/backend/src/main/java/coffeeshout/global/redis/config/RedissonProperties.java
@@ -1,0 +1,19 @@
+package coffeeshout.global.redis.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "redisson")
+public record RedissonProperties(
+        boolean enabled,
+        int timeout,
+        int connectTimeout,
+        int retryAttempts,
+        int retryInterval
+) {
+    public RedissonProperties {
+        if (timeout <= 0) timeout = 1000;
+        if (connectTimeout <= 0) connectTimeout = 1000;
+        if (retryAttempts < 0) retryAttempts = 1;
+        if (retryInterval <= 0) retryInterval = 500;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,7 +23,6 @@ redis:
       max-length: 100
       batch-size: 10
       poll-timeout: 2s
-
     # 공유 스레드풀
     thread-pools:
       #      sequential: # 단일 스레드풀은 여러 리스너에서 공유 불가능
@@ -34,7 +33,6 @@ redis:
         core-size: 8
         max-size: 16
         queue-capacity: 1024
-
     # 스트림 설정 (key가 식별자)
     keys:
       "[room]":
@@ -53,6 +51,13 @@ redis:
         thread-pool-name: concurrent
       "[racinggame]":
         thread-pool-name: concurrent
+
+redisson:
+  enabled: true
+  timeout: 1000
+  connect-timeout: 3000
+  retry-attempts: 1
+  retry-interval: 500
 
 oracle:
   cloud:
@@ -104,11 +109,11 @@ management:
   metrics:
     enable:
       tomcat: true
-
   prometheus:
     metrics:
       export:
         enabled: true
+
 server:
   shutdown: graceful
   tomcat:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1093

# 🚀 작업 내용

### 변경 사항

**1. RedisLockAspect — Double-checked locking 추가**

기존 코드에서 done key 체크와 락 획득 사이에 Race Condition이 존재했습니다.

```
Thread A: isAlreadyProcessed → false (통과)
Thread B: isAlreadyProcessed → false (통과)  ← A가 아직 done 마킹 안 함
Thread A: tryLock → 성공 → 비즈니스 로직 실행 → done 마킹 → unlock
Thread B: tryLock → 성공 (A가 이미 풀었으니까) → 비즈니스 로직 실행 → 중복 처리!
```

`waitTime=0`이라 동시 tryLock은 하나가 튕기지만, Thread A가 락을 해제한 직후에 Thread B가 잡는 시간차 시나리오에서 중복이 발생합니다.

**수정:** 락 획득 직후에 done key를 한 번 더 확인하는 Double-checked locking 패턴을 적용했습니다.

- 1단계 체크 (락 획득 전): 성능 최적화. 이미 처리된 이벤트는 락 시도 없이 스킵
- 2단계 체크 (락 획득 후): 정합성 보장. 다른 스레드가 먼저 처리한 경우를 차단

**2. RedissonConfig — timeout 튜닝**

Redisson 기본값(`timeout=3000ms`, `connectTimeout=10000ms`)이 설정되어 있지 않아, Redis 미세 지연(Slowlog 등) 시 tryLock 내부에서 최대 3~10초 블로킹 가능성이 있었습니다.

`room:join`처럼 단일 스레드 풀(core=1)에서 이 블로킹이 발생하면 뒤의 입장 이벤트가 전부 밀립니다.

**수정:**
- `timeout`: 3000ms → 1000ms
- `connectTimeout`: 10000ms → 3000ms
- `retryAttempts`: 3 → 1
- `retryInterval`: 1500ms → 500ms

### 영향 범위

`@RedisLock` 어노테이션을 사용하는 모든 이벤트 핸들러:
- `MiniGameResultSaveEventListener.handle()`
- `RoulettePersistenceService.saveRoomStatus()`
- `RoulettePersistenceService.saveRouletteResult()`
- `MiniGamePersistenceService.saveGameEntities()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redis 동시 처리 시 발생 가능한 경쟁 조건을 잠금 획득 후 재검사로 방지하고 관련 로그를 명확히 구분

* **New Features**
  * Redisson 관련 설정을 애플리케이션 설정으로 노출(타임아웃·연결·재시도 등)하고 안전한 기본값 적용
  * 애플리케이션 설정에 메트릭스 내보내기(Prometheus) 및 서버 종료(그레이스풀) 관련 구성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->