### PR TITLE
[fix] Docker Promtail Unhealthy 문제 해결

### DIFF
--- a/backend/docker/dev/conf/promtail.yml
+++ b/backend/docker/dev/conf/promtail.yml
@@ -27,7 +27,7 @@ scrape_configs:
       - labels:
           level:
 
-      # loki에서는
+      # promtail이 직접 자신의 시스템 시계를 보고 Loki에게 보내도록 설정
       # 타임스탬프 설정 (KST → UTC 변환)
 #      - timestamp:
 #          source: timestamp

--- a/backend/docker/dev/conf/promtail.yml
+++ b/backend/docker/dev/conf/promtail.yml
@@ -27,8 +27,9 @@ scrape_configs:
       - labels:
           level:
 
+      # loki에서는
       # 타임스탬프 설정 (KST → UTC 변환)
-      - timestamp:
-          source: timestamp
-          format: '2006-01-02 15:04:05.000'
-          location: Asia/Seoul
+#      - timestamp:
+#          source: timestamp
+#          format: '2006-01-02 15:04:05.000'
+#          location: Asia/Seoul

--- a/backend/docker/dev/docker-compose.yml
+++ b/backend/docker/dev/docker-compose.yml
@@ -191,7 +191,6 @@ services:
       - dev-app-logs:/app/logs:ro
       - ./conf/promtail.yml:/etc/promtail/promtail.yml:ro
       - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     command: -config.file=/etc/promtail/promtail.yml
     networks:
       - dev-network

--- a/backend/docker/dev/docker-compose.yml
+++ b/backend/docker/dev/docker-compose.yml
@@ -190,6 +190,8 @@ services:
     volumes:
       - dev-app-logs:/app/logs:ro
       - ./conf/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: -config.file=/etc/promtail/promtail.yml
     networks:
       - dev-network

--- a/backend/docker/prod/docker-compose.yml
+++ b/backend/docker/prod/docker-compose.yml
@@ -208,6 +208,8 @@ services:
     volumes:
       - prod-app-logs:/app/logs:ro
       - ./conf/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
     command: -config.file=/etc/promtail/promtail.yml
     networks:
       - prod-network

--- a/backend/docker/prod/docker-compose.yml
+++ b/backend/docker/prod/docker-compose.yml
@@ -209,7 +209,6 @@ services:
       - prod-app-logs:/app/logs:ro
       - ./conf/promtail.yml:/etc/promtail/promtail.yml:ro
       - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
     command: -config.file=/etc/promtail/promtail.yml
     networks:
       - prod-network


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1097

# 🚀 작업 내용

https://www.notion.so/7iwook/Docker-Promtail-TimeZone-31820b265277804b9125cafb8d531d10?source=copy_link
1. loki와 dev-promtail의 타임존이 달라 에러가 지속 발생했습니다.
2. loki의 타임존을 수정하고자 했지만 여전히 UTC로 고정되는 현상이 있습니다
3. loki와 promtail이 각 호스트 OS의 타임존을 바라보도록 설정하였습니다.
4. timestamp의 KST를 주석처리 하였습니다.
- 해당 처리를 하면 promtail이 자신의 시계를 보고 UTC로 전송하게 됩니다. 이를 통해 LOKI와 Promtail 간 시간 문제를 해소할 수 있을 거 같습니다.
5. 처리가 안될 경우 임시로 loki 의 미래 시간 허용 범위를 10시간(한국 시간 +9H)로 허용할 예정입니다.
- 이는 여러 분산 서버의 경우 각 서버마다 시간이 달라 문제가 발생할 수 있지만, 단일 인스턴스 환경이 되었으므로 허용범위라 생각합니다.
# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 로깅 서비스의 타임존 동기화 설정을 개선했습니다. 개발 및 프로덕션 환경 모두에서 호스트의 시간대 정보를 올바르게 동기화하도록 업데이트하여 로그 타임스탬프 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->