### PR TITLE
[feat] Redis Stream 메트릭 모니터링 구현 (E2E Latency + Lag Gauge)

### DIFF
--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
@@ -154,33 +153,5 @@ public class RedisStreamLagMetricService {
         }
 
         return RedisStreamThreadPoolConfig.convertBeanName(streamKey);
-    }
-
-    /**
-     * 10초 주기로 스트림 길이가 maxLength의 80%를 넘으면 경고 로그를 남긴다.
-     */
-    @Scheduled(fixedRate = 10_000)
-    public void logStreamStatus() {
-        if (redisStreamProperties.keys() == null) {
-            return;
-        }
-
-        for (Map.Entry<String, StreamConfig> entry : redisStreamProperties.keys().entrySet()) {
-            String streamKey = entry.getKey();
-            double length = getStreamLength(streamKey);
-
-            // XLEN 조회 실패 시 비교 스킵
-            if (Double.isNaN(length)) {
-                continue;
-            }
-
-            int maxLength = entry.getValue().getMaxLength(redisStreamProperties.commonSettings());
-
-            if (length > maxLength * 0.8) {
-                log.warn("Redis Stream 길이 경고: stream={}, length={}, maxLength={} ({}%)",
-                        streamKey, (long) length, maxLength,
-                        String.format("%.1f", (length / maxLength) * 100));
-            }
-        }
     }
 }

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -135,20 +135,25 @@ public class RedisStreamLagMetricService {
 
     private ThreadPoolTaskExecutor resolveExecutor(String streamKey, StreamConfig config) {
         try {
-            String beanName;
-            if (config.isUseSharedThreadPool()) {
-                beanName = RedisStreamThreadPoolConfig.convertBeanName(config.threadPoolName());
-            } else {
-                beanName = RedisStreamThreadPoolConfig.convertBeanName(streamKey);
-            }
+            String beanName = resolveBeanName(streamKey, config);
             Object bean = applicationContext.getBean(beanName);
-            if (bean instanceof ThreadPoolTaskExecutor executor) {
-                return executor;
+
+            if (!(bean instanceof ThreadPoolTaskExecutor executor)) {
+                return null;
             }
-            return null;
+
+            return executor;
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private String resolveBeanName(String streamKey, StreamConfig config) {
+        if (config != null && config.threadPoolName() != null) {
+            return RedisStreamThreadPoolConfig.convertBeanName(config.threadPoolName());
+        }
+
+        return RedisStreamThreadPoolConfig.convertBeanName(streamKey);
     }
 
     /**

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -1,0 +1,169 @@
+package coffeeshout.global.metric;
+
+import coffeeshout.global.redis.config.RedisStreamProperties;
+import coffeeshout.global.redis.config.RedisStreamProperties.StreamConfig;
+import coffeeshout.global.redis.config.RedisStreamThreadPoolConfig;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis Stream의 공간적 백로그(lag)를 주기적으로 수집한다.
+ *
+ * <p>현재 ZZOL은 Consumer Group 없이 StreamOffset.fromStart()로 소비하므로,
+ * XINFO GROUPS 대신 XLEN(스트림 길이)과 스레드풀 큐 깊이를 조합하여 측정한다.</p>
+ *
+ * <p>Redis 부하 최소화:
+ * <ul>
+ *   <li>XLEN은 O(1) 연산이므로 Redis에 거의 부하를 주지 않음</li>
+ *   <li>스레드풀 큐 깊이는 JVM 내부 조회이므로 Redis 호출 없음</li>
+ *   <li>Gauge는 Prometheus scrape 시점에만 평가되므로 불필요한 polling 없음</li>
+ * </ul>
+ * </p>
+ *
+ * <p>Prometheus 메트릭명:
+ * <ul>
+ *   <li>redis_stream_length (tag: stream)</li>
+ *   <li>redis_stream_threadpool_queue_size (tag: stream)</li>
+ *   <li>redis_stream_threadpool_active_count (tag: stream)</li>
+ * </ul>
+ * </p>
+ */
+@Slf4j
+@Component
+public class RedisStreamLagMetricService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisStreamProperties redisStreamProperties;
+    private final MeterRegistry meterRegistry;
+    private final ApplicationContext applicationContext;
+
+    public RedisStreamLagMetricService(
+            StringRedisTemplate stringRedisTemplate,
+            RedisStreamProperties redisStreamProperties,
+            MeterRegistry meterRegistry,
+            ApplicationContext applicationContext
+    ) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.redisStreamProperties = redisStreamProperties;
+        this.meterRegistry = meterRegistry;
+        this.applicationContext = applicationContext;
+    }
+
+    @PostConstruct
+    public void initializeMetrics() {
+        if (redisStreamProperties.keys() == null) {
+            log.warn("Redis Stream 설정이 없습니다. Lag 메트릭을 등록하지 않습니다.");
+            return;
+        }
+
+        for (Map.Entry<String, StreamConfig> entry : redisStreamProperties.keys().entrySet()) {
+            final String streamKey = entry.getKey();
+            final StreamConfig streamConfig = entry.getValue();
+
+            // 1) 스트림 길이 Gauge (XLEN - O(1))
+            Gauge.builder("redis.stream.length", () -> getStreamLength(streamKey))
+                    .description("Redis Stream의 현재 메시지 수 (XLEN)")
+                    .tag("stream", streamKey)
+                    .register(meterRegistry);
+
+            // 2) 스레드풀 큐 깊이 Gauge
+            Gauge.builder("redis.stream.threadpool.queue.size",
+                            () -> getThreadPoolQueueSize(streamKey, streamConfig))
+                    .description("Redis Stream 컨슈머 스레드풀의 대기 큐 크기")
+                    .tag("stream", streamKey)
+                    .register(meterRegistry);
+
+            // 3) 스레드풀 활성 스레드 수
+            Gauge.builder("redis.stream.threadpool.active.count",
+                            () -> getThreadPoolActiveCount(streamKey, streamConfig))
+                    .description("Redis Stream 컨슈머 스레드풀의 활성 스레드 수")
+                    .tag("stream", streamKey)
+                    .register(meterRegistry);
+        }
+
+        log.info("Redis Stream Lag 메트릭 등록 완료: streams={}",
+                redisStreamProperties.keys().keySet());
+    }
+
+    private double getStreamLength(String streamKey) {
+        try {
+            Long length = stringRedisTemplate.opsForStream().size(streamKey);
+            return length != null ? length.doubleValue() : 0.0;
+        } catch (Exception e) {
+            log.warn("XLEN 조회 실패: stream={}", streamKey, e);
+            return -1.0;
+        }
+    }
+
+    private double getThreadPoolQueueSize(String streamKey, StreamConfig config) {
+        try {
+            ThreadPoolTaskExecutor executor = resolveExecutor(streamKey, config);
+            if (executor == null) return -1.0;
+
+            ThreadPoolExecutor threadPoolExecutor = executor.getThreadPoolExecutor();
+            return threadPoolExecutor.getQueue().size();
+        } catch (Exception e) {
+            log.debug("스레드풀 큐 크기 조회 실패: stream={}", streamKey, e);
+            return -1.0;
+        }
+    }
+
+    private double getThreadPoolActiveCount(String streamKey, StreamConfig config) {
+        try {
+            ThreadPoolTaskExecutor executor = resolveExecutor(streamKey, config);
+            if (executor == null) return -1.0;
+
+            return executor.getThreadPoolExecutor().getActiveCount();
+        } catch (Exception e) {
+            log.debug("활성 스레드 수 조회 실패: stream={}", streamKey, e);
+            return -1.0;
+        }
+    }
+
+    private ThreadPoolTaskExecutor resolveExecutor(String streamKey, StreamConfig config) {
+        try {
+            String beanName;
+            if (config.isUseSharedThreadPool()) {
+                beanName = RedisStreamThreadPoolConfig.convertBeanName(config.threadPoolName());
+            } else {
+                beanName = RedisStreamThreadPoolConfig.convertBeanName(streamKey);
+            }
+            Object bean = applicationContext.getBean(beanName);
+            if (bean instanceof ThreadPoolTaskExecutor executor) {
+                return executor;
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * 10초 주기로 스트림 길이가 maxLength의 80%를 넘으면 경고 로그를 남긴다.
+     */
+    @Scheduled(fixedRate = 10_000)
+    public void logStreamStatus() {
+        if (redisStreamProperties.keys() == null) return;
+
+        for (Map.Entry<String, StreamConfig> entry : redisStreamProperties.keys().entrySet()) {
+            String streamKey = entry.getKey();
+            double length = getStreamLength(streamKey);
+            int maxLength = entry.getValue().getMaxLength(redisStreamProperties.commonSettings());
+
+            if (length > maxLength * 0.8) {
+                log.warn("Redis Stream 길이 경고: stream={}, length={}, maxLength={} ({}%)",
+                        streamKey, (long) length, maxLength,
+                        String.format("%.1f", (length / maxLength) * 100));
+            }
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -128,7 +128,7 @@ public class RedisStreamLagMetricService {
             return executor.getThreadPoolExecutor().getActiveCount();
         } catch (Exception e) {
             log.debug("활성 스레드 수 조회 실패: stream={}", streamKey, e);
-            return -Double.NaN;
+            return Double.NaN;
         }
     }
 

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -157,6 +157,12 @@ public class RedisStreamLagMetricService {
         for (Map.Entry<String, StreamConfig> entry : redisStreamProperties.keys().entrySet()) {
             String streamKey = entry.getKey();
             double length = getStreamLength(streamKey);
+
+            // XLEN 조회 실패 시 비교 스킵
+            if (length < 0) {
+                continue;
+            }
+
             int maxLength = entry.getValue().getMaxLength(redisStreamProperties.commonSettings());
 
             if (length > maxLength * 0.8) {

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -170,7 +170,7 @@ public class RedisStreamLagMetricService {
             double length = getStreamLength(streamKey);
 
             // XLEN 조회 실패 시 비교 스킵
-            if (length < 0) {
+            if (Double.isNaN(length)) {
                 continue;
             }
 

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -100,32 +100,36 @@ public class RedisStreamLagMetricService {
             return length != null ? length.doubleValue() : 0.0;
         } catch (Exception e) {
             log.warn("XLEN 조회 실패: stream={}", streamKey, e);
-            return -1.0;
+            return Double.NaN;
         }
     }
 
     private double getThreadPoolQueueSize(String streamKey, StreamConfig config) {
         try {
             ThreadPoolTaskExecutor executor = resolveExecutor(streamKey, config);
-            if (executor == null) return -1.0;
+            if (executor == null) {
+                return Double.NaN;
+            }
 
             ThreadPoolExecutor threadPoolExecutor = executor.getThreadPoolExecutor();
             return threadPoolExecutor.getQueue().size();
         } catch (Exception e) {
             log.debug("스레드풀 큐 크기 조회 실패: stream={}", streamKey, e);
-            return -1.0;
+            return Double.NaN;
         }
     }
 
     private double getThreadPoolActiveCount(String streamKey, StreamConfig config) {
         try {
             ThreadPoolTaskExecutor executor = resolveExecutor(streamKey, config);
-            if (executor == null) return -1.0;
+            if (executor == null) {
+                return Double.NaN;
+            }
 
             return executor.getThreadPoolExecutor().getActiveCount();
         } catch (Exception e) {
             log.debug("활성 스레드 수 조회 실패: stream={}", streamKey, e);
-            return -1.0;
+            return -Double.NaN;
         }
     }
 
@@ -152,7 +156,9 @@ public class RedisStreamLagMetricService {
      */
     @Scheduled(fixedRate = 10_000)
     public void logStreamStatus() {
-        if (redisStreamProperties.keys() == null) return;
+        if (redisStreamProperties.keys() == null) {
+            return;
+        }
 
         for (Map.Entry<String, StreamConfig> entry : redisStreamProperties.keys().entrySet()) {
             String streamKey = entry.getKey();

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLatencyMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLatencyMetricService.java
@@ -43,6 +43,10 @@ public class RedisStreamLatencyMetricService {
      * @param event 소비된 Redis Stream 이벤트
      */
     public void recordLatency(BaseEvent event) {
+        if (streamLatencyTimer == null) {
+            return;
+        }
+
         if (event.timestamp() == null) {
             log.warn("이벤트에 timestamp가 없습니다: eventId={}", event.eventId());
             return;

--- a/backend/src/main/java/coffeeshout/global/metric/RedisStreamLatencyMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RedisStreamLatencyMetricService.java
@@ -1,0 +1,66 @@
+package coffeeshout.global.metric;
+
+import coffeeshout.global.redis.BaseEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis Stream 메시지의 End-to-End 지연 시간을 측정한다.
+ *
+ * <p>BaseEvent.timestamp() (발행 시점) ~ 소비 시점 간의 시간차를 Micrometer Timer로 기록한다.
+ * EventDispatcher에서 이벤트 처리 직전에 호출한다.</p>
+ *
+ * <p>Prometheus 메트릭명: redis_stream_e2e_latency_seconds</p>
+ */
+@Slf4j
+@Component
+public class RedisStreamLatencyMetricService {
+
+    private final MeterRegistry meterRegistry;
+    private Timer streamLatencyTimer;
+
+    public RedisStreamLatencyMetricService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    public void initializeMetrics() {
+        this.streamLatencyTimer = Timer.builder("redis.stream.e2e.latency")
+                .description("Redis Stream 메시지 발행~소비 간 End-to-End 지연 시간")
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .publishPercentileHistogram()
+                .register(meterRegistry);
+    }
+
+    /**
+     * 이벤트의 발행 타임스탬프와 현재 시각의 차이를 기록한다.
+     *
+     * @param event 소비된 Redis Stream 이벤트
+     */
+    public void recordLatency(BaseEvent event) {
+        if (event.timestamp() == null) {
+            log.warn("이벤트에 timestamp가 없습니다: eventId={}", event.eventId());
+            return;
+        }
+
+        final Duration latency = Duration.between(event.timestamp(), Instant.now());
+
+        if (latency.isNegative()) {
+            log.warn("음수 지연 감지 (clock skew 의심): eventId={}, latency={}ms",
+                    event.eventId(), latency.toMillis());
+            return;
+        }
+
+        streamLatencyTimer.record(latency);
+
+        if (latency.toMillis() > 50) {
+            log.warn("Redis Stream 지연 50ms 초과: eventId={}, latency={}ms, eventType={}",
+                    event.eventId(), latency.toMillis(), event.getClass().getSimpleName());
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/metric/RoomActiveMetricService.java
+++ b/backend/src/main/java/coffeeshout/global/metric/RoomActiveMetricService.java
@@ -1,0 +1,52 @@
+package coffeeshout.global.metric;
+
+import coffeeshout.room.domain.RoomState;
+import coffeeshout.room.domain.repository.MemoryRoomRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Room 상태별 활성 수를 Gauge로 수집한다.
+ *
+ * <p>MemoryRoomRepository의 인메모리 Room 데이터를 기반으로
+ * RoomState별(READY, PLAYING, SCORE_BOARD, ROULETTE, DONE) 활성 Room 수와
+ * 전체 Room 수를 Prometheus에 노출한다.</p>
+ *
+ * <p>Prometheus 메트릭명:
+ * <ul>
+ *   <li>room_active_count (tag: state)</li>
+ *   <li>room_total_count</li>
+ * </ul>
+ * </p>
+ */
+@Slf4j
+@Component
+public class RoomActiveMetricService {
+
+    private final MemoryRoomRepository memoryRoomRepository;
+    private final MeterRegistry meterRegistry;
+
+    public RoomActiveMetricService(MemoryRoomRepository memoryRoomRepository, MeterRegistry meterRegistry) {
+        this.memoryRoomRepository = memoryRoomRepository;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    public void initializeMetrics() {
+        for (RoomState state : RoomState.values()) {
+            Gauge.builder("room.active.count", () -> memoryRoomRepository.countByState(state))
+                    .description("상태별 활성 Room 수")
+                    .tag("state", state.name())
+                    .register(meterRegistry);
+        }
+
+        Gauge.builder("room.total.count", memoryRoomRepository::totalCount)
+                .description("전체 활성 Room 수")
+                .register(meterRegistry);
+
+        log.info("Room 활성 수 메트릭 등록 완료: states={}", RoomState.values().length);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/redis/EventDispatcher.java
+++ b/backend/src/main/java/coffeeshout/global/redis/EventDispatcher.java
@@ -1,5 +1,6 @@
 package coffeeshout.global.redis;
 
+import coffeeshout.global.metric.RedisStreamLatencyMetricService;
 import coffeeshout.global.trace.Traceable;
 import coffeeshout.global.trace.TracerProvider;
 import java.util.function.Consumer;
@@ -17,10 +18,13 @@ public class EventDispatcher {
 
     private final TracerProvider tracerProvider;
     private final ApplicationContext applicationContext;
+    private final RedisStreamLatencyMetricService latencyMetricService;
 
     @SuppressWarnings("unchecked")
     public void handle(BaseEvent event) {
         try {
+            latencyMetricService.recordLatency(event);
+
             final Consumer<BaseEvent> consumer = (Consumer<BaseEvent>) getConsumer(event.getClass());
             final Runnable handling = () -> consumer.accept(event);
 

--- a/backend/src/main/java/coffeeshout/global/redis/EventDispatcher.java
+++ b/backend/src/main/java/coffeeshout/global/redis/EventDispatcher.java
@@ -23,7 +23,7 @@ public class EventDispatcher {
     @SuppressWarnings("unchecked")
     public void handle(BaseEvent event) {
         try {
-            latencyMetricService.recordLatency(event);
+            recordLatency(event);
 
             final Consumer<BaseEvent> consumer = (Consumer<BaseEvent>) getConsumer(event.getClass());
             final Runnable handling = () -> consumer.accept(event);
@@ -36,6 +36,14 @@ public class EventDispatcher {
 
         } catch (Exception e) {
             log.error("이벤트 처리 실패: message={}", event, e);
+        }
+    }
+
+    private void recordLatency(BaseEvent event) {
+        try {
+            latencyMetricService.recordLatency(event);
+        } catch (Exception e) {
+            log.warn("Redis Stream 지연 메트릭 기록 실패: eventId={}", event.eventId(), e);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/global/websocket/ratelimit/WebSocketRateLimiter.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/ratelimit/WebSocketRateLimiter.java
@@ -1,5 +1,7 @@
 package coffeeshout.global.websocket.ratelimit;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,18 +29,31 @@ public class WebSocketRateLimiter {
 
     private final int maxMessagesPerSecond;
     private final Clock clock;
+    private final Counter rateLimitDropCounter;
     private final Map<String, SessionCounter> sessionCounters = new ConcurrentHashMap<>();
 
     @Autowired
     public WebSocketRateLimiter(
-            @Value("${websocket.rate-limit.max-messages-per-second:20}") int maxMessagesPerSecond
+            @Value("${websocket.rate-limit.max-messages-per-second:20}") int maxMessagesPerSecond,
+            MeterRegistry meterRegistry
     ) {
-        this(maxMessagesPerSecond, Clock.systemUTC());
+        this(maxMessagesPerSecond, Clock.systemUTC(), meterRegistry);
     }
 
     WebSocketRateLimiter(int maxMessagesPerSecond, Clock clock) {
+        this(maxMessagesPerSecond, clock, null);
+    }
+
+    WebSocketRateLimiter(int maxMessagesPerSecond, Clock clock, MeterRegistry meterRegistry) {
         this.maxMessagesPerSecond = maxMessagesPerSecond;
         this.clock = clock;
+        if (meterRegistry != null) {
+            this.rateLimitDropCounter = Counter.builder("websocket.ratelimit.dropped.total")
+                    .description("WebSocket Rate Limit에 의해 드롭된 메시지 수")
+                    .register(meterRegistry);
+        } else {
+            this.rateLimitDropCounter = null;
+        }
     }
 
     /**
@@ -51,7 +66,11 @@ public class WebSocketRateLimiter {
         final SessionCounter counter = sessionCounters.computeIfAbsent(
                 sessionId, k -> new SessionCounter(clock.millis())
         );
-        return counter.tryAcquire(maxMessagesPerSecond, clock.millis());
+        boolean allowed = counter.tryAcquire(maxMessagesPerSecond, clock.millis());
+        if (!allowed && rateLimitDropCounter != null) {
+            rateLimitDropCounter.increment();
+        }
+        return allowed;
     }
 
     /**

--- a/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
@@ -4,6 +4,7 @@ import static org.springframework.util.Assert.notNull;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.RoomState;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,5 +40,21 @@ public class MemoryRoomRepository implements RoomRepository {
         notNull(joinCode, "JoinCode는 null일 수 없습니다.");
 
         rooms.remove(joinCode);
+    }
+
+    /**
+     * 특정 상태의 Room 수를 반환한다.
+     */
+    public long countByState(RoomState state) {
+        return rooms.values().stream()
+                .filter(room -> room.getRoomState() == state)
+                .count();
+    }
+
+    /**
+     * 전체 Room 수를 반환한다.
+     */
+    public int totalCount() {
+        return rooms.size();
     }
 }

--- a/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
+++ b/backend/src/main/java/coffeeshout/room/domain/repository/MemoryRoomRepository.java
@@ -54,7 +54,7 @@ public class MemoryRoomRepository implements RoomRepository {
     /**
      * 전체 Room 수를 반환한다.
      */
-    public int totalCount() {
+    public long totalCount() {
         return rooms.size();
     }
 }

--- a/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
@@ -90,12 +90,12 @@ class RedisStreamLagMetricServiceTest {
         // when
         lagMetricService.initializeMetrics();
 
-        // then: 빈을 못 찾으면 -1.0 반환
+        // then: 빈을 못 찾으면 Nan 반환
         Gauge queueGauge = meterRegistry.find("redis.stream.threadpool.queue.size")
                 .tag("stream", "room")
                 .gauge();
         assertThat(queueGauge).isNotNull();
-        assertThat(queueGauge.value()).isEqualTo(-1.0);
+        assertThat(queueGauge.value()).isNaN();
     }
 
     @Test
@@ -116,7 +116,7 @@ class RedisStreamLagMetricServiceTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void XLEN_조회_실패_시_음수를_반환한다() {
+    void XLEN_조회_실패_시_Nan를_반환한다() {
         // given
         StreamOperations<String, Object, Object> failingOps = mock(StreamOperations.class);
         given(stringRedisTemplate.opsForStream()).willReturn(failingOps);
@@ -131,6 +131,6 @@ class RedisStreamLagMetricServiceTest {
 
         // then
         assertThat(gauge).isNotNull();
-        assertThat(gauge.value()).isEqualTo(-1.0);
+        assertThat(gauge.value()).isEqualTo(Double.NaN);
     }
 }

--- a/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
@@ -1,0 +1,136 @@
+package coffeeshout.global.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.global.redis.config.RedisStreamProperties;
+import coffeeshout.global.redis.config.RedisStreamProperties.CommonSettings;
+import coffeeshout.global.redis.config.RedisStreamProperties.StreamConfig;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+class RedisStreamLagMetricServiceTest {
+
+    private MeterRegistry meterRegistry;
+    private StringRedisTemplate stringRedisTemplate;
+    private RedisStreamProperties redisStreamProperties;
+    private ApplicationContext applicationContext;
+    private RedisStreamLagMetricService lagMetricService;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        stringRedisTemplate = mock(StringRedisTemplate.class);
+        applicationContext = mock(ApplicationContext.class);
+
+        StreamOperations<String, Object, Object> streamOps = mock(StreamOperations.class);
+        given(stringRedisTemplate.opsForStream()).willReturn(streamOps);
+        given(streamOps.size("room")).willReturn(42L);
+        given(streamOps.size("racinggame")).willReturn(7L);
+
+        CommonSettings commonSettings = new CommonSettings(100, 10, Duration.ofSeconds(2));
+        StreamConfig roomConfig = new StreamConfig("concurrent", null, null, null, null);
+        StreamConfig racingConfig = new StreamConfig("concurrent", null, null, null, null);
+
+        redisStreamProperties = new RedisStreamProperties(
+                commonSettings,
+                null,
+                Map.of("room", roomConfig, "racinggame", racingConfig)
+        );
+
+        lagMetricService = new RedisStreamLagMetricService(
+                stringRedisTemplate, redisStreamProperties, meterRegistry, applicationContext
+        );
+    }
+
+    @Test
+    void 스트림별_길이_게이지가_등록된다() {
+        // when
+        lagMetricService.initializeMetrics();
+
+        // then
+        Gauge roomGauge = meterRegistry.find("redis.stream.length")
+                .tag("stream", "room")
+                .gauge();
+        assertThat(roomGauge).isNotNull();
+        assertThat(roomGauge.value()).isEqualTo(42.0);
+    }
+
+    @Test
+    void 여러_스트림의_게이지가_각각_등록된다() {
+        // when
+        lagMetricService.initializeMetrics();
+
+        // then
+        Gauge roomGauge = meterRegistry.find("redis.stream.length")
+                .tag("stream", "room")
+                .gauge();
+        Gauge racingGauge = meterRegistry.find("redis.stream.length")
+                .tag("stream", "racinggame")
+                .gauge();
+
+        assertThat(roomGauge).isNotNull();
+        assertThat(racingGauge).isNotNull();
+        assertThat(roomGauge.value()).isEqualTo(42.0);
+        assertThat(racingGauge.value()).isEqualTo(7.0);
+    }
+
+    @Test
+    void 스레드풀_큐_깊이_게이지가_등록된다() {
+        // when
+        lagMetricService.initializeMetrics();
+
+        // then: 빈을 못 찾으면 -1.0 반환
+        Gauge queueGauge = meterRegistry.find("redis.stream.threadpool.queue.size")
+                .tag("stream", "room")
+                .gauge();
+        assertThat(queueGauge).isNotNull();
+        assertThat(queueGauge.value()).isEqualTo(-1.0);
+    }
+
+    @Test
+    void 스트림_설정이_없으면_게이지를_등록하지_않는다() {
+        // given
+        RedisStreamProperties emptyProperties = new RedisStreamProperties(null, null, null);
+        RedisStreamLagMetricService emptyService = new RedisStreamLagMetricService(
+                stringRedisTemplate, emptyProperties, meterRegistry, applicationContext
+        );
+
+        // when
+        emptyService.initializeMetrics();
+
+        // then
+        Gauge gauge = meterRegistry.find("redis.stream.length").gauge();
+        assertThat(gauge).isNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void XLEN_조회_실패_시_음수를_반환한다() {
+        // given
+        StreamOperations<String, Object, Object> failingOps = mock(StreamOperations.class);
+        given(stringRedisTemplate.opsForStream()).willReturn(failingOps);
+        given(failingOps.size("room")).willThrow(new RuntimeException("Redis 연결 실패"));
+
+        lagMetricService.initializeMetrics();
+
+        // when
+        Gauge gauge = meterRegistry.find("redis.stream.length")
+                .tag("stream", "room")
+                .gauge();
+
+        // then
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo(-1.0);
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
@@ -131,6 +131,6 @@ class RedisStreamLagMetricServiceTest {
 
         // then
         assertThat(gauge).isNotNull();
-        assertThat(gauge.value()).isEqualTo(Double.NaN);
+        assertThat(gauge.value()).isNaN();
     }
 }

--- a/backend/src/test/java/coffeeshout/global/metric/RedisStreamLatencyMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RedisStreamLatencyMetricServiceTest.java
@@ -1,0 +1,99 @@
+package coffeeshout.global.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.redis.BaseEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RedisStreamLatencyMetricServiceTest {
+
+    private MeterRegistry meterRegistry;
+    private RedisStreamLatencyMetricService latencyMetricService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        latencyMetricService = new RedisStreamLatencyMetricService(meterRegistry);
+        latencyMetricService.initializeMetrics();
+    }
+
+    @Test
+    void 정상적인_이벤트의_지연_시간이_기록된다() {
+        // given
+        BaseEvent event = createEvent(Instant.now().minusMillis(30));
+
+        // when
+        latencyMetricService.recordLatency(event);
+
+        // then
+        Timer timer = meterRegistry.find("redis.stream.e2e.latency").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+        assertThat(timer.totalTime(java.util.concurrent.TimeUnit.MILLISECONDS)).isGreaterThan(0);
+    }
+
+    @Test
+    void timestamp가_null인_이벤트는_기록하지_않는다() {
+        // given
+        BaseEvent event = createEvent(null);
+
+        // when
+        latencyMetricService.recordLatency(event);
+
+        // then
+        Timer timer = meterRegistry.find("redis.stream.e2e.latency").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(0);
+    }
+
+    @Test
+    void 음수_지연은_기록하지_않는다() {
+        // given: 미래 시점의 timestamp (clock skew 시뮬레이션)
+        BaseEvent event = createEvent(Instant.now().plusSeconds(10));
+
+        // when
+        latencyMetricService.recordLatency(event);
+
+        // then
+        Timer timer = meterRegistry.find("redis.stream.e2e.latency").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(0);
+    }
+
+    @Test
+    void 여러_이벤트의_지연_시간이_누적_기록된다() {
+        // given
+        BaseEvent event1 = createEvent(Instant.now().minusMillis(10));
+        BaseEvent event2 = createEvent(Instant.now().minusMillis(20));
+        BaseEvent event3 = createEvent(Instant.now().minusMillis(30));
+
+        // when
+        latencyMetricService.recordLatency(event1);
+        latencyMetricService.recordLatency(event2);
+        latencyMetricService.recordLatency(event3);
+
+        // then
+        Timer timer = meterRegistry.find("redis.stream.e2e.latency").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(3);
+    }
+
+    private BaseEvent createEvent(Instant timestamp) {
+        return new BaseEvent() {
+            @Override
+            public String eventId() {
+                return "test-event-id";
+            }
+
+            @Override
+            public Instant timestamp() {
+                return timestamp;
+            }
+        };
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
@@ -44,7 +44,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_생성_시_READY_상태_Gauge가_증가한다() {
         // given
-        Room room = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
+        Room room = Room.createNewRoom(new JoinCode("ABC1"), new PlayerName("host1"));
         memoryRoomRepository.save(room);
 
         // when
@@ -61,8 +61,8 @@ class RoomActiveMetricServiceTest {
     @Test
     void 여러_Room의_상태별_Gauge가_정확히_집계된다() {
         // given
-        Room room1 = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
-        Room room2 = Room.createNewRoom(new JoinCode("DEF34"), new PlayerName("host2"));
+        Room room1 = Room.createNewRoom(new JoinCode("ABC1"), new PlayerName("host1"));
+        Room room2 = Room.createNewRoom(new JoinCode("DEF3"), new PlayerName("host2"));
 
         memoryRoomRepository.save(room1);
         memoryRoomRepository.save(room2);
@@ -81,7 +81,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_삭제_시_Gauge가_감소한다() {
         // given
-        JoinCode joinCode = new JoinCode("ABC12");
+        JoinCode joinCode = new JoinCode("ABC1");
         Room room = Room.createNewRoom(joinCode, new PlayerName("host1"));
         memoryRoomRepository.save(room);
 

--- a/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
@@ -48,7 +48,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_생성_시_READY_상태_Gauge가_증가한다() {
         // given
-        Room room = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
+        Room room = Room.createNewRoom(new JoinCode("ABC4"), new PlayerName("host1"));
         memoryRoomRepository.save(room);
 
         // when
@@ -65,8 +65,8 @@ class RoomActiveMetricServiceTest {
     @Test
     void 여러_Room의_상태별_Gauge가_정확히_집계된다() {
         // given
-        Room room1 = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
-        Room room2 = Room.createNewRoom(new JoinCode("DEF34"), new PlayerName("host2"));
+        Room room1 = Room.createNewRoom(new JoinCode("ABC6"), new PlayerName("host1"));
+        Room room2 = Room.createNewRoom(new JoinCode("D7F4"), new PlayerName("host2"));
 
         memoryRoomRepository.save(room1);
         memoryRoomRepository.save(room2);
@@ -85,7 +85,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_삭제_시_Gauge가_감소한다() {
         // given
-        JoinCode joinCode = new JoinCode("ABC12");
+        JoinCode joinCode = new JoinCode("ABC4");
         Room room = Room.createNewRoom(joinCode, new PlayerName("host1"));
         memoryRoomRepository.save(room);
 

--- a/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
@@ -1,0 +1,113 @@
+package coffeeshout.global.metric;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.repository.MemoryRoomRepository;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RoomActiveMetricServiceTest {
+
+    private MeterRegistry meterRegistry;
+    private MemoryRoomRepository memoryRoomRepository;
+    private RoomActiveMetricService roomActiveMetricService;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        memoryRoomRepository = new MemoryRoomRepository();
+        roomActiveMetricService = new RoomActiveMetricService(memoryRoomRepository, meterRegistry);
+        roomActiveMetricService.initializeMetrics();
+    }
+
+    @Test
+    void Room이_없을_때_모든_상태의_Gauge가_0이다() {
+        // when
+        Gauge readyGauge = meterRegistry.find("room.active.count")
+                .tag("state", "READY")
+                .gauge();
+        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
+
+        // then
+        assertThat(readyGauge).isNotNull();
+        assertThat(readyGauge.value()).isEqualTo(0.0);
+        assertThat(totalGauge).isNotNull();
+        assertThat(totalGauge.value()).isEqualTo(0.0);
+    }
+
+    @Test
+    void Room_생성_시_READY_상태_Gauge가_증가한다() {
+        // given
+        Room room = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
+        memoryRoomRepository.save(room);
+
+        // when
+        Gauge readyGauge = meterRegistry.find("room.active.count")
+                .tag("state", "READY")
+                .gauge();
+        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
+
+        // then
+        assertThat(readyGauge.value()).isEqualTo(1.0);
+        assertThat(totalGauge.value()).isEqualTo(1.0);
+    }
+
+    @Test
+    void 여러_Room의_상태별_Gauge가_정확히_집계된다() {
+        // given
+        Room room1 = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
+        Room room2 = Room.createNewRoom(new JoinCode("DEF34"), new PlayerName("host2"));
+
+        memoryRoomRepository.save(room1);
+        memoryRoomRepository.save(room2);
+
+        // when
+        Gauge readyGauge = meterRegistry.find("room.active.count")
+                .tag("state", "READY")
+                .gauge();
+        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
+
+        // then
+        assertThat(readyGauge.value()).isEqualTo(2.0);
+        assertThat(totalGauge.value()).isEqualTo(2.0);
+    }
+
+    @Test
+    void Room_삭제_시_Gauge가_감소한다() {
+        // given
+        JoinCode joinCode = new JoinCode("ABC12");
+        Room room = Room.createNewRoom(joinCode, new PlayerName("host1"));
+        memoryRoomRepository.save(room);
+
+        // when
+        memoryRoomRepository.deleteByJoinCode(joinCode);
+
+        // then
+        Gauge readyGauge = meterRegistry.find("room.active.count")
+                .tag("state", "READY")
+                .gauge();
+        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
+
+        assertThat(readyGauge.value()).isEqualTo(0.0);
+        assertThat(totalGauge.value()).isEqualTo(0.0);
+    }
+
+    @Test
+    void 모든_RoomState에_대해_Gauge가_등록된다() {
+        // when & then
+        for (String state : new String[]{"READY", "PLAYING", "SCORE_BOARD", "ROULETTE", "DONE"}) {
+            Gauge gauge = meterRegistry.find("room.active.count")
+                    .tag("state", state)
+                    .gauge();
+            assertThat(gauge)
+                    .as("state=%s에 대한 Gauge가 등록되어야 한다", state)
+                    .isNotNull();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
@@ -44,7 +44,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_생성_시_READY_상태_Gauge가_증가한다() {
         // given
-        Room room = Room.createNewRoom(new JoinCode("ABC1"), new PlayerName("host1"));
+        Room room = Room.createNewRoom(new JoinCode("ABC4"), new PlayerName("host1"));
         memoryRoomRepository.save(room);
 
         // when
@@ -61,8 +61,8 @@ class RoomActiveMetricServiceTest {
     @Test
     void 여러_Room의_상태별_Gauge가_정확히_집계된다() {
         // given
-        Room room1 = Room.createNewRoom(new JoinCode("ABC1"), new PlayerName("host1"));
-        Room room2 = Room.createNewRoom(new JoinCode("DEF3"), new PlayerName("host2"));
+        Room room1 = Room.createNewRoom(new JoinCode("ABC4"), new PlayerName("host1"));
+        Room room2 = Room.createNewRoom(new JoinCode("D7F3"), new PlayerName("host2"));
 
         memoryRoomRepository.save(room1);
         memoryRoomRepository.save(room2);
@@ -81,7 +81,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_삭제_시_Gauge가_감소한다() {
         // given
-        JoinCode joinCode = new JoinCode("ABC1");
+        JoinCode joinCode = new JoinCode("ABC4");
         Room room = Room.createNewRoom(joinCode, new PlayerName("host1"));
         memoryRoomRepository.save(room);
 

--- a/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/metric/RoomActiveMetricServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.RoomState;
 import coffeeshout.room.domain.player.PlayerName;
 import coffeeshout.room.domain.repository.MemoryRoomRepository;
 import io.micrometer.core.instrument.Gauge;
@@ -27,16 +28,19 @@ class RoomActiveMetricServiceTest {
     }
 
     @Test
-    void Room이_없을_때_모든_상태의_Gauge가_0이다() {
-        // when
-        Gauge readyGauge = meterRegistry.find("room.active.count")
-                .tag("state", "READY")
-                .gauge();
-        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
+    void 모든_RoomState에_대해_Gauge가_등록된다() {
+        // when & then
+        for (RoomState state : RoomState.values()) {
+            Gauge gauge = meterRegistry.find("room.active.count")
+                    .tag("state", state.name())
+                    .gauge();
+            assertThat(gauge)
+                    .as("state=%s에 대한 Gauge가 등록되어야 한다", state.name())
+                    .isNotNull();
+            assertThat(gauge.value()).isEqualTo(0.0);
+        }
 
-        // then
-        assertThat(readyGauge).isNotNull();
-        assertThat(readyGauge.value()).isEqualTo(0.0);
+        Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
         assertThat(totalGauge).isNotNull();
         assertThat(totalGauge.value()).isEqualTo(0.0);
     }
@@ -44,12 +48,12 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_생성_시_READY_상태_Gauge가_증가한다() {
         // given
-        Room room = Room.createNewRoom(new JoinCode("ABC4"), new PlayerName("host1"));
+        Room room = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
         memoryRoomRepository.save(room);
 
         // when
         Gauge readyGauge = meterRegistry.find("room.active.count")
-                .tag("state", "READY")
+                .tag("state", RoomState.READY.name())
                 .gauge();
         Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
 
@@ -61,15 +65,15 @@ class RoomActiveMetricServiceTest {
     @Test
     void 여러_Room의_상태별_Gauge가_정확히_집계된다() {
         // given
-        Room room1 = Room.createNewRoom(new JoinCode("ABC4"), new PlayerName("host1"));
-        Room room2 = Room.createNewRoom(new JoinCode("D7F3"), new PlayerName("host2"));
+        Room room1 = Room.createNewRoom(new JoinCode("ABC12"), new PlayerName("host1"));
+        Room room2 = Room.createNewRoom(new JoinCode("DEF34"), new PlayerName("host2"));
 
         memoryRoomRepository.save(room1);
         memoryRoomRepository.save(room2);
 
         // when
         Gauge readyGauge = meterRegistry.find("room.active.count")
-                .tag("state", "READY")
+                .tag("state", RoomState.READY.name())
                 .gauge();
         Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
 
@@ -81,7 +85,7 @@ class RoomActiveMetricServiceTest {
     @Test
     void Room_삭제_시_Gauge가_감소한다() {
         // given
-        JoinCode joinCode = new JoinCode("ABC4");
+        JoinCode joinCode = new JoinCode("ABC12");
         Room room = Room.createNewRoom(joinCode, new PlayerName("host1"));
         memoryRoomRepository.save(room);
 
@@ -90,24 +94,11 @@ class RoomActiveMetricServiceTest {
 
         // then
         Gauge readyGauge = meterRegistry.find("room.active.count")
-                .tag("state", "READY")
+                .tag("state", RoomState.READY.name())
                 .gauge();
         Gauge totalGauge = meterRegistry.find("room.total.count").gauge();
 
         assertThat(readyGauge.value()).isEqualTo(0.0);
         assertThat(totalGauge.value()).isEqualTo(0.0);
-    }
-
-    @Test
-    void 모든_RoomState에_대해_Gauge가_등록된다() {
-        // when & then
-        for (String state : new String[]{"READY", "PLAYING", "SCORE_BOARD", "ROULETTE", "DONE"}) {
-            Gauge gauge = meterRegistry.find("room.active.count")
-                    .tag("state", state)
-                    .gauge();
-            assertThat(gauge)
-                    .as("state=%s에 대한 Gauge가 등록되어야 한다", state)
-                    .isNotNull();
-        }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/websocket/ratelimit/WebSocketRateLimiterMetricTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/ratelimit/WebSocketRateLimiterMetricTest.java
@@ -1,0 +1,131 @@
+package coffeeshout.global.websocket.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class WebSocketRateLimiterMetricTest {
+
+    private static final int MAX_MESSAGES_PER_SECOND = 20;
+    private static final Instant BASE_TIME = Instant.parse("2026-01-01T00:00:00Z");
+
+    private TestClock testClock;
+    private MeterRegistry meterRegistry;
+    private WebSocketRateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() {
+        testClock = new TestClock(BASE_TIME);
+        meterRegistry = new SimpleMeterRegistry();
+        rateLimiter = new WebSocketRateLimiter(MAX_MESSAGES_PER_SECOND, testClock, meterRegistry);
+    }
+
+    @Test
+    void Rate_Limit_초과_시_드롭_카운터가_증가한다() {
+        // given
+        String sessionId = "session-1";
+        for (int i = 0; i < MAX_MESSAGES_PER_SECOND; i++) {
+            rateLimiter.tryAcquire(sessionId);
+        }
+
+        // when: 21번째 메시지 → 드롭
+        rateLimiter.tryAcquire(sessionId);
+
+        // then
+        Counter counter = meterRegistry.find("websocket.ratelimit.dropped.total").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void Rate_Limit_이내에서는_드롭_카운터가_증가하지_않는다() {
+        // given
+        String sessionId = "session-1";
+
+        // when
+        for (int i = 0; i < MAX_MESSAGES_PER_SECOND; i++) {
+            rateLimiter.tryAcquire(sessionId);
+        }
+
+        // then
+        Counter counter = meterRegistry.find("websocket.ratelimit.dropped.total").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(0.0);
+    }
+
+    @Test
+    void 여러_번_초과_시_드롭_카운터가_누적된다() {
+        // given
+        String sessionId = "session-1";
+        for (int i = 0; i < MAX_MESSAGES_PER_SECOND; i++) {
+            rateLimiter.tryAcquire(sessionId);
+        }
+
+        // when: 3번 초과
+        rateLimiter.tryAcquire(sessionId);
+        rateLimiter.tryAcquire(sessionId);
+        rateLimiter.tryAcquire(sessionId);
+
+        // then
+        Counter counter = meterRegistry.find("websocket.ratelimit.dropped.total").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(3.0);
+    }
+
+    @Test
+    void 윈도우_리셋_후_초과하면_드롭_카운터가_다시_누적된다() {
+        // given
+        String sessionId = "session-1";
+        for (int i = 0; i < MAX_MESSAGES_PER_SECOND; i++) {
+            rateLimiter.tryAcquire(sessionId);
+        }
+        rateLimiter.tryAcquire(sessionId); // 드롭 1회
+
+        // when: 윈도우 리셋 후 다시 초과
+        testClock.advance(Duration.ofSeconds(1));
+        for (int i = 0; i < MAX_MESSAGES_PER_SECOND; i++) {
+            rateLimiter.tryAcquire(sessionId);
+        }
+        rateLimiter.tryAcquire(sessionId); // 드롭 2회째
+
+        // then
+        Counter counter = meterRegistry.find("websocket.ratelimit.dropped.total").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(2.0);
+    }
+
+    static class TestClock extends Clock {
+        private Instant current;
+
+        TestClock(Instant initial) {
+            this.current = initial;
+        }
+
+        void advance(Duration duration) {
+            current = current.plus(duration);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return current;
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1098

# 🚀 작업 내용
## 배경

현재 모니터링 환경은 시스템 기본 지표(CPU, Memory, JVM), HTTP 트래픽, HikariCP, WebSocket 연결 수 수준에 머물러 있다.
실시간 멀티플레이 게임의 핵심 데이터 파이프라인인 Redis Stream에 대한 관측 지표가 전무하여,
메시지 처리 지연이나 스레드풀 포화 같은 장애 징후를 사전에 감지할 수 없는 상태이다.

## 문제

- Redis Stream 메시지 발행~소비 간 End-to-End 지연 시간을 측정하고 있지 않음
- 5개 스트림(`room`, `room:join`, `cardgame:select`, `minigame`, `racinggame`)의 백로그/큐 포화도 파악 불가
- WebSocket Rate Limit 드롭 횟수 미집계 → 임계치 적정성 판단 불가
- Room/Game 상태별 활성 수 미측정 → 동시 부하 규모 파악 불가

## 요약

Redis Stream 파이프라인에 대한 관측 가능성(Observability)이 전무했던 문제를 해결한다.
메시지 처리 지연 시간, 스트림 백로그, WebSocket Rate Limit 드롭 수, Room 상태별 활성 수를
Micrometer 메트릭으로 수집하여 Prometheus/Grafana에서 시각화가 가능하도록 한다.

## 변경 사항

### 신규 파일

| 파일 | 역할 |
|------|------|
| `RedisStreamLatencyMetricService` | `BaseEvent.timestamp()` ~ 소비 시점 간 시간차를 Timer로 기록. p50/p95/p99 퍼센타일 히스토그램 노출 |
| `RedisStreamLagMetricService` | 스트림별 `XLEN`, 스레드풀 큐 깊이, 활성 스레드 수를 Gauge로 등록. 10초 주기로 maxLength 80% 초과 시 경고 로그 |
| `RoomActiveMetricService` | `MemoryRoomRepository` 기반 Room 상태별(READY, PLAYING, SCORE_BOARD, ROULETTE, DONE) 활성 수 Gauge |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `EventDispatcher` | `RedisStreamLatencyMetricService` 의존성 추가, `handle()` 진입 시점에 `recordLatency()` 호출 |
| `WebSocketRateLimiter` | `MeterRegistry` 의존성 추가, `tryAcquire()` 실패 시 `websocket.ratelimit.dropped.total` Counter increment |
| `MemoryRoomRepository` | `countByState(RoomState)`, `totalCount()` 메서드 추가 |

### 노출되는 Prometheus 메트릭

| 메트릭명 | 타입 | 설명 |
|----------|------|------|
| `redis_stream_e2e_latency_seconds` | Timer (Histogram) | 발행~소비 E2E 지연 시간 |
| `redis_stream_length` | Gauge | 스트림별 현재 메시지 수 (XLEN) |
| `redis_stream_threadpool_queue_size` | Gauge | 컨슈머 스레드풀 대기 큐 크기 |
| `redis_stream_threadpool_active_count` | Gauge | 컨슈머 스레드풀 활성 스레드 수 |
| `websocket_ratelimit_dropped_total` | Counter | Rate Limit 초과로 드롭된 메시지 수 |
| `room_active_count` | Gauge | Room 상태별 활성 수 (tag: state) |
| `room_total_count` | Gauge | 전체 활성 Room 수 |

## 성능 영향

- **WAS**: `Instant.now()` + `Duration.between()` 연산 1회 추가 (나노초 수준, 기존 WebSocketMetricService와 동일 패턴)
- **Redis**: `XLEN`은 O(1) 연산. Prometheus scrape 주기(15s)에만 호출되므로 초당 ~0.33 요청 수준
- **Prometheus TSDB**: 히스토그램 버킷 ~70개 + Gauge/Counter 시리즈 ~25개 추가. 전체 TSDB 용량 대비 1% 미만
- **Rate Limit Counter**: `tryAcquire()` 실패 시에만 increment하므로 정상 트래픽에서는 추가 비용 없음
- **Room Gauge**: `MemoryRoomRepository`의 ConcurrentHashMap 순회. Room 수가 수백 개 이하이므로 scrape당 마이크로초 수준

## 테스트

- `RedisStreamLatencyMetricServiceTest`: E2E 지연 기록, null timestamp 방어, clock skew(음수 지연) 방어, 누적 기록 검증
- `RedisStreamLagMetricServiceTest`: 스트림별 Gauge 등록, 다중 스트림 독립 측정, 스레드풀 빈 미발견 시 fallback, 빈 설정 방어, XLEN 실패 시 -1 반환 검증
- `WebSocketRateLimiterMetricTest`: 드롭 시 Counter 증가, 제한 이내 시 Counter 미증가, 누적 카운팅, 윈도우 리셋 후 재누적 검증
- `RoomActiveMetricServiceTest`: 빈 상태 Gauge 0 검증, Room 생성 시 READY 증가, 상태별 집계, 삭제 시 감소, 전체 RoomState Gauge 등록 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Redis Stream 지연 시간 및 큐 메트릭 모니터링 추가
  * Redis Stream 메시지 엔드-투-엔드 지연 시간 측정 기능 추가
  * 활성 채팅방 상태별 개수 추적 메트릭 추가
  * WebSocket 속도 제한 초과 메시지 카운팅 추가

* **Tests**
  * 메트릭 수집 및 노출 기능에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->