### PR TITLE
[feat] Transactional Outbox 패턴 도입 — createRoom Dual Write Problem 해결

### DIFF
--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxAfterCommitRelay.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxAfterCommitRelay.java
@@ -1,0 +1,75 @@
+package coffeeshout.global.outbox;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 트랜잭션 커밋 직후 Outbox 이벤트를 즉시 Redis Stream에 발행하는 릴레이.
+ * <p>
+ * 2단 콤보 Outbox의 1단계(즉시 발행)를 담당한다.
+ * <p>
+ * 동작 흐름:
+ * 1. {@link OutboxEventRecorder}가 Outbox 저장 + {@link OutboxSavedEvent} 발행
+ * 2. 트랜잭션이 커밋되면 이 리스너가 실행되어 Redis에 즉시 발행 시도
+ * 3. 성공 시 → Outbox 레코드를 PUBLISHED로 전환 (REQUIRES_NEW 트랜잭션)
+ * 4. 실패 시 → 예외를 삼킴. Outbox에 PENDING으로 남아있으므로
+ *    {@link OutboxRelayWorker}가 500ms 후 재시도
+ */
+@Slf4j
+@Component
+public class OutboxAfterCommitRelay {
+
+    private final StreamPublisher streamPublisher;
+    private final OutboxEventProcessor eventProcessor;
+    private final ObjectMapper objectMapper;
+
+    public OutboxAfterCommitRelay(
+            StreamPublisher streamPublisher,
+            OutboxEventProcessor eventProcessor,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper
+    ) {
+        this.streamPublisher = streamPublisher;
+        this.eventProcessor = eventProcessor;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 트랜잭션 커밋 직후 실행된다.
+     * <p>
+     * AFTER_COMMIT이므로 이 시점에서 DB에는 비즈니스 데이터 + Outbox 레코드가
+     * 모두 커밋된 상태다. Redis 발행이 실패해도 DB 데이터에는 영향이 없다.
+     * <p>
+     * markPublished()는 REQUIRES_NEW로 새 트랜잭션을 강제한다.
+     * AFTER_COMMIT 리스너 내에서는 원래 트랜잭션의 동기화 컨텍스트가 아직 활성 상태라서,
+     * REQUIRED로 호출하면 이미 커밋된 트랜잭션에 참여하려 해서 변경이 반영되지 않기 때문이다.
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOutboxSaved(OutboxSavedEvent savedEvent) {
+        try {
+            final BaseEvent baseEvent = objectMapper.readValue(
+                    savedEvent.payload(), BaseEvent.class
+            );
+            streamPublisher.publish(
+                    StreamKey.fromRedisKey(savedEvent.streamKey()),
+                    baseEvent
+            );
+
+            // 즉시 발행 성공 → PUBLISHED로 전환 (REQUIRES_NEW 트랜잭션)
+            eventProcessor.markPublished(savedEvent.outboxEventId());
+
+            log.debug("Outbox 즉시 발행 성공: outboxId={}, streamKey={}",
+                    savedEvent.outboxEventId(), savedEvent.streamKey());
+        } catch (Exception e) {
+            // 즉시 발행 실패 → 무시. Outbox에 PENDING으로 남아있으므로 Worker가 재시도
+            log.warn("Outbox 즉시 발행 실패 (Worker가 재시도 예정): outboxId={}, streamKey={}, error={}",
+                    savedEvent.outboxEventId(), savedEvent.streamKey(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxEvent.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxEvent.java
@@ -1,0 +1,75 @@
+package coffeeshout.global.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "outbox_event",
+        indexes = @Index(name = "idx_outbox_status_id", columnList = "status, id")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String streamKey;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static OutboxEvent create(String streamKey, String payload) {
+        final OutboxEvent event = new OutboxEvent();
+        event.streamKey = streamKey;
+        event.payload = payload;
+        event.status = OutboxStatus.PENDING;
+        event.retryCount = 0;
+        event.createdAt = LocalDateTime.now();
+        return event;
+    }
+
+    public void markInProgress() {
+        this.status = OutboxStatus.IN_PROGRESS;
+    }
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+
+    public void markDeadLetter() {
+        this.status = OutboxStatus.DEAD_LETTER;
+    }
+
+    public void setStatusPending() {
+        this.status = OutboxStatus.PENDING;
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxEventProcessor.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxEventProcessor.java
@@ -1,0 +1,86 @@
+package coffeeshout.global.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox 이벤트의 DB 상태를 변경하는 트랜잭션 단위.
+ * <p>
+ * OutboxRelayWorker에서 직접 @Transactional을 쓰면
+ * Redis I/O 동안 DB 커넥션을 물고 있게 되므로,
+ * DB 조작만 따로 분리한 클래스다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventProcessor {
+
+    private static final int MAX_RETRY_COUNT = 10;
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    /**
+     * PENDING 이벤트를 SKIP LOCKED로 조회하고 IN_PROGRESS로 전환 후 커밋한다.
+     * 이 메서드가 반환되면 DB 커넥션은 즉시 반환된다.
+     */
+    @Transactional
+    public List<OutboxEvent> fetchAndMarkInProgress(int batchSize) {
+        final List<OutboxEvent> events = outboxEventRepository.findPendingEventsForUpdate(batchSize);
+        events.forEach(OutboxEvent::markInProgress);
+        return events;
+    }
+
+    /**
+     * 발행 성공한 이벤트를 PUBLISHED로 전환한다.
+     * <p>
+     * REQUIRES_NEW를 사용하는 이유: AFTER_COMMIT 리스너에서 호출될 때
+     * 기존 트랜잭션의 동기화 컨텍스트가 아직 활성 상태라서
+     * REQUIRED로는 새 트랜잭션이 열리지 않고 변경이 반영되지 않는다.
+     * Worker에서 호출할 때도 relay()가 @Transactional 없이 실행되므로
+     * REQUIRES_NEW와 REQUIRED의 동작 차이가 없다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markPublished(Long eventId) {
+        outboxEventRepository.findById(eventId).ifPresent(OutboxEvent::markPublished);
+    }
+
+    /**
+     * 발행 실패한 이벤트의 재시도 카운트를 증가시키고,
+     * 최대 재시도 횟수를 초과하면 DEAD_LETTER로 전환한다.
+     * 재시도 대상은 다시 PENDING으로 되돌린다.
+     */
+    @Transactional
+    public void handleFailure(Long eventId) {
+        outboxEventRepository.findById(eventId).ifPresent(this::processFailure);
+    }
+
+    private void processFailure(OutboxEvent event) {
+        event.incrementRetryCount();
+
+        if (event.getRetryCount() >= MAX_RETRY_COUNT) {
+            event.markDeadLetter();
+            log.error("Outbox 이벤트 최대 재시도 초과, DEAD_LETTER 전환: id={}, streamKey={}",
+                    event.getId(), event.getStreamKey());
+            return;
+        }
+
+        event.setStatusPending();
+        log.warn("Outbox 이벤트 발행 실패, PENDING 복귀: id={}, retryCount={}",
+                event.getId(), event.getRetryCount());
+    }
+
+    /**
+     * IN_PROGRESS 상태에서 서버가 죽은 경우를 대비한 복구.
+     * 5분 이상 IN_PROGRESS로 남아있는 이벤트를 PENDING으로 되돌린다.
+     */
+    @Transactional
+    public int recoverStaleEvents() {
+        final LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+        return outboxEventRepository.recoverStaleInProgressEvents(threshold);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxEventRecorder.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxEventRecorder.java
@@ -1,0 +1,67 @@
+package coffeeshout.global.outbox;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 이벤트를 Outbox 테이블에 저장하는 단일 진입점.
+ * <p>
+ * 저장 후 {@link OutboxSavedEvent}를 Spring 내부 이벤트로 발행하여,
+ * 트랜잭션 커밋 직후 {@link OutboxAfterCommitRelay}가 즉시 Redis 발행을 시도하게 한다.
+ * <p>
+ * 이것이 2단 콤보 Outbox의 핵심이다:
+ * - 평상시: 커밋 즉시 Redis 발행 (0ms 지연)
+ * - Redis 장애 시: Outbox에 PENDING으로 남아있어 Worker가 500ms 후 재시도
+ */
+@Slf4j
+@Component
+public class OutboxEventRecorder {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public OutboxEventRecorder(
+            OutboxEventRepository outboxEventRepository,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper,
+            ApplicationEventPublisher applicationEventPublisher
+    ) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.objectMapper = objectMapper;
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    /**
+     * 이벤트를 Outbox 테이블에 저장하고, 트랜잭션 커밋 직후 즉시 발행을 트리거한다.
+     * <p>
+     * 호출자에 트랜잭션이 있으면 해당 트랜잭션에 참여하여
+     * 비즈니스 데이터와 Outbox 레코드가 함께 커밋된다.
+     * 호출자에 트랜잭션이 없으면 자체 트랜잭션을 생성한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void record(StreamKey streamKey, BaseEvent event) {
+        try {
+            final String payload = objectMapper.writeValueAsString(event);
+            final OutboxEvent outboxEvent = OutboxEvent.create(streamKey.getRedisKey(), payload);
+            outboxEventRepository.saveAndFlush(outboxEvent);
+
+            // Spring 내부 이벤트 발행 → 트랜잭션 커밋 후 OutboxAfterCommitRelay가 수신
+            applicationEventPublisher.publishEvent(
+                    new OutboxSavedEvent(outboxEvent.getId(), streamKey.getRedisKey(), payload)
+            );
+
+            log.debug("Outbox 이벤트 저장: streamKey={}, eventId={}",
+                    streamKey.getRedisKey(), event.eventId());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("이벤트 직렬화 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxEventRepository.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxEventRepository.java
@@ -1,0 +1,37 @@
+package coffeeshout.global.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+
+    @Query(
+            value = "SELECT * FROM outbox_event "
+                    + "WHERE status = 'PENDING' "
+                    + "ORDER BY id ASC "
+                    + "LIMIT :size "
+                    + "FOR UPDATE SKIP LOCKED",
+            nativeQuery = true
+    )
+    List<OutboxEvent> findPendingEventsForUpdate(@Param("size") int size);
+
+    Optional<OutboxEvent> findById(Long id);
+
+    /**
+     * IN_PROGRESS 상태로 오래 남아있는 이벤트를 복구한다.
+     * 서버가 IN_PROGRESS 상태에서 죽었을 때를 대비한 안전장치.
+     */
+    @Modifying
+    @Query("UPDATE OutboxEvent o SET o.status = 'PENDING' "
+            + "WHERE o.status = 'IN_PROGRESS' AND o.createdAt < :threshold")
+    int recoverStaleInProgressEvents(@Param("threshold") LocalDateTime threshold);
+
+    @Modifying
+    @Query("DELETE FROM OutboxEvent o WHERE o.status = 'PUBLISHED' AND o.createdAt < :threshold")
+    int deletePublishedEventsBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxRelayWorker.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxRelayWorker.java
@@ -1,0 +1,117 @@
+package coffeeshout.global.outbox;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox 테이블의 PENDING 이벤트를 Redis Stream으로 릴레이하는 Worker.
+ * <p>
+ * 핵심 설계: DB 트랜잭션과 Redis I/O를 철저히 분리한다.
+ * <p>
+ * 1단계: fetchAndMarkInProgress() — DB 트랜잭션으로 PENDING → IN_PROGRESS 전환 후 즉시 커밋 (DB 커넥션 반환)
+ * 2단계: streamPublisher.publish() — 트랜잭션 밖에서 Redis I/O 수행 (타임아웃이 DB 커넥션에 영향 없음)
+ * 3단계: markPublished() / handleFailure() — 단건 업데이트 트랜잭션
+ * <p>
+ * 이 분리가 없으면 Redis 장애 시 타임아웃 * 배치 크기만큼 DB 커넥션을 물고 있게 되어
+ * HikariCP 풀이 고갈되는 Cascading Failure가 발생한다.
+ */
+@Slf4j
+@Component
+public class OutboxRelayWorker {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final OutboxEventProcessor eventProcessor;
+    private final OutboxEventRepository outboxEventRepository;
+    private final StreamPublisher streamPublisher;
+    private final ObjectMapper objectMapper;
+
+    public OutboxRelayWorker(
+            OutboxEventProcessor eventProcessor,
+            OutboxEventRepository outboxEventRepository,
+            StreamPublisher streamPublisher,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper
+    ) {
+        this.eventProcessor = eventProcessor;
+        this.outboxEventRepository = outboxEventRepository;
+        this.streamPublisher = streamPublisher;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 500ms마다 Outbox 폴링.
+     * <p>
+     * 이 메서드에 @Transactional이 없는 것이 핵심이다.
+     * Redis publish()가 3초 타임아웃 나더라도 DB 커넥션을 물고 있지 않는다.
+     */
+    @Scheduled(fixedDelay = 500)
+    public void relay() {
+        // 1단계: DB 트랜잭션 — PENDING 조회 + IN_PROGRESS 전환 + 커밋 (DB 커넥션 즉시 반환)
+        final List<OutboxEvent> events = eventProcessor.fetchAndMarkInProgress(BATCH_SIZE);
+
+        if (events.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (final OutboxEvent event : events) {
+            try {
+                // 2단계: 트랜잭션 밖에서 Redis I/O
+                final BaseEvent baseEvent = objectMapper.readValue(
+                        event.getPayload(), BaseEvent.class
+                );
+                streamPublisher.publish(
+                        StreamKey.fromRedisKey(event.getStreamKey()),
+                        baseEvent
+                );
+
+                // 3단계: 단건 DB 트랜잭션 — PUBLISHED 전환
+                eventProcessor.markPublished(event.getId());
+                successCount++;
+            } catch (Exception e) {
+                // 3단계: 단건 DB 트랜잭션 — 실패 처리
+                eventProcessor.handleFailure(event.getId());
+                failCount++;
+            }
+        }
+
+        if (successCount > 0 || failCount > 0) {
+            log.info("Outbox relay 완료: success={}, fail={}", successCount, failCount);
+        }
+    }
+
+    /**
+     * IN_PROGRESS 상태에서 서버가 죽은 이벤트를 복구한다.
+     * 1분마다 실행. 5분 이상 IN_PROGRESS로 남아있는 이벤트를 PENDING으로 되돌린다.
+     */
+    @Scheduled(fixedDelay = 60_000)
+    public void recoverStaleEvents() {
+        final int recovered = eventProcessor.recoverStaleEvents();
+        if (recovered > 0) {
+            log.warn("IN_PROGRESS 상태 복구: {}건 PENDING으로 전환", recovered);
+        }
+    }
+
+    /**
+     * 처리 완료된 Outbox 레코드를 정리한다.
+     * 24시간 이전의 PUBLISHED 레코드를 삭제한다.
+     */
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void cleanup() {
+        final LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        final int deleted = outboxEventRepository.deletePublishedEventsBefore(threshold);
+        log.info("Outbox 정리 완료: {}건 삭제", deleted);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxSavedEvent.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxSavedEvent.java
@@ -1,0 +1,15 @@
+package coffeeshout.global.outbox;
+
+/**
+ * Outbox 레코드가 저장되었음을 알리는 Spring 내부 이벤트.
+ * <p>
+ * {@link OutboxEventRecorder}가 Outbox 테이블에 레코드를 저장한 직후 발행하며,
+ * {@link OutboxAfterCommitRelay}가 트랜잭션 커밋 후 이 이벤트를 수신하여
+ * 즉시 Redis Stream 발행을 시도한다.
+ */
+public record OutboxSavedEvent(
+        Long outboxEventId,
+        String streamKey,
+        String payload
+) {
+}

--- a/backend/src/main/java/coffeeshout/global/outbox/OutboxStatus.java
+++ b/backend/src/main/java/coffeeshout/global/outbox/OutboxStatus.java
@@ -1,0 +1,8 @@
+package coffeeshout.global.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    IN_PROGRESS,
+    PUBLISHED,
+    DEAD_LETTER
+}

--- a/backend/src/main/java/coffeeshout/global/redis/stream/StreamKey.java
+++ b/backend/src/main/java/coffeeshout/global/redis/stream/StreamKey.java
@@ -1,5 +1,6 @@
 package coffeeshout.global.redis.stream;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +14,11 @@ public enum StreamKey {
     RACING_GAME_EVENTS("racinggame");
 
     private final String redisKey;
+
+    public static StreamKey fromRedisKey(String redisKey) {
+        return Arrays.stream(values())
+                .filter(key -> key.redisKey.equals(redisKey))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("알 수 없는 Redis Stream 키: " + redisKey));
+    }
 }

--- a/backend/src/main/java/coffeeshout/room/application/service/RoomService.java
+++ b/backend/src/main/java/coffeeshout/room/application/service/RoomService.java
@@ -1,5 +1,6 @@
 package coffeeshout.room.application.service;
 
+import coffeeshout.global.outbox.OutboxEventRecorder;
 import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.redis.stream.StreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
@@ -63,6 +64,7 @@ public class RoomService {
     private final RoomJpaRepository roomJpaRepository;
     private final RoulettePersistenceService roulettePersistenceService;
     private final RouletteService rouletteService;
+    private final OutboxEventRecorder outboxEventRecorder;
     private final StreamPublisher streamPublisher;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -79,7 +81,10 @@ public class RoomService {
         // 방 생성 후 이벤트 전달
         final BaseEvent event = new RoomCreateEvent(hostName, joinCode.getValue());
 
-        streamPublisher.publish(StreamKey.ROOM_BROADCAST, event);
+        // 방 생성 이벤트: DB 저장과 원자적으로 묶기 위해 Outbox 경로 사용
+        // 트랜잭션 커밋 직후 AFTER_COMMIT으로 즉시 발행 (0ms 지연)
+        // Redis 장애 시에만 Worker가 500ms 후 재시도
+        outboxEventRecorder.record(StreamKey.ROOM_BROADCAST, event);
 
         // QR 코드 비동기 생성 시작
         qrCodeService.generateQrCodeAsync(joinCode.getValue());
@@ -98,6 +103,7 @@ public class RoomService {
 
         return processEventAsync(
                 event.eventId(),
+                // 방 참가는 결과를 CompletableFuture로 기다리는 요청-응답 패턴이므로 즉시 발행
                 () -> streamPublisher.publish(StreamKey.ROOM_JOIN, event),
                 "방 참가",
                 String.format("joinCode=%s, guestName=%s", joinCode, guestName),

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxAfterCommitRelayTest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxAfterCommitRelayTest.java
@@ -1,0 +1,81 @@
+package coffeeshout.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.domain.event.PlayerListUpdateEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * OutboxAfterCommitRelay 단위 테스트.
+ * <p>
+ * AFTER_COMMIT 리스너의 핵심 동작을 검증한다:
+ * - Redis 발행 성공 시 → markPublished() 호출
+ * - Redis 발행 실패 시 → 예외를 삼키고 PENDING 상태 유지 (Worker가 재시도)
+ */
+@ExtendWith(MockitoExtension.class)
+class OutboxAfterCommitRelayTest {
+
+    @Mock
+    private StreamPublisher streamPublisher;
+
+    @Mock
+    private OutboxEventProcessor eventProcessor;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OutboxAfterCommitRelay outboxAfterCommitRelay;
+
+    @Nested
+    class onOutboxSaved_메서드는 {
+
+        @Test
+        void Redis_발행_성공_시_markPublished를_호출한다() throws Exception {
+            // given
+            BaseEvent mockEvent = new PlayerListUpdateEvent("test");
+            OutboxSavedEvent savedEvent = new OutboxSavedEvent(1L, "room", "{\"@type\":\"PlayerListUpdateEvent\"}");
+
+            org.mockito.BDDMockito.given(objectMapper.readValue(savedEvent.payload(), BaseEvent.class))
+                    .willReturn(mockEvent);
+
+            // when
+            outboxAfterCommitRelay.onOutboxSaved(savedEvent);
+
+            // then
+            verify(streamPublisher).publish(eq(StreamKey.ROOM_BROADCAST), any());
+            verify(eventProcessor).markPublished(1L);
+        }
+
+        @Test
+        void Redis_발행_실패_시_예외를_삼키고_markPublished를_호출하지_않는다() throws Exception {
+            // given
+            BaseEvent mockEvent = new PlayerListUpdateEvent("test");
+            OutboxSavedEvent savedEvent = new OutboxSavedEvent(1L, "room", "{\"@type\":\"PlayerListUpdateEvent\"}");
+
+            org.mockito.BDDMockito.given(objectMapper.readValue(savedEvent.payload(), BaseEvent.class))
+                    .willReturn(mockEvent);
+            doThrow(new RuntimeException("Redis connection refused"))
+                    .when(streamPublisher).publish(any(), any());
+
+            // when — 예외가 밖으로 나가면 안 된다
+            outboxAfterCommitRelay.onOutboxSaved(savedEvent);
+
+            // then — markPublished가 호출되지 않아야 한다 (PENDING 유지)
+            verify(eventProcessor, org.mockito.Mockito.never()).markPublished(any());
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
@@ -1,0 +1,232 @@
+package coffeeshout.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.room.domain.event.PlayerListUpdateEvent;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Outbox 패턴 E2E 테스트 (2단 콤보 Outbox).
+ * <p>
+ * Testcontainers로 MySQL + Redis를 실제로 띄워서 전체 흐름을 검증한다.
+ * <p>
+ * 2단 콤보 구조: - 1단계: record() → 트랜잭션 커밋 → AFTER_COMMIT 즉시 발행 → PUBLISHED (Happy Path) - 2단계: 즉시 발행 실패 시 → PENDING 유지 →
+ * Worker가 500ms 후 재시도 (Fallback)
+ * <p>
+ * H2 대신 MySQL을 쓰는 이유: FOR UPDATE SKIP LOCKED가 H2에서 지원되지 않는다.
+ */
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+@Import(OutboxE2ETest.OutboxE2ETestConfig.class)
+class OutboxE2ETest {
+
+    @Container
+    static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+            .withDatabaseName("outbox_test")
+            .withUsername("test")
+            .withPassword("test")
+            .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("valkey/valkey:latest"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.MySQLDialect");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> "false");
+
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+
+    @TestConfiguration
+    static class OutboxE2ETestConfig {
+
+        @Bean
+        @Primary
+        public RedisConnectionFactory testRedisConnectionFactory() {
+            final LettuceConnectionFactory factory = new LettuceConnectionFactory(
+                    redis.getHost(), redis.getMappedPort(6379)
+            );
+            factory.afterPropertiesSet();
+            return factory;
+        }
+
+        @Bean(name = "cardGameTaskScheduler")
+        public TaskScheduler cardGameTaskScheduler() {
+            return new coffeeshout.global.config.ShutDownTestScheduler();
+        }
+
+        @Bean(name = "delayRemovalScheduler")
+        public TaskScheduler delayRemovalScheduler() {
+            return new coffeeshout.global.config.ShutDownTestScheduler();
+        }
+
+        @Bean(name = "racingGameScheduler")
+        public TaskScheduler racingGameScheduler() {
+            return new coffeeshout.global.config.ShutDownTestScheduler();
+        }
+    }
+
+    @Autowired
+    private OutboxEventRecorder outboxEventRecorder;
+
+    @Autowired
+    private OutboxRelayWorker outboxRelayWorker;
+
+    @Autowired
+    private OutboxEventProcessor outboxEventProcessor;
+
+    @Autowired
+    private OutboxEventRepository outboxEventRepository;
+
+    @BeforeEach
+    void setUp() {
+        outboxEventRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    class AFTER_COMMIT_즉시_발행_Happy_Path는 {
+
+        @Test
+        void record_호출_후_트랜잭션_커밋_시_즉시_PUBLISHED로_전환된다() {
+            // given & when — record() 호출 → 자체 @Transactional 커밋 → AFTER_COMMIT 즉시 발행
+            final BaseEvent event = new PlayerListUpdateEvent("test-join-code");
+            outboxEventRecorder.record(StreamKey.ROOM_BROADCAST, event);
+
+            // then — AFTER_COMMIT이 즉시 실행되어 이미 PUBLISHED
+            final List<OutboxEvent> events = outboxEventRepository.findAll();
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).getStatus()).isEqualTo(OutboxStatus.PUBLISHED);
+        }
+
+        @Test
+        void 여러_이벤트를_record하면_각각_즉시_PUBLISHED로_전환된다() {
+            // given & when
+            IntStream.range(0, 5).forEach(i -> {
+                final BaseEvent event = new PlayerListUpdateEvent("join-code-" + i);
+                outboxEventRecorder.record(StreamKey.ROOM_BROADCAST, event);
+            });
+
+            // then
+            final List<OutboxEvent> events = outboxEventRepository.findAll();
+            assertThat(events).hasSize(5);
+            assertThat(events).allSatisfy(event ->
+                    assertThat(event.getStatus()).isEqualTo(OutboxStatus.PUBLISHED)
+            );
+        }
+    }
+
+    @Nested
+    class Worker_폴링_재시도_Fallback는 {
+
+        @Test
+        void 직접_PENDING_레코드를_넣으면_Worker가_relay해서_PUBLISHED로_전환한다() {
+            // given — Outbox에 직접 PENDING 레코드 삽입 (AFTER_COMMIT 우회)
+            final OutboxEvent event = OutboxEvent.create("room",
+                    "{\"@type\":\"PlayerListUpdateEvent\",\"eventId\":\"test\",\"timestamp\":\"2025-01-01T00:00:00Z\",\"joinCode\":\"ABCD\"}");
+            outboxEventRepository.saveAndFlush(event);
+
+            assertThat(outboxEventRepository.findAll().get(0).getStatus()).isEqualTo(OutboxStatus.PENDING);
+
+            // when — Worker 수동 호출
+            outboxRelayWorker.relay();
+
+            // then
+            final OutboxEvent afterRelay = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(afterRelay.getStatus()).isEqualTo(OutboxStatus.PUBLISHED);
+        }
+
+        @Test
+        void Redis_발행_실패_시_retryCount가_증가하고_PENDING으로_복귀한다() {
+            // given — 존재하지 않는 streamKey로 발행 실패를 유도
+            final OutboxEvent event = OutboxEvent.create("nonexistent-stream-key", "{\"invalid\":true}");
+            outboxEventRepository.saveAndFlush(event);
+
+            // when
+            outboxRelayWorker.relay();
+
+            // then
+            final OutboxEvent afterRelay = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(afterRelay.getRetryCount()).isEqualTo(1);
+            assertThat(afterRelay.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        }
+
+        @Test
+        void 재시도_10회_실패_시_DEAD_LETTER로_전환된다() {
+            // given
+            final OutboxEvent event = OutboxEvent.create("nonexistent-stream-key", "{\"invalid\":true}");
+            outboxEventRepository.saveAndFlush(event);
+
+            // when — 10번 relay 반복
+            IntStream.range(0, 10).forEach(i -> outboxRelayWorker.relay());
+
+            // then
+            final OutboxEvent afterRetries = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(afterRetries.getStatus()).isEqualTo(OutboxStatus.DEAD_LETTER);
+            assertThat(afterRetries.getRetryCount()).isEqualTo(10);
+        }
+    }
+
+    @Nested
+    class fetchAndMarkInProgress는 {
+
+        @Test
+        void PENDING_이벤트를_IN_PROGRESS로_전환한다() {
+            // given — 직접 PENDING 레코드 삽입
+            final OutboxEvent event = OutboxEvent.create("room", "{\"type\":\"test\"}");
+            outboxEventRepository.saveAndFlush(event);
+
+            // when
+            final List<OutboxEvent> fetched = outboxEventProcessor.fetchAndMarkInProgress(50);
+
+            // then
+            assertThat(fetched).hasSize(1);
+            assertThat(fetched.get(0).getStatus()).isEqualTo(OutboxStatus.IN_PROGRESS);
+        }
+
+        @Test
+        void IN_PROGRESS_이벤트는_다음_폴링에서_조회되지_않는다() {
+            // given
+            final OutboxEvent event = OutboxEvent.create("room", "{\"type\":\"test\"}");
+            outboxEventRepository.saveAndFlush(event);
+            outboxEventProcessor.fetchAndMarkInProgress(50);
+
+            // when
+            final List<OutboxEvent> secondFetch = outboxEventProcessor.fetchAndMarkInProgress(50);
+
+            // then
+            assertThat(secondFetch).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxEventProcessorTest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxEventProcessorTest.java
@@ -1,0 +1,152 @@
+package coffeeshout.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.transaction.TestTransaction;
+
+class OutboxEventProcessorTest extends ServiceTest {
+
+    @Autowired
+    private OutboxEventProcessor outboxEventProcessor;
+
+    @Autowired
+    private OutboxEventRepository outboxEventRepository;
+
+    @MockitoBean
+    private StreamPublisher streamPublisher;
+
+    @BeforeEach
+    void setUp() {
+        outboxEventRepository.deleteAllInBatch();
+    }
+
+    private OutboxEvent createPendingEvent(String streamKey, String payload) {
+        return outboxEventRepository.save(OutboxEvent.create(streamKey, payload));
+    }
+
+    @Nested
+    class fetchAndMarkInProgress_메서드 {
+
+        @Test
+        void PENDING_이벤트를_조회하고_IN_PROGRESS로_전환한다() {
+            // given
+            createPendingEvent("room", "{\"type\":\"test1\"}");
+            createPendingEvent("room", "{\"type\":\"test2\"}");
+
+            // when
+            List<OutboxEvent> result = outboxEventProcessor.fetchAndMarkInProgress(10);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).allSatisfy(event ->
+                    assertThat(event.getStatus()).isEqualTo(OutboxStatus.IN_PROGRESS)
+            );
+        }
+
+        @Test
+        void PENDING_이벤트가_없으면_빈_리스트를_반환한다() {
+            // when
+            List<OutboxEvent> result = outboxEventProcessor.fetchAndMarkInProgress(10);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void batchSize만큼만_조회한다() {
+            // given
+            IntStream.range(0, 5).forEach(i ->
+                    createPendingEvent("room", "{\"index\":" + i + "}")
+            );
+
+            // when
+            List<OutboxEvent> result = outboxEventProcessor.fetchAndMarkInProgress(3);
+
+            // then
+            assertThat(result).hasSize(3);
+        }
+    }
+
+    @Nested
+    class markPublished_메서드는 {
+
+        @Test
+        void 이벤트를_PUBLISHED_상태로_전환한다() {
+            // given — REQUIRES_NEW 트랜잭션에서 데이터가 보이도록 테스트 트랜잭션을 먼저 커밋
+            OutboxEvent event = createPendingEvent("room", "{\"type\":\"test\"}");
+            TestTransaction.flagForCommit();
+            TestTransaction.end();
+
+            // when
+            outboxEventProcessor.markPublished(event.getId());
+
+            // then
+            TestTransaction.start();
+            OutboxEvent updated = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(updated.getStatus()).isEqualTo(OutboxStatus.PUBLISHED);
+        }
+    }
+
+    @Nested
+    class handleFailure_메서드 {
+
+        @Test
+        void 실패_시_retryCount를_증가시키고_PENDING으로_되돌린다() {
+            // given
+            OutboxEvent event = createPendingEvent("room", "{\"type\":\"test\"}");
+
+            // when
+            outboxEventProcessor.handleFailure(event.getId());
+
+            // then
+            OutboxEvent updated = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(updated.getRetryCount()).isEqualTo(1);
+            assertThat(updated.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        }
+
+        @Test
+        void 재시도_10회_실패_시_DEAD_LETTER로_전환한다() {
+            // given
+            OutboxEvent event = createPendingEvent("room", "{\"type\":\"test\"}");
+
+            // when
+            IntStream.range(0, 10).forEach(i ->
+                    outboxEventProcessor.handleFailure(event.getId())
+            );
+
+            // then
+            OutboxEvent updated = outboxEventRepository.findById(event.getId()).orElseThrow();
+            assertThat(updated.getStatus()).isEqualTo(OutboxStatus.DEAD_LETTER);
+            assertThat(updated.getRetryCount()).isEqualTo(10);
+        }
+    }
+
+    @Nested
+    class recoverStaleEvents_메서드 {
+
+        @Test
+        void 메서드_호출이_에러_없이_동작한다() {
+            // given
+            OutboxEvent event = createPendingEvent("room", "{\"type\":\"stale\"}");
+            event.markInProgress();
+            outboxEventRepository.save(event);
+            outboxEventRepository.flush();
+
+            // when
+            int recovered = outboxEventProcessor.recoverStaleEvents();
+
+            // then — H2에서는 created_at 조건으로 0이 될 수 있다.
+            // 실제 MySQL 통합 테스트에서 시간 조건을 검증할 부분.
+            assertThat(recovered).isGreaterThanOrEqualTo(0);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxEventRecorderTest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxEventRecorderTest.java
@@ -1,0 +1,70 @@
+package coffeeshout.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.domain.event.PlayerListUpdateEvent;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * OutboxEventRecorder 단위 테스트.
+ * <p>
+ * ServiceTest가 @Transactional이므로 테스트 종료 시 롤백된다.
+ * 따라서 @TransactionalEventListener(AFTER_COMMIT)은 실행되지 않는다.
+ * AFTER_COMMIT 즉시 발행 동작은 OutboxAfterCommitRelayTest에서 별도 검증한다.
+ */
+class OutboxEventRecorderTest extends ServiceTest {
+
+    @Autowired
+    private OutboxEventRecorder outboxEventRecorder;
+
+    @Autowired
+    private OutboxEventRepository outboxEventRepository;
+
+    @MockitoBean
+    private StreamPublisher streamPublisher;
+
+    @BeforeEach
+    void setUp() {
+        outboxEventRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void record_호출_시_Outbox_테이블에_PENDING_상태로_이벤트가_저장된다() {
+        // given
+        BaseEvent event = new PlayerListUpdateEvent("test-join-code");
+
+        // when
+        outboxEventRecorder.record(StreamKey.ROOM_BROADCAST, event);
+
+        // then
+        List<OutboxEvent> events = outboxEventRepository.findAll();
+        assertThat(events).hasSize(1);
+
+        OutboxEvent saved = events.get(0);
+        assertThat(saved.getStreamKey()).isEqualTo("room");
+        assertThat(saved.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(saved.getRetryCount()).isZero();
+        assertThat(saved.getPayload()).contains("test-join-code");
+    }
+
+    @Test
+    void record는_트랜잭션_커밋_전에는_Redis를_호출하지_않는다() {
+        // given
+        BaseEvent event = new PlayerListUpdateEvent("test-join-code");
+
+        // when
+        outboxEventRecorder.record(StreamKey.ROOM_BROADCAST, event);
+
+        // then — @Transactional 테스트이므로 커밋 안 됨 → AFTER_COMMIT 미실행 → Redis 미호출
+        Mockito.verifyNoInteractions(streamPublisher);
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxEventTest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxEventTest.java
@@ -1,0 +1,63 @@
+package coffeeshout.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class OutboxEventTest {
+
+    @Test
+    void 생성_시_PENDING_상태이고_retryCount는_0이다() {
+        // when
+        OutboxEvent event = OutboxEvent.create("room", "{\"type\":\"test\"}");
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(event.getRetryCount()).isZero();
+        assertThat(event.getStreamKey()).isEqualTo("room");
+        assertThat(event.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    void 상태_전이_PENDING에서_IN_PROGRESS를_거쳐_PUBLISHED로_변경된다() {
+        // given
+        OutboxEvent event = OutboxEvent.create("room", "{}");
+
+        // when & then
+        event.markInProgress();
+        assertThat(event.getStatus()).isEqualTo(OutboxStatus.IN_PROGRESS);
+
+        event.markPublished();
+        assertThat(event.getStatus()).isEqualTo(OutboxStatus.PUBLISHED);
+    }
+
+    @Test
+    void 발행_실패_시_PENDING으로_복귀하고_retryCount가_증가한다() {
+        // given
+        OutboxEvent event = OutboxEvent.create("room", "{}");
+        event.markInProgress();
+
+        // when
+        event.incrementRetryCount();
+        event.setStatusPending();
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(event.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 재시도_10회_실패_시_DEAD_LETTER로_전환된다() {
+        // given
+        OutboxEvent event = OutboxEvent.create("room", "{}");
+
+        // when
+        IntStream.range(0, 10).forEach(i -> event.incrementRetryCount());
+        event.markDeadLetter();
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(OutboxStatus.DEAD_LETTER);
+        assertThat(event.getRetryCount()).isEqualTo(10);
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxRelayWorkerTest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxRelayWorkerTest.java
@@ -1,0 +1,134 @@
+package coffeeshout.global.outbox;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.domain.event.PlayerListUpdateEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxRelayWorkerTest {
+
+    @Mock
+    private OutboxEventProcessor eventProcessor;
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private StreamPublisher streamPublisher;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OutboxRelayWorker outboxRelayWorker;
+
+    private OutboxEvent createMockEvent(Long id, String streamKey, String payload) {
+        OutboxEvent event = OutboxEvent.create(streamKey, payload);
+        try {
+            Field idField = OutboxEvent.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(event, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return event;
+    }
+
+    @Nested
+    class relay_메서드 {
+
+        @Test
+        void PENDING_이벤트가_없으면_아무것도_하지_않는다() {
+            // given
+            given(eventProcessor.fetchAndMarkInProgress(50)).willReturn(Collections.emptyList());
+
+            // when
+            outboxRelayWorker.relay();
+
+            // then
+            verify(streamPublisher, never()).publish(any(), any());
+            verify(eventProcessor, never()).markPublished(any());
+        }
+
+        @Test
+        void 발행_성공_시_markPublished를_호출한다() throws Exception {
+            // given
+            OutboxEvent event = createMockEvent(1L, "room", "{\"@type\":\"PlayerListUpdateEvent\"}");
+            given(eventProcessor.fetchAndMarkInProgress(50)).willReturn(List.of(event));
+            given(objectMapper.readValue(event.getPayload(), BaseEvent.class))
+                    .willReturn(new PlayerListUpdateEvent("test"));
+
+            // when
+            outboxRelayWorker.relay();
+
+            // then
+            verify(eventProcessor).fetchAndMarkInProgress(50);
+            verify(streamPublisher).publish(eq(StreamKey.ROOM_BROADCAST), any());
+            verify(eventProcessor).markPublished(1L);
+        }
+
+        @Test
+        void Redis_발행_실패_시_handleFailure를_호출한다() throws Exception {
+            // given
+            OutboxEvent event = createMockEvent(1L, "room", "{\"@type\":\"PlayerListUpdateEvent\"}");
+            given(eventProcessor.fetchAndMarkInProgress(50)).willReturn(List.of(event));
+            given(objectMapper.readValue(event.getPayload(), BaseEvent.class))
+                    .willReturn(new PlayerListUpdateEvent("test"));
+            doThrow(new RuntimeException("Redis connection refused"))
+                    .when(streamPublisher).publish(any(), any());
+
+            // when
+            outboxRelayWorker.relay();
+
+            // then
+            verify(eventProcessor).handleFailure(1L);
+            verify(eventProcessor, never()).markPublished(any());
+        }
+
+        @Test
+        void 배치_내_일부_실패해도_나머지는_정상_처리된다() throws Exception {
+            // given
+            OutboxEvent event1 = createMockEvent(1L, "room", "{\"@type\":\"event1\"}");
+            OutboxEvent event2 = createMockEvent(2L, "room", "{\"@type\":\"event2\"}");
+            OutboxEvent event3 = createMockEvent(3L, "room", "{\"@type\":\"event3\"}");
+
+            given(eventProcessor.fetchAndMarkInProgress(50))
+                    .willReturn(List.of(event1, event2, event3));
+
+            BaseEvent mockEvent = new PlayerListUpdateEvent("test");
+            given(objectMapper.readValue(any(String.class), eq(BaseEvent.class)))
+                    .willReturn(mockEvent);
+
+            doThrow(new RuntimeException("timeout"))
+                    .doNothing()
+                    .doNothing()
+                    .when(streamPublisher).publish(any(), any());
+
+            // when
+            outboxRelayWorker.relay();
+
+            // then — event1은 실패 처리, event2와 event3은 성공 처리
+            verify(eventProcessor).handleFailure(1L);
+            verify(eventProcessor).markPublished(2L);
+            verify(eventProcessor).markPublished(3L);
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1106

# 🚀 작업 내용
## 배경
`createRoom()`에서 DB 커밋과 Redis Stream 발행이 원자적이지 않아 Dual Write Problem이 존재했다. Redis 장애 시 이벤트가 유실되거나, 트랜잭션 롤백 시 유령 이벤트가 발생할 수 있었다.

## 변경 사항
- Outbox 인프라 구축: `OutboxEvent`, `OutboxEventRecorder`, `OutboxEventProcessor`, `OutboxRelayWorker`, `OutboxAfterCommitRelay`
- `createRoom()`에 2단 콤보 Outbox 적용
  - 평상시: `@TransactionalEventListener(AFTER_COMMIT)` 즉시 발행 (지연 0ms)
  - Redis 장애 시: Worker가 500ms 폴링으로 PENDING 이벤트 재시도
- Worker 트랜잭션 분리: Redis I/O와 DB 트랜잭션을 분리하여 Cascading Failure 방지
- `SKIP LOCKED`로 다중 인스턴스 중복 발행 차단
- `StreamKey.fromRedisKey()` 역변환 메서드 추가

## 적용 범위
- Outbox 적용: `createRoom()` (DB 변경 + 이벤트 발행의 원자성이 필요한 유일한 경로)
- 직접 발행 유지: WebSocket 컨트롤러, 미니게임 입력, 세션 이벤트 등 (DB 원자성 불필요, 실시간성 우선)

## 성능 영향
- `createRoom()` 호출당 DB 쿼리 +2회 (INSERT + UPDATE), 추가 지연 ~1ms
- Worker 평시 부하: 500ms마다 빈 SELECT 1회 (~0.1ms)