### PR TITLE
[fix] Redis Stream 비동기 이벤트 Trace Context 전파

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
 
     // --- Test ---
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.micrometer:micrometer-tracing-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.h2database:h2")
     testImplementation("org.testcontainers:testcontainers:${testcontainersVersion}")

--- a/backend/src/main/java/coffeeshout/global/redis/config/RedisStreamThreadPoolConfig.java
+++ b/backend/src/main/java/coffeeshout/global/redis/config/RedisStreamThreadPoolConfig.java
@@ -2,6 +2,7 @@ package coffeeshout.global.redis.config;
 
 import coffeeshout.global.redis.config.RedisStreamProperties.StreamConfig;
 import coffeeshout.global.redis.config.RedisStreamProperties.ThreadPoolConfig;
+import io.micrometer.context.ContextSnapshotFactory;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ public class RedisStreamThreadPoolConfig {
 
     private final RedisStreamProperties properties;
     private final GenericApplicationContext applicationContext;
+    private final ContextSnapshotFactory snapshotFactory;
     private static final String BEAN_NAME = "redis-stream-thread-pool-%s";
 
     @PostConstruct
@@ -48,6 +50,7 @@ public class RedisStreamThreadPoolConfig {
         executor.setMaxPoolSize(config.maxSize());
         executor.setQueueCapacity(config.queueCapacity());
         executor.setThreadNamePrefix(threadNamePrefix);
+        executor.setTaskDecorator(runnable -> snapshotFactory.captureAll().wrap(runnable));
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(10);
         return executor;

--- a/backend/src/main/java/coffeeshout/global/trace/TracerProvider.java
+++ b/backend/src/main/java/coffeeshout/global/trace/TracerProvider.java
@@ -31,6 +31,9 @@ public class TracerProvider {
                 .start();
         try (Tracer.SpanInScope spanInScope = tracer.withSpan(span)) {
             task.run();
+        } catch (Throwable t) {
+            span.error(t);
+            throw t;
         } finally {
             span.end();
         }

--- a/backend/src/main/java/coffeeshout/racinggame/domain/event/TapCommandEvent.java
+++ b/backend/src/main/java/coffeeshout/racinggame/domain/event/TapCommandEvent.java
@@ -3,6 +3,7 @@ package coffeeshout.racinggame.domain.event;
 import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.trace.TraceInfo;
 import coffeeshout.global.trace.TraceInfoExtractor;
+import coffeeshout.global.trace.Traceable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -13,7 +14,7 @@ public record TapCommandEvent(
         int tapCount,
         Instant timestamp,
         TraceInfo traceInfo
-) implements BaseEvent {
+) implements BaseEvent, Traceable {
 
     public static TapCommandEvent create(String joinCode, String playerName, int tapCount) {
         final String eventId = UUID.randomUUID().toString();

--- a/backend/src/main/java/coffeeshout/room/domain/event/RouletteShownEvent.java
+++ b/backend/src/main/java/coffeeshout/room/domain/event/RouletteShownEvent.java
@@ -1,20 +1,25 @@
 package coffeeshout.room.domain.event;
 
 import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.trace.TraceInfo;
+import coffeeshout.global.trace.TraceInfoExtractor;
+import coffeeshout.global.trace.Traceable;
 import coffeeshout.room.domain.RoomState;
 import java.time.Instant;
 import java.util.UUID;
 
 public record RouletteShownEvent(
         String eventId,
+        TraceInfo traceInfo,
         Instant timestamp,
         String joinCode,
         RoomState roomState
-) implements BaseEvent {
+) implements BaseEvent, Traceable {
 
     public RouletteShownEvent(String joinCode, RoomState roomState) {
         this(
                 UUID.randomUUID().toString(),
+                TraceInfoExtractor.extract(),
                 Instant.now(),
                 joinCode,
                 roomState

--- a/backend/src/main/java/coffeeshout/room/domain/event/RouletteWinnerEvent.java
+++ b/backend/src/main/java/coffeeshout/room/domain/event/RouletteWinnerEvent.java
@@ -1,19 +1,25 @@
 package coffeeshout.room.domain.event;
 
 import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.trace.TraceInfo;
+import coffeeshout.global.trace.TraceInfoExtractor;
+import coffeeshout.global.trace.Traceable;
 import coffeeshout.room.domain.player.Winner;
 import java.time.Instant;
+import java.util.UUID;
 
 public record RouletteWinnerEvent(
         String eventId,
+        TraceInfo traceInfo,
         Instant timestamp,
         String joinCode,
         Winner winner
-) implements BaseEvent {
+) implements BaseEvent, Traceable {
 
-    public RouletteWinnerEvent(String joinCode, Winner winner){
+    public RouletteWinnerEvent(String joinCode, Winner winner) {
         this(
-                java.util.UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                TraceInfoExtractor.extract(),
                 Instant.now(),
                 joinCode,
                 winner

--- a/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
@@ -1,0 +1,180 @@
+package coffeeshout.global.trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import coffeeshout.fixture.RoomFixture;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.event.RoomJoinEvent;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.support.test.IntegrationTest;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Scope;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.Tracer;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Redis Stream을 경유하는 이벤트의 Trace Context 전파를 검증하는 통합 테스트.
+ * <p>
+ * Publisher 스레드에서 생성한 traceId가 Consumer 스레드(EventDispatcher → TracerProvider)까지 정상적으로 전파되는지 확인한다.
+ */
+@IntegrationTest
+class RedisStreamContextPropagationTest {
+
+    @Autowired
+    StreamPublisher streamPublisher;
+
+    @Autowired
+    RoomRepository roomRepository;
+
+    @Autowired
+    ObservationRegistry observationRegistry;
+
+    @Autowired
+    Tracer tracer;
+
+    private String joinCode;
+
+    @BeforeEach
+    void setUp() {
+        Room testRoom = RoomFixture.호스트_꾹이();
+        roomRepository.save(testRoom);
+        joinCode = testRoom.getJoinCode().getValue();
+    }
+
+    @Nested
+    class Observation_스코프_내에서_이벤트_발행_시 {
+
+        @Test
+        void Publisher의_traceId가_이벤트_DTO의_TraceInfo에_주입된다() {
+            // given
+            AtomicReference<String> publisherTraceId = new AtomicReference<>();
+            AtomicReference<String> eventTraceId = new AtomicReference<>();
+
+            Observation observation = Observation.createNotStarted("test-publish", observationRegistry).start();
+            try (Scope scope = observation.openScope()) {
+                publisherTraceId.set(tracer.currentSpan().context().traceId());
+
+                RoomJoinEvent event = new RoomJoinEvent(joinCode, "전파테스트");
+                eventTraceId.set(event.traceInfo().traceId());
+            } finally {
+                observation.stop();
+            }
+
+            // then
+            assertThat(eventTraceId.get()).isNotBlank();
+            assertThat(eventTraceId.get()).isEqualTo(publisherTraceId.get());
+        }
+
+        @Test
+        void Redis_Stream을_경유해도_Consumer에서_이벤트가_정상_처리된다() {
+            // given
+            AtomicReference<String> publisherTraceId = new AtomicReference<>();
+
+            Observation observation = Observation.createNotStarted("test-e2e-trace", observationRegistry).start();
+            try (Scope scope = observation.openScope()) {
+                publisherTraceId.set(tracer.currentSpan().context().traceId());
+
+                RoomJoinEvent event = new RoomJoinEvent(joinCode, "E2E전파");
+                streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+            } finally {
+                observation.stop();
+            }
+
+            // then — Awaitility로 비동기 Consumer 처리 완료를 폴링
+            await().atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(100))
+                    .untilAsserted(() -> {
+                        Room updatedRoom = roomRepository.findByJoinCode(new JoinCode(joinCode)).orElseThrow();
+                        boolean playerExists = updatedRoom.getPlayers().stream()
+                                .anyMatch(player -> "E2E전파".equals(player.getName().value()));
+                        assertThat(playerExists)
+                                .as("Consumer가 traceId를 복원하고 이벤트를 정상 처리해야 한다")
+                                .isTrue();
+                    });
+
+            assertThat(publisherTraceId.get()).isNotBlank();
+        }
+
+        @Test
+        void 여러_이벤트를_동시에_발행해도_각각의_traceId가_올바르게_전파된다() {
+            // given
+            int eventCount = 3;
+            CountDownLatch publishLatch = new CountDownLatch(eventCount);
+            String[] playerNames = {"동시전파1", "동시전파2", "동시전파3"};
+
+            for (String playerName : playerNames) {
+                Observation observation = Observation.createNotStarted("test-concurrent-" + playerName,
+                        observationRegistry).start();
+                try (Scope scope = observation.openScope()) {
+                    RoomJoinEvent event = new RoomJoinEvent(joinCode, playerName);
+
+                    // traceId가 비어있지 않은지 발행 시점에 확인
+                    assertThat(event.traceInfo().traceId()).isNotBlank();
+
+                    streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+                    publishLatch.countDown();
+                } finally {
+                    observation.stop();
+                }
+            }
+
+            // then — 모든 이벤트가 Consumer에서 정상 처리되었는지 Awaitility로 검증
+            await().atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(100))
+                    .untilAsserted(() -> {
+                        Room updatedRoom = roomRepository.findByJoinCode(new JoinCode(joinCode)).orElseThrow();
+                        for (String playerName : playerNames) {
+                            boolean exists = updatedRoom.getPlayers().stream()
+                                    .anyMatch(p -> playerName.equals(p.getName().value()));
+                            assertThat(exists)
+                                    .as("플레이어 '%s'가 Consumer에서 처리되어야 한다", playerName)
+                                    .isTrue();
+                        }
+                    });
+        }
+    }
+
+    @Nested
+    class Observation_스코프_바깥에서_이벤트_생성_시 {
+
+        @Test
+        void TraceInfo가_빈_값이다() {
+            // given
+            RoomJoinEvent event = new RoomJoinEvent(joinCode, "노트레이스");
+
+            // then
+            assertThat(event.traceInfo().traceId()).isEmpty();
+            assertThat(event.traceInfo().spanId()).isEmpty();
+        }
+
+        @Test
+        void 빈_TraceInfo여도_Consumer에서_이벤트는_정상_처리된다() {
+            // given
+            RoomJoinEvent event = new RoomJoinEvent(joinCode, "노트레이스처리");
+            assertThat(event.traceInfo().traceable()).isFalse();
+
+            streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+
+            // then — trace 없어도 비즈니스 로직은 돌아야 한다
+            await().atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(100))
+                    .untilAsserted(() -> {
+                        Room updatedRoom = roomRepository.findByJoinCode(new JoinCode(joinCode)).orElseThrow();
+                        boolean exists = updatedRoom.getPlayers().stream()
+                                .anyMatch(p -> "노트레이스처리".equals(p.getName().value()));
+                        assertThat(exists).isTrue();
+                    });
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
@@ -134,37 +134,40 @@ class RedisStreamContextPropagationTest {
             CountDownLatch startBarrier = new CountDownLatch(1);
             ExecutorService executor = Executors.newFixedThreadPool(playerNames.length);
 
-            // when — CompletableFuture로 실제 동시 발행
-            CompletableFuture<?>[] futures = new CompletableFuture[playerNames.length];
-            for (int i = 0; i < playerNames.length; i++) {
-                String playerName = playerNames[i];
-                futures[i] = CompletableFuture.runAsync(() -> {
-                    try {
-                        startBarrier.await(3, java.util.concurrent.TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
-
-                    Observation observation = Observation.createNotStarted(
-                            "test-concurrent-" + playerName, observationRegistry).start();
-                    try (Scope scope = observation.openScope()) {
-                        RoomJoinEvent event = new RoomJoinEvent(joinCode, playerName);
-
-                        synchronized (capturedTraceIds) {
-                            capturedTraceIds.add(event.traceInfo().traceId());
+            try {
+                // when — CompletableFuture로 실제 동시 발행
+                CompletableFuture<?>[] futures = new CompletableFuture[playerNames.length];
+                for (int i = 0; i < playerNames.length; i++) {
+                    String playerName = playerNames[i];
+                    futures[i] = CompletableFuture.runAsync(() -> {
+                        try {
+                            startBarrier.await(3, java.util.concurrent.TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
                         }
 
-                        streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
-                    } finally {
-                        observation.stop();
-                    }
-                }, executor);
-            }
+                        Observation observation = Observation.createNotStarted(
+                                "test-concurrent-" + playerName, observationRegistry).start();
+                        try (Scope scope = observation.openScope()) {
+                            RoomJoinEvent event = new RoomJoinEvent(joinCode, playerName);
 
-            startBarrier.countDown();
-            CompletableFuture.allOf(futures).join();
-            executor.shutdown();
+                            synchronized (capturedTraceIds) {
+                                capturedTraceIds.add(event.traceInfo().traceId());
+                            }
+
+                            streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+                        } finally {
+                            observation.stop();
+                        }
+                    }, executor);
+                }
+
+                startBarrier.countDown();
+                CompletableFuture.allOf(futures).join();
+            } finally {
+                executor.shutdownNow();
+            }
 
             // then — 각 이벤트가 서로 다른 traceId를 가짐
             assertThat(capturedTraceIds)

--- a/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
@@ -16,7 +16,12 @@ import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -25,8 +30,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Redis Stream을 경유하는 이벤트의 Trace Context 전파를 검증하는 통합 테스트.
- * <p>
- * Publisher 스레드에서 생성한 traceId가 Consumer 스레드(EventDispatcher → TracerProvider)까지 정상적으로 전파되는지 확인한다.
+ *
+ * <p>Publisher 스레드에서 생성한 traceId가 이벤트 DTO에 정상 주입되고,
+ * Consumer 스레드(EventDispatcher → TracerProvider)에서 해당 traceId로 Span이 복원되는지 확인한다.</p>
+ *
+ * <p>Consumer 내부의 MDC/Span 복원은 {@link TracerProviderTest}에서 단위 테스트로 증명한다.
+ * 이 통합 테스트는 "Publisher traceId → 이벤트 DTO → Redis Stream → Consumer 정상 처리"
+ * 의 E2E 흐름이 끊어지지 않는 것을 검증한다.</p>
  */
 @IntegrationTest
 class RedisStreamContextPropagationTest {
@@ -77,21 +87,32 @@ class RedisStreamContextPropagationTest {
         }
 
         @Test
-        void Redis_Stream을_경유해도_Consumer에서_이벤트가_정상_처리된다() {
+        void Publisher의_traceId가_담긴_이벤트가_Consumer에서_정상_처리된다() {
             // given
             AtomicReference<String> publisherTraceId = new AtomicReference<>();
+            AtomicReference<String> eventTraceId = new AtomicReference<>();
 
             Observation observation = Observation.createNotStarted("test-e2e-trace", observationRegistry).start();
             try (Scope scope = observation.openScope()) {
                 publisherTraceId.set(tracer.currentSpan().context().traceId());
 
                 RoomJoinEvent event = new RoomJoinEvent(joinCode, "E2E전파");
+                eventTraceId.set(event.traceInfo().traceId());
+
                 streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
             } finally {
                 observation.stop();
             }
 
-            // then — Awaitility로 비동기 Consumer 처리 완료를 폴링
+            // then — 이벤트에 Publisher의 traceId가 주입됨을 먼저 확인
+            assertThat(eventTraceId.get())
+                    .as("이벤트 DTO에 Publisher의 traceId가 주입되어야 한다")
+                    .isEqualTo(publisherTraceId.get());
+
+            // then — Consumer가 Traceable 이벤트를 정상 처리 (TracerProvider 경유)
+            // TracerProvider가 traceInfo.traceable() == true인 이벤트를 받으면
+            // Span을 복원하고 MDC에 traceId를 세팅한 뒤 task를 실행한다.
+            // MDC 복원 자체는 TracerProviderTest에서 단위 검증 완료.
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(100))
                     .untilAsserted(() -> {
@@ -99,37 +120,68 @@ class RedisStreamContextPropagationTest {
                         boolean playerExists = updatedRoom.getPlayers().stream()
                                 .anyMatch(player -> "E2E전파".equals(player.getName().value()));
                         assertThat(playerExists)
-                                .as("Consumer가 traceId를 복원하고 이벤트를 정상 처리해야 한다")
+                                .as("traceable 이벤트가 Consumer에서 정상 처리되어야 한다")
                                 .isTrue();
                     });
-
-            assertThat(publisherTraceId.get()).isNotBlank();
         }
 
         @Test
         void 여러_이벤트를_동시에_발행해도_각각의_traceId가_올바르게_전파된다() {
             // given
-            int eventCount = 3;
-            CountDownLatch publishLatch = new CountDownLatch(eventCount);
             String[] playerNames = {"동시전파1", "동시전파2", "동시전파3"};
+            List<String> capturedTraceIds = new ArrayList<>();
 
-            for (String playerName : playerNames) {
-                Observation observation = Observation.createNotStarted("test-concurrent-" + playerName,
-                        observationRegistry).start();
-                try (Scope scope = observation.openScope()) {
-                    RoomJoinEvent event = new RoomJoinEvent(joinCode, playerName);
+            // 모든 스레드가 동시에 출발하도록 barrier 사용
+            CountDownLatch startBarrier = new CountDownLatch(1);
+            ExecutorService executor = Executors.newFixedThreadPool(playerNames.length);
 
-                    // traceId가 비어있지 않은지 발행 시점에 확인
-                    assertThat(event.traceInfo().traceId()).isNotBlank();
+            // when — CompletableFuture로 실제 동시 발행
+            CompletableFuture<?>[] futures = new CompletableFuture[playerNames.length];
+            for (int i = 0; i < playerNames.length; i++) {
+                String playerName = playerNames[i];
+                futures[i] = CompletableFuture.runAsync(() -> {
+                    try {
+                        startBarrier.await(3, java.util.concurrent.TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
 
-                    streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
-                    publishLatch.countDown();
-                } finally {
-                    observation.stop();
-                }
+                    Observation observation = Observation.createNotStarted(
+                            "test-concurrent-" + playerName, observationRegistry).start();
+                    try (Scope scope = observation.openScope()) {
+                        RoomJoinEvent event = new RoomJoinEvent(joinCode, playerName);
+
+                        synchronized (capturedTraceIds) {
+                            capturedTraceIds.add(event.traceInfo().traceId());
+                        }
+
+                        streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+                    } finally {
+                        observation.stop();
+                    }
+                }, executor);
             }
 
-            // then — 모든 이벤트가 Consumer에서 정상 처리되었는지 Awaitility로 검증
+            // 모든 스레드 동시 출발
+            startBarrier.countDown();
+
+            // 모든 발행이 완료될 때까지 대기
+            CompletableFuture.allOf(futures).join();
+            executor.shutdown();
+
+            // then — 각 이벤트가 서로 다른 traceId를 가지고 있어야 함 (Observation이 각각 별도)
+            assertThat(capturedTraceIds)
+                    .as("모든 이벤트에 traceId가 주입되어야 한다")
+                    .hasSize(playerNames.length)
+                    .allSatisfy(traceId -> assertThat(traceId).isNotBlank());
+
+            // 각 traceId가 서로 다른지 확인 (각 Observation이 독립적이므로)
+            assertThat(capturedTraceIds)
+                    .as("동시 발행된 이벤트들은 서로 다른 traceId를 가져야 한다")
+                    .doesNotHaveDuplicates();
+
+            // then — 모든 이벤트가 Consumer에서 정상 처리되었는지 검증
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(100))
                     .untilAsserted(() -> {
@@ -156,11 +208,14 @@ class RedisStreamContextPropagationTest {
             // then
             assertThat(event.traceInfo().traceId()).isEmpty();
             assertThat(event.traceInfo().spanId()).isEmpty();
+            assertThat(event.traceInfo().traceable()).isFalse();
         }
 
         @Test
         void 빈_TraceInfo여도_Consumer에서_이벤트는_정상_처리된다() {
-            // given
+            // given — Observation 없이 이벤트 생성 → traceInfo.traceable() == false
+            // EventDispatcher에서 Traceable 분기는 타지만,
+            // TracerProvider는 traceable()이 false이면 Span 생성 없이 task를 바로 실행한다.
             RoomJoinEvent event = new RoomJoinEvent(joinCode, "노트레이스처리");
             assertThat(event.traceInfo().traceable()).isFalse();
 

--- a/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/RedisStreamContextPropagationTest.java
@@ -2,6 +2,9 @@ package coffeeshout.global.trace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
 
 import coffeeshout.fixture.RoomFixture;
 import coffeeshout.global.redis.stream.StreamKey;
@@ -27,16 +30,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 /**
  * Redis Stream을 경유하는 이벤트의 Trace Context 전파를 검증하는 통합 테스트.
  *
  * <p>Publisher 스레드에서 생성한 traceId가 이벤트 DTO에 정상 주입되고,
- * Consumer 스레드(EventDispatcher → TracerProvider)에서 해당 traceId로 Span이 복원되는지 확인한다.</p>
- *
- * <p>Consumer 내부의 MDC/Span 복원은 {@link TracerProviderTest}에서 단위 테스트로 증명한다.
- * 이 통합 테스트는 "Publisher traceId → 이벤트 DTO → Redis Stream → Consumer 정상 처리"
- * 의 E2E 흐름이 끊어지지 않는 것을 검증한다.</p>
+ * Consumer 스레드에서 EventDispatcher가 TracerProvider.executeWithTraceContext()를
+ * 실제로 호출하여 Span을 복원하는지 검증한다.</p>
  */
 @IntegrationTest
 class RedisStreamContextPropagationTest {
@@ -52,6 +53,9 @@ class RedisStreamContextPropagationTest {
 
     @Autowired
     Tracer tracer;
+
+    @MockitoSpyBean
+    TracerProvider tracerProvider;
 
     private String joinCode;
 
@@ -87,42 +91,38 @@ class RedisStreamContextPropagationTest {
         }
 
         @Test
-        void Publisher의_traceId가_담긴_이벤트가_Consumer에서_정상_처리된다() {
+        void Consumer에서_TracerProvider_executeWithTraceContext가_호출된다() {
             // given
             AtomicReference<String> publisherTraceId = new AtomicReference<>();
-            AtomicReference<String> eventTraceId = new AtomicReference<>();
 
             Observation observation = Observation.createNotStarted("test-e2e-trace", observationRegistry).start();
             try (Scope scope = observation.openScope()) {
                 publisherTraceId.set(tracer.currentSpan().context().traceId());
 
                 RoomJoinEvent event = new RoomJoinEvent(joinCode, "E2E전파");
-                eventTraceId.set(event.traceInfo().traceId());
-
                 streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
             } finally {
                 observation.stop();
             }
 
-            // then — 이벤트에 Publisher의 traceId가 주입됨을 먼저 확인
-            assertThat(eventTraceId.get())
-                    .as("이벤트 DTO에 Publisher의 traceId가 주입되어야 한다")
-                    .isEqualTo(publisherTraceId.get());
-
-            // then — Consumer가 Traceable 이벤트를 정상 처리 (TracerProvider 경유)
-            // TracerProvider가 traceInfo.traceable() == true인 이벤트를 받으면
-            // Span을 복원하고 MDC에 traceId를 세팅한 뒤 task를 실행한다.
-            // MDC 복원 자체는 TracerProviderTest에서 단위 검증 완료.
+            // then — Consumer가 이벤트를 처리할 때까지 대기
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(100))
                     .untilAsserted(() -> {
                         Room updatedRoom = roomRepository.findByJoinCode(new JoinCode(joinCode)).orElseThrow();
                         boolean playerExists = updatedRoom.getPlayers().stream()
                                 .anyMatch(player -> "E2E전파".equals(player.getName().value()));
-                        assertThat(playerExists)
-                                .as("traceable 이벤트가 Consumer에서 정상 처리되어야 한다")
-                                .isTrue();
+                        assertThat(playerExists).isTrue();
                     });
+
+            // then — EventDispatcher가 TracerProvider.executeWithTraceContext()를
+            // Publisher의 traceId가 담긴 TraceInfo로 실제 호출했는지 검증
+            String expectedTraceId = publisherTraceId.get();
+            verify(tracerProvider).executeWithTraceContext(
+                    argThat(traceInfo -> expectedTraceId.equals(traceInfo.traceId())),
+                    any(Runnable.class),
+                    any()
+            );
         }
 
         @Test
@@ -131,7 +131,6 @@ class RedisStreamContextPropagationTest {
             String[] playerNames = {"동시전파1", "동시전파2", "동시전파3"};
             List<String> capturedTraceIds = new ArrayList<>();
 
-            // 모든 스레드가 동시에 출발하도록 barrier 사용
             CountDownLatch startBarrier = new CountDownLatch(1);
             ExecutorService executor = Executors.newFixedThreadPool(playerNames.length);
 
@@ -163,25 +162,17 @@ class RedisStreamContextPropagationTest {
                 }, executor);
             }
 
-            // 모든 스레드 동시 출발
             startBarrier.countDown();
-
-            // 모든 발행이 완료될 때까지 대기
             CompletableFuture.allOf(futures).join();
             executor.shutdown();
 
-            // then — 각 이벤트가 서로 다른 traceId를 가지고 있어야 함 (Observation이 각각 별도)
+            // then — 각 이벤트가 서로 다른 traceId를 가짐
             assertThat(capturedTraceIds)
-                    .as("모든 이벤트에 traceId가 주입되어야 한다")
                     .hasSize(playerNames.length)
-                    .allSatisfy(traceId -> assertThat(traceId).isNotBlank());
-
-            // 각 traceId가 서로 다른지 확인 (각 Observation이 독립적이므로)
-            assertThat(capturedTraceIds)
-                    .as("동시 발행된 이벤트들은 서로 다른 traceId를 가져야 한다")
+                    .allSatisfy(traceId -> assertThat(traceId).isNotBlank())
                     .doesNotHaveDuplicates();
 
-            // then — 모든 이벤트가 Consumer에서 정상 처리되었는지 검증
+            // then — 모든 이벤트가 Consumer에서 정상 처리됨
             await().atMost(Duration.ofSeconds(5))
                     .pollInterval(Duration.ofMillis(100))
                     .untilAsserted(() -> {
@@ -194,6 +185,15 @@ class RedisStreamContextPropagationTest {
                                     .isTrue();
                         }
                     });
+
+            // then — 각 이벤트에 대해 TracerProvider가 호출됨
+            for (String traceId : capturedTraceIds) {
+                verify(tracerProvider).executeWithTraceContext(
+                        argThat(info -> traceId.equals(info.traceId())),
+                        any(Runnable.class),
+                        any()
+                );
+            }
         }
     }
 
@@ -213,9 +213,7 @@ class RedisStreamContextPropagationTest {
 
         @Test
         void 빈_TraceInfo여도_Consumer에서_이벤트는_정상_처리된다() {
-            // given — Observation 없이 이벤트 생성 → traceInfo.traceable() == false
-            // EventDispatcher에서 Traceable 분기는 타지만,
-            // TracerProvider는 traceable()이 false이면 Span 생성 없이 task를 바로 실행한다.
+            // given
             RoomJoinEvent event = new RoomJoinEvent(joinCode, "노트레이스처리");
             assertThat(event.traceInfo().traceable()).isFalse();
 
@@ -230,6 +228,14 @@ class RedisStreamContextPropagationTest {
                                 .anyMatch(p -> "노트레이스처리".equals(p.getName().value()));
                         assertThat(exists).isTrue();
                     });
+
+            // then — TracerProvider는 빈 TraceInfo로 호출되어야 하고,
+            // 내부에서 traceable() == false이므로 Span 생성 없이 task만 실행
+            verify(tracerProvider).executeWithTraceContext(
+                    argThat(info -> !info.traceable()),
+                    any(Runnable.class),
+                    any()
+            );
         }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
@@ -1,0 +1,145 @@
+package coffeeshout.global.trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coffeeshout.global.redis.BaseEvent;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TracerProviderTest {
+
+    private SimpleTracer simpleTracer;
+    private TracerProvider tracerProvider;
+
+    @BeforeEach
+    void setUp() {
+        simpleTracer = new SimpleTracer();
+        tracerProvider = new TracerProvider(simpleTracer);
+    }
+
+    @Nested
+    class executeWithTraceContext_호출_시 {
+
+        @Test
+        void 유효한_TraceInfo가_주어지면_해당_traceId로_Span이_생성된다() {
+            // given
+            String expectedTraceId = "463ac35c9f6413ad48485a3953bb6124";
+            String expectedSpanId = "0020000000000001";
+            TraceInfo traceInfo = new TraceInfo(expectedTraceId, expectedSpanId);
+
+            AtomicReference<String> capturedTraceId = new AtomicReference<>();
+
+            // when
+            tracerProvider.executeWithTraceContext(traceInfo, () -> {
+                Span currentSpan = simpleTracer.currentSpan();
+                capturedTraceId.set(currentSpan.context().traceId());
+            }, new StubEvent());
+
+            // then
+            assertThat(capturedTraceId.get()).isEqualTo(expectedTraceId);
+        }
+
+        @Test
+        void 빈_TraceInfo가_주어지면_Span_생성_없이_task를_바로_실행한다() {
+            // given
+            TraceInfo emptyTraceInfo = new TraceInfo("", "");
+            AtomicReference<Boolean> executed = new AtomicReference<>(false);
+
+            // when
+            tracerProvider.executeWithTraceContext(emptyTraceInfo, () -> executed.set(true), new StubEvent());
+
+            // then
+            assertThat(executed.get()).isTrue();
+            assertThat(simpleTracer.getSpans()).isEmpty();
+        }
+
+        @Test
+        void task_실행_후_Span이_정상적으로_종료된다() {
+            // given
+            TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
+
+            // when
+            tracerProvider.executeWithTraceContext(traceInfo, () -> {}, new StubEvent());
+
+            // then
+            assertThat(simpleTracer.getSpans()).hasSize(1);
+            assertThat(simpleTracer.getSpans().getFirst().getEndTimestamp()).isNotNull();
+        }
+
+        @Test
+        void task_내부에서_예외가_발생해도_Span은_종료된다() {
+            // given
+            TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
+
+            // when & then
+            assertThatCode(() ->
+                    tracerProvider.executeWithTraceContext(traceInfo, () -> {
+                        throw new RuntimeException("의도된 예외");
+                    }, new StubEvent())
+            ).isInstanceOf(RuntimeException.class);
+
+            assertThat(simpleTracer.getSpans()).isNotEmpty();
+        }
+
+        @Test
+        void Span_이름은_이벤트_클래스의_SimpleName이다() {
+            // given
+            TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
+
+            // when
+            tracerProvider.executeWithTraceContext(traceInfo, () -> {}, new StubEvent());
+
+            // then
+            assertThat(simpleTracer.getSpans().getFirst().getName()).isEqualTo("StubEvent");
+        }
+
+        @Test
+        void 별도_스레드에서_실행해도_전달받은_traceId가_해당_스레드에_복원된다() throws InterruptedException {
+            // given
+            String expectedTraceId = "463ac35c9f6413ad48485a3953bb6124";
+            TraceInfo traceInfo = new TraceInfo(expectedTraceId, "0020000000000001");
+
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<String> capturedTraceId = new AtomicReference<>();
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+
+            // when — 다른 스레드에서 executeWithTraceContext 호출
+            executor.submit(() -> {
+                tracerProvider.executeWithTraceContext(traceInfo, () -> {
+                    capturedTraceId.set(simpleTracer.currentSpan().context().traceId());
+                }, new StubEvent());
+                latch.countDown();
+            });
+
+            // then — CountDownLatch로 스레드 완료 대기 (Thread.sleep 아님)
+            assertThat(latch.await(3, TimeUnit.SECONDS))
+                    .as("비동기 태스크가 3초 이내에 완료되어야 한다")
+                    .isTrue();
+            assertThat(capturedTraceId.get()).isEqualTo(expectedTraceId);
+
+            executor.shutdown();
+        }
+    }
+
+    private static class StubEvent implements BaseEvent {
+        @Override
+        public String eventId() {
+            return "stub-event-id";
+        }
+
+        @Override
+        public Instant timestamp() {
+            return Instant.now();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
@@ -127,21 +127,23 @@ class TracerProviderTest {
             AtomicReference<String> capturedTraceId = new AtomicReference<>();
             ExecutorService executor = Executors.newSingleThreadExecutor();
 
-            // when — 다른 스레드에서 executeWithTraceContext 호출
-            executor.submit(() -> {
-                tracerProvider.executeWithTraceContext(traceInfo, () -> {
-                    capturedTraceId.set(simpleTracer.currentSpan().context().traceId());
-                }, new StubEvent());
-                latch.countDown();
-            });
+            try {
+                // when — 다른 스레드에서 executeWithTraceContext 호출
+                executor.submit(() -> {
+                    tracerProvider.executeWithTraceContext(traceInfo, () -> {
+                        capturedTraceId.set(simpleTracer.currentSpan().context().traceId());
+                    }, new StubEvent());
+                    latch.countDown();
+                });
 
-            // then — CountDownLatch로 스레드 완료 대기
-            assertThat(latch.await(3, TimeUnit.SECONDS))
-                    .as("비동기 태스크가 3초 이내에 완료되어야 한다")
-                    .isTrue();
-            assertThat(capturedTraceId.get()).isEqualTo(expectedTraceId);
-
-            executor.shutdown();
+                // then — CountDownLatch로 스레드 완료 대기
+                assertThat(latch.await(3, TimeUnit.SECONDS))
+                        .as("비동기 태스크가 3초 이내에 완료되어야 한다")
+                        .isTrue();
+                assertThat(capturedTraceId.get()).isEqualTo(expectedTraceId);
+            } finally {
+                executor.shutdownNow();
+            }
         }
     }
 

--- a/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import coffeeshout.global.redis.BaseEvent;
 import io.micrometer.tracing.Span;
+import io.micrometer.tracing.test.simple.SimpleSpan;
 import io.micrometer.tracing.test.simple.SimpleTracer;
 import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
@@ -69,11 +70,12 @@ class TracerProviderTest {
             TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
 
             // when
-            tracerProvider.executeWithTraceContext(traceInfo, () -> {}, new StubEvent());
+            tracerProvider.executeWithTraceContext(traceInfo, () -> {
+            }, new StubEvent());
 
             // then
-            assertThat(simpleTracer.getSpans()).hasSize(1);
-            assertThat(simpleTracer.getSpans().getFirst().getEndTimestamp()).isNotNull();
+            SimpleSpan span = simpleTracer.getSpans().getFirst();
+            assertThat(span.getEndTimestamp()).isNotNull();
         }
 
         @Test
@@ -88,7 +90,11 @@ class TracerProviderTest {
                     }, new StubEvent())
             ).isInstanceOf(RuntimeException.class);
 
-            assertThat(simpleTracer.getSpans()).isNotEmpty();
+            // finally 블록에서 span.end()가 호출되었는지 getEndTimestamp로 직접 검증
+            SimpleSpan span = simpleTracer.getSpans().getFirst();
+            assertThat(span.getEndTimestamp())
+                    .as("예외가 발생해도 finally에서 span.end()가 호출되어야 한다")
+                    .isNotNull();
         }
 
         @Test
@@ -97,7 +103,8 @@ class TracerProviderTest {
             TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
 
             // when
-            tracerProvider.executeWithTraceContext(traceInfo, () -> {}, new StubEvent());
+            tracerProvider.executeWithTraceContext(traceInfo, () -> {
+            }, new StubEvent());
 
             // then
             assertThat(simpleTracer.getSpans().getFirst().getName()).isEqualTo("StubEvent");
@@ -121,7 +128,7 @@ class TracerProviderTest {
                 latch.countDown();
             });
 
-            // then — CountDownLatch로 스레드 완료 대기 (Thread.sleep 아님)
+            // then — CountDownLatch로 스레드 완료 대기
             assertThat(latch.await(3, TimeUnit.SECONDS))
                     .as("비동기 태스크가 3초 이내에 완료되어야 한다")
                     .isTrue();

--- a/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
+++ b/backend/src/test/java/coffeeshout/global/trace/TracerProviderTest.java
@@ -79,7 +79,7 @@ class TracerProviderTest {
         }
 
         @Test
-        void task_내부에서_예외가_발생해도_Span은_종료된다() {
+        void task_내부에서_예외가_발생하면_Span에_에러가_기록되고_종료된다() {
             // given
             TraceInfo traceInfo = new TraceInfo("463ac35c9f6413ad48485a3953bb6124", "0020000000000001");
 
@@ -90,8 +90,15 @@ class TracerProviderTest {
                     }, new StubEvent())
             ).isInstanceOf(RuntimeException.class);
 
-            // finally 블록에서 span.end()가 호출되었는지 getEndTimestamp로 직접 검증
             SimpleSpan span = simpleTracer.getSpans().getFirst();
+
+            // span.error(t)가 호출되어 Tempo에서 에러 Span으로 표시됨
+            assertThat(span.getError())
+                    .as("span.error(t)로 예외가 기록되어야 한다")
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("의도된 예외");
+
+            // finally에서 span.end()가 호출됨
             assertThat(span.getEndTimestamp())
                     .as("예외가 발생해도 finally에서 span.end()가 호출되어야 한다")
                     .isNotNull();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1104

# 🚀 작업 내용
## 문제

Redis Stream 이벤트가 별도 스레드풀에서 소비될 때 traceId/spanId가 유실되어 Tempo에서 트레이스가 끊어짐.

```
WebSocket Thread (traceId: abc)  ──XADD──▶  Consumer Thread (traceId: 없음)
```

로그에도 `[,]`로 빈 값 출력. WebSocket → Consumer 구간 추적 불가.

## 해결

이벤트 payload에 traceId/spanId를 실어 보내고, Consumer에서 복원하는 구조.

```
WebSocket Thread (traceId: abc)  ──XADD──▶  Consumer Thread (TraceInfo에서 abc 복원 → Span 생성)
```

**Publisher:** `TraceInfoExtractor`가 현재 Observation에서 traceId/spanId 추출 → `TraceInfo` record에 담아 이벤트와 함께 직렬화

**Consumer:** `EventDispatcher`에서 `Traceable` 이벤트 감지 → `TracerProvider`가 parent context 복원 → `Tracer.withSpan()`으로 MDC 세팅 → `finally`에서 span.end()

**ThreadPool:** `ContextSnapshotFactory.captureAll().wrap()`으로 TaskDecorator 설정

## 변경 파일
**수정**
- `EventDispatcher` — Traceable 분기 추가
- `RedisStreamThreadPoolConfig` — ContextSnapshot 기반 TaskDecorator
- 모든 Event DTO — `Traceable` 구현 + `TraceInfo` 필드
- `build.gradle.kts` — `micrometer-tracing-test` 의존성 추가

## 테스트
- 단위 테스트 — TracerProvider Span 생성/종료/예외/멀티스레드 검증
- 통합 테스트 — Redis Stream E2E 전파 + 동시성 검증 (Testcontainers + Awaitility)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트와 작업 스레드에 대한 분산 트레이스 컨텍스트 전파가 도입되어 트레이싱 가시성이 향상되었습니다.

* **버그 수정**
  * 트레이스 실행 중 예외 발생 시 에러가 트레이스에 기록되도록 개선되어 오류 관찰이 정확해졌습니다.

* **리팩터**
  * 일부 이벤트에 추적 정보(TraceInfo)가 포함되어 이벤트 초기화 및 인터페이스가 변경되었습니다.

* **테스트**
  * 컨텍스트 전파 및 트레이서 동작을 검증하는 통합 및 단위 테스트가 추가되었습니다.

* **잡일(Chore)**
  * 테스트용 트레이싱 관련 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->