### PR TITLE
[feat] 미니게임 결과 저장 Bulk Insert 전환으로 DB 커넥션 점유 시간 최소화

### DIFF
--- a/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
+++ b/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
@@ -71,7 +71,11 @@ public class MiniGameResultSaveEventListener {
         final Map<String, PlayerEntity> playerEntityMap = playerJpaRepository
                 .findByRoomSessionAndPlayerNameIn(roomEntity, playerNames)
                 .stream()
-                .collect(Collectors.toMap(PlayerEntity::getPlayerName, Function.identity()));
+                .collect(Collectors.toMap(
+                        PlayerEntity::getPlayerName,
+                        Function.identity(),
+                        (existing, replacement) -> existing
+                ));
 
         final List<MiniGameResultEntity> resultEntities = new ArrayList<>();
 

--- a/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
+++ b/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
@@ -19,6 +19,8 @@ import coffeeshout.room.infra.persistence.PlayerJpaRepository;
 import coffeeshout.room.infra.persistence.RoomEntity;
 import coffeeshout.room.infra.persistence.RoomJpaRepository;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,6 +62,8 @@ public class MiniGameResultSaveEventListener {
         final MiniGameResult result = miniGame.getResult();
         final Map<Player, MiniGameScore> scores = miniGame.getScores();
 
+        final List<MiniGameResultEntity> resultEntities = new ArrayList<>();
+
         for (Player player : room.getPlayers()) {
             final PlayerEntity playerEntity = playerJpaRepository.findByRoomSessionAndPlayerName(roomEntity,
                             player.getName().value())
@@ -68,16 +72,16 @@ public class MiniGameResultSaveEventListener {
             final Integer rank = result.getPlayerRank(player);
             final Long score = scores.get(player).getValue();
 
-            final MiniGameResultEntity resultEntity = new MiniGameResultEntity(
+            resultEntities.add(new MiniGameResultEntity(
                     miniGameEntity,
                     playerEntity,
                     rank,
                     score
-            );
-
-            miniGameResultJpaRepository.save(resultEntity);
+            ));
         }
 
-        log.info("미니게임 결과 저장 완료: joinCode={}", event.joinCode());
+        miniGameResultJpaRepository.bulkInsert(resultEntities);
+
+        log.info("미니게임 결과 벌크 저장 완료: joinCode={}, playerCount={}", event.joinCode(), resultEntities.size());
     }
 }

--- a/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
+++ b/backend/src/main/java/coffeeshout/minigame/event/MiniGameResultSaveEventListener.java
@@ -22,6 +22,8 @@ import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -62,12 +64,22 @@ public class MiniGameResultSaveEventListener {
         final MiniGameResult result = miniGame.getResult();
         final Map<Player, MiniGameScore> scores = miniGame.getScores();
 
+        final List<String> playerNames = room.getPlayers().stream()
+                .map(player -> player.getName().value())
+                .toList();
+
+        final Map<String, PlayerEntity> playerEntityMap = playerJpaRepository
+                .findByRoomSessionAndPlayerNameIn(roomEntity, playerNames)
+                .stream()
+                .collect(Collectors.toMap(PlayerEntity::getPlayerName, Function.identity()));
+
         final List<MiniGameResultEntity> resultEntities = new ArrayList<>();
 
         for (Player player : room.getPlayers()) {
-            final PlayerEntity playerEntity = playerJpaRepository.findByRoomSessionAndPlayerName(roomEntity,
-                            player.getName().value())
-                    .orElseThrow(() -> new IllegalArgumentException("플레이어가 존재하지 않습니다: " + player.getName().value()));
+            final PlayerEntity playerEntity = playerEntityMap.get(player.getName().value());
+            if (playerEntity == null) {
+                throw new IllegalArgumentException("플레이어가 존재하지 않습니다: " + player.getName().value());
+            }
 
             final Integer rank = result.getPlayerRank(player);
             final Long score = scores.get(player).getValue();

--- a/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepository.java
+++ b/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepository.java
@@ -1,0 +1,8 @@
+package coffeeshout.minigame.infra.persistence;
+
+import java.util.List;
+
+public interface MiniGameResultBulkRepository {
+
+    void bulkInsert(List<MiniGameResultEntity> resultEntities);
+}

--- a/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
@@ -1,0 +1,41 @@
+package coffeeshout.minigame.infra.persistence;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RequiredArgsConstructor
+public class MiniGameResultBulkRepositoryImpl implements MiniGameResultBulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void bulkInsert(List<MiniGameResultEntity> resultEntities) {
+        final String sql = """
+                INSERT INTO mini_game_result (mini_game_play_id, player_id, player_rank, score, mini_game_type, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """;
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                final MiniGameResultEntity entity = resultEntities.get(i);
+                ps.setLong(1, entity.getMiniGamePlay().getId());
+                ps.setLong(2, entity.getPlayer().getId());
+                ps.setInt(3, entity.getRank());
+                ps.setLong(4, entity.getScore());
+                ps.setString(5, entity.getMiniGameType().name());
+                ps.setTimestamp(6, Timestamp.valueOf(entity.getCreatedAt()));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return resultEntities.size();
+            }
+        });
+    }
+}

--- a/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultBulkRepositoryImpl.java
@@ -15,6 +15,10 @@ public class MiniGameResultBulkRepositoryImpl implements MiniGameResultBulkRepos
 
     @Override
     public void bulkInsert(List<MiniGameResultEntity> resultEntities) {
+        if (resultEntities.isEmpty()) {
+            return;
+        }
+
         final String sql = """
                 INSERT INTO mini_game_result (mini_game_play_id, player_id, player_rank, score, mini_game_type, created_at)
                 VALUES (?, ?, ?, ?, ?, ?)

--- a/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/minigame/infra/persistence/MiniGameResultJpaRepository.java
@@ -2,7 +2,8 @@ package coffeeshout.minigame.infra.persistence;
 
 import org.springframework.data.repository.Repository;
 
-public interface MiniGameResultJpaRepository extends Repository<MiniGameResultEntity, Long> {
+public interface MiniGameResultJpaRepository extends Repository<MiniGameResultEntity, Long>,
+        MiniGameResultBulkRepository {
 
     MiniGameResultEntity save(MiniGameResultEntity miniGameResultEntity);
 }

--- a/backend/src/main/java/coffeeshout/room/infra/persistence/PlayerJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/room/infra/persistence/PlayerJpaRepository.java
@@ -1,5 +1,6 @@
 package coffeeshout.room.infra.persistence;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
@@ -7,4 +8,6 @@ public interface PlayerJpaRepository extends Repository<PlayerEntity, Long> {
     PlayerEntity save(PlayerEntity playerEntity);
 
     Optional<PlayerEntity> findByRoomSessionAndPlayerName(RoomEntity roomSession, String playerName);
+
+    List<PlayerEntity> findByRoomSessionAndPlayerNameIn(RoomEntity roomSession, List<String> playerNames);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      data-source-properties:
+        rewriteBatchedStatements: true
   lifecycle:
     timeout-per-shutdown-phase: 5m
   data:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1095

# 🚀 작업 내용

## Background

ZZOL은 점심시간에 트래픽이 집중되도록 겨냥한 실시간 멀티플레이어 게임 서비스다. 방 하나에 최대 9명이 참여하며, 미니게임이 종료되면 9명의 결과 데이터를 DB에 저장해야 한다.

### 기존 문제

`MiniGameResultSaveEventListener`에서 for문을 돌며 아래 두 가지를 반복 호출하고 있었다.

1. **SELECT N+1:** `playerJpaRepository.findByRoomSessionAndPlayerName()`을 플레이어 수만큼 단건 호출 → 9명이면 9번의 SELECT
2. **INSERT N회:** `miniGameResultJpaRepository.save()`를 단건 호출 → 9명이면 9번의 INSERT

하나의 트랜잭션에서 **18번의 쿼리**(9 SELECT + 9 INSERT)가 발생하는 구조였다.

INSERT의 경우, `MiniGameResultEntity`가 `GenerationType.IDENTITY` 전략을 사용하기 때문에 Hibernate는 `persist()` 시점에 즉시 INSERT를 실행해야 PK를 확보할 수 있다. 이로 인해 `saveAll()`을 사용하더라도 쓰기 지연(write-behind)이 동작하지 않아 **N건의 개별 INSERT**가 발생한다.

### 피크 타임 시나리오

방 10개가 동시에 종료되면:

- 10방 × 18쿼리 = **180번의 쿼리**
- HikariCP 기본 풀 사이즈(10) 기준, 10개 트랜잭션이 커넥션을 장시간 점유
- 다른 요청 커넥션 대기 → Tomcat 스레드 블로킹 → **Cascading Failure** 가능성

---

## Changes

### 1. SELECT N+1 제거: `WHERE IN` 절 다건 조회

- `PlayerJpaRepository`에 `findByRoomSessionAndPlayerNameIn()` 메서드 추가
- for문 내 단건 SELECT 9회 → IN 절 1회 조회 + `Map<String, PlayerEntity>` 매핑
- 이후 for문에서는 DB를 치지 않고 메모리에서 O(1) 조회

### 2. `JdbcTemplate.batchUpdate()` 기반 Bulk Insert 도입

- JPA 영속성 컨텍스트를 우회하여 JDBC 레벨에서 배치 처리
- `rewriteBatchedStatements=true` 옵션과 결합 시, MySQL Connector/J가 Multi-row INSERT로 재작성
- 9명 기준 INSERT 쿼리 **9회 → 1회**

### 3. Spring Data JPA Custom Repository 확장 패턴 적용

- `MiniGameResultBulkRepository` 인터페이스 + `MiniGameResultBulkRepositoryImpl` 구현체 신규 생성
- `MiniGameResultJpaRepository`가 `MiniGameResultBulkRepository`를 상속
- 기존 `save()` 메서드 미수정. OCP 준수

### 4. `rewriteBatchedStatements=true` 설정 추가

- `application.yml` (공통)에 `spring.datasource.hikari.data-source-properties.rewriteBatchedStatements: true` 추가
- HikariCP가 커넥션 생성 시 MySQL Connector/J에 해당 프로퍼티를 전달
- JDBC URL을 환경별로 수정할 필요 없이, local/dev/prod 전 환경에 일괄 적용

### 변경 파일

| 파일 | 변경 |
|---|---|
| `PlayerJpaRepository.java` | 수정 (`findByRoomSessionAndPlayerNameIn` 추가) |
| `MiniGameResultBulkRepository.java` | 신규 |
| `MiniGameResultBulkRepositoryImpl.java` | 신규 |
| `MiniGameResultJpaRepository.java` | 수정 (상속 추가) |
| `MiniGameResultSaveEventListener.java` | 수정 (IN 절 조회 + bulk insert 적용) |
| `application.yml` | 수정 (hikari data-source-properties에 rewriteBatchedStatements 추가) |

### 쿼리 수 변화 (방 1개, 플레이어 9명 기준)

| | Before | After |
|---|---|---|
| SELECT (PlayerEntity 조회) | 9회 | 1회 (IN 절) |
| INSERT (MiniGameResult 저장) | 9회 | 1회 (Bulk INSERT) |
| 총 쿼리 수 | **18회** | **2회** |

방 10개 동시 종료: **180회 → 20회 (89% 감소)**

---

## Trade-offs

| 얻은 것 | 잃은 것 |
|---|---|
| SELECT 9회 → 1회, INSERT 9회 → 1회 | JPA 영속성 컨텍스트의 1차 캐시, 변경 감지(Dirty Checking) 미적용 |
| DB 커넥션 점유 시간 대폭 감소 | `@CreatedDate` 등 JPA Auditing 자동 적용 불가 (생성자에서 직접 `LocalDateTime.now()` 세팅) |
| 피크 타임 커넥션 풀 고갈 위험 완화 | JDBC 레벨 raw SQL 관리 필요 |

### 포기가 합리적인 이유

`mini_game_result`는 게임 종료 시 한 번 쓰고, 이후 수정이 발생하지 않는 **append-only 데이터**다. Dirty Checking, 생명주기 콜백, Auditing 모두 이 엔티티에서는 불필요하다. 성능을 얻기 위해 포기한 것들이 애초에 쓰이지 않는 기능들이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 미니게임 결과 저장을 일괄 처리로 전환해 데이터베이스 효율성과 저장 성능을 개선했습니다.
  * 일괄 삽입 구현과 연계된 리포지토리 확장 및 연동을 추가했습니다.
  * 대량 저장 최적화를 위한 데이터베이스 설정을 추가했습니다.
  * 플레이어 조회를 묶어 한 번에 가져오도록 변경해 전체 처리 성능을 향상시켰습니다

* **버그 수정**
  * 미등록 플레이어에 대해 명확한 예외를 던지도록 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->