### PR TITLE
[feat] 스피드 터치 미니게임 추가

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,6 +36,7 @@ val websocketDocsVersion = "1.0.7"
 val testcontainersVersion = "2.0.2"
 val reflectionsVersion = "0.10.2"
 val resilience4jVersion = "2.2.0"
+val awaitilityVersion = "4.2.2"
 
 dependencies {
     // --- Spring Boot Starters (버전 생략: Boot가 관리) ---
@@ -95,7 +96,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:${testcontainersVersion}")
     testImplementation("org.testcontainers:mysql:1.20.4")
     testImplementation("org.testcontainers:junit-jupiter:1.20.4")
-    testImplementation("org.awaitility:awaitility:4.2.2")
+    testImplementation("org.awaitility:awaitility:${awaitilityVersion}")
 
     // --- Reflections (클래스패스 스캔) ---
     implementation("org.reflections:reflections:${reflectionsVersion}")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,7 +36,6 @@ val websocketDocsVersion = "1.0.7"
 val testcontainersVersion = "2.0.2"
 val reflectionsVersion = "0.10.2"
 val resilience4jVersion = "2.2.0"
-val awaitilityVersion = "4.2.2"
 
 dependencies {
     // --- Spring Boot Starters (버전 생략: Boot가 관리) ---
@@ -96,7 +95,6 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:${testcontainersVersion}")
     testImplementation("org.testcontainers:mysql:1.20.4")
     testImplementation("org.testcontainers:junit-jupiter:1.20.4")
-    testImplementation("org.awaitility:awaitility:${awaitilityVersion}")
 
     // --- Reflections (클래스패스 스캔) ---
     implementation("org.reflections:reflections:${reflectionsVersion}")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:${testcontainersVersion}")
     testImplementation("org.testcontainers:mysql:1.20.4")
     testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+    testImplementation("org.awaitility:awaitility:4.2.2")
 
     // --- Reflections (클래스패스 스캔) ---
     implementation("org.reflections:reflections:${reflectionsVersion}")

--- a/backend/src/main/java/coffeeshout/global/redis/stream/StreamKey.java
+++ b/backend/src/main/java/coffeeshout/global/redis/stream/StreamKey.java
@@ -10,7 +10,8 @@ public enum StreamKey {
     ROOM_JOIN("room:join"),
     CARD_GAME_SELECT_BROADCAST("cardgame:select"),
     MINIGAME_EVENTS("minigame"),
-    RACING_GAME_EVENTS("racinggame");
+    RACING_GAME_EVENTS("racinggame"),
+    SPEED_TOUCH_EVENTS("speedtouch");
 
     private final String redisKey;
 }

--- a/backend/src/main/java/coffeeshout/minigame/domain/MiniGameType.java
+++ b/backend/src/main/java/coffeeshout/minigame/domain/MiniGameType.java
@@ -4,6 +4,7 @@ import coffeeshout.cardgame.domain.CardGame;
 import coffeeshout.cardgame.domain.card.CardGameRandomDeckGenerator;
 import coffeeshout.racinggame.domain.RacingGame;
 import coffeeshout.room.domain.Playable;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 
@@ -12,6 +13,7 @@ public enum MiniGameType {
 
     CARD_GAME,
     RACING_GAME,
+    SPEED_TOUCH,
     ;
 
     public Playable createMiniGame(String joinCode) {
@@ -22,6 +24,7 @@ public enum MiniGameType {
                 yield new CardGame(new CardGameRandomDeckGenerator(), seed);
             }
             case RACING_GAME -> new RacingGame();
+            case SPEED_TOUCH -> new SpeedTouchGame();
         };
     }
 }

--- a/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameProgressHandler.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameProgressHandler.java
@@ -1,0 +1,42 @@
+package coffeeshout.speedtouch.application;
+
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.service.RoomQueryService;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SpeedTouchGameProgressHandler {
+
+    private final RoomQueryService roomQueryService;
+    private final SpeedTouchGameService speedTouchGameService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void handleTouch(String joinCode, String playerName, int touchedNumber) {
+        final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
+        final SpeedTouchGame game = speedTouchGameService.getSpeedTouchGame(room);
+
+        final boolean accepted = game.touch(new PlayerName(playerName), touchedNumber, Instant.now());
+        if (!accepted) {
+            log.debug("터치 무시: joinCode={}, player={}, number={}", joinCode, playerName, touchedNumber);
+            return;
+        }
+
+        eventPublisher.publishEvent(SpeedTouchProgressEvent.of(game, joinCode));
+        log.debug("터치 처리: joinCode={}, player={}, number={}", joinCode, playerName, touchedNumber);
+
+        if (game.isAllFinished()) {
+            log.info("전원 완주 - 게임 종료: joinCode={}", joinCode);
+            speedTouchGameService.finishGame(game, joinCode);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
@@ -1,0 +1,123 @@
+package coffeeshout.speedtouch.application;
+
+import coffeeshout.global.metric.GameDurationMetricService;
+import coffeeshout.minigame.domain.MiniGameService;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.minigame.event.dto.MiniGameFinishedEvent;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.service.RoomQueryService;
+import coffeeshout.speedtouch.config.SpeedTouchGameTimingProperties;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.SpeedTouchGameState;
+import coffeeshout.speedtouch.domain.event.SpeedTouchFinishedEvent;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
+import coffeeshout.speedtouch.domain.event.SpeedTouchStateChangedEvent;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ScheduledFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class SpeedTouchGameService implements MiniGameService {
+
+    private final RoomQueryService roomQueryService;
+    private final TaskScheduler taskScheduler;
+    private final ApplicationEventPublisher eventPublisher;
+    private final SpeedTouchGameTimingProperties timing;
+    private final GameDurationMetricService gameDurationMetricService;
+
+    public SpeedTouchGameService(
+            RoomQueryService roomQueryService,
+            @Qualifier("speedTouchGameScheduler") TaskScheduler taskScheduler,
+            ApplicationEventPublisher eventPublisher,
+            SpeedTouchGameTimingProperties timing,
+            GameDurationMetricService gameDurationMetricService
+    ) {
+        this.roomQueryService = roomQueryService;
+        this.taskScheduler = taskScheduler;
+        this.eventPublisher = eventPublisher;
+        this.timing = timing;
+        this.gameDurationMetricService = gameDurationMetricService;
+    }
+
+    @Override
+    public void start(String joinCode, String hostName) {
+        final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
+        final SpeedTouchGame game = getSpeedTouchGame(room);
+
+        scheduleDescription(game, joinCode);
+
+        eventPublisher.publishEvent(SpeedTouchStateChangedEvent.of(game, joinCode));
+        log.info("스피드 터치 게임 시작: joinCode={}", joinCode);
+    }
+
+    @Override
+    public MiniGameType getMiniGameType() {
+        return MiniGameType.SPEED_TOUCH;
+    }
+
+    private void scheduleDescription(SpeedTouchGame game, String joinCode) {
+        game.updateState(SpeedTouchGameState.DESCRIPTION);
+        taskScheduler.schedule(
+                () -> schedulePrepare(game, joinCode),
+                Instant.now().plus(timing.description().toMillis(), ChronoUnit.MILLIS)
+        );
+    }
+
+    private void schedulePrepare(SpeedTouchGame game, String joinCode) {
+        game.updateState(SpeedTouchGameState.PREPARE);
+        eventPublisher.publishEvent(SpeedTouchStateChangedEvent.of(game, joinCode));
+        eventPublisher.publishEvent(SpeedTouchProgressEvent.of(game, joinCode));
+
+        taskScheduler.schedule(
+                () -> startPlaying(game, joinCode),
+                Instant.now().plus(timing.prepare().toMillis(), ChronoUnit.MILLIS)
+        );
+    }
+
+    private void startPlaying(SpeedTouchGame game, String joinCode) {
+        game.startPlaying();
+        eventPublisher.publishEvent(SpeedTouchStateChangedEvent.of(game, joinCode));
+        gameDurationMetricService.startGameTimer(joinCode);
+
+        final ScheduledFuture<?> timeoutFuture = taskScheduler.schedule(
+                () -> handleTimeout(game, joinCode),
+                Instant.now().plus(timing.playing().toMillis(), ChronoUnit.MILLIS)
+        );
+        game.setTimeoutFuture(timeoutFuture);
+    }
+
+    private void handleTimeout(SpeedTouchGame game, String joinCode) {
+        if (game.isDone()) {
+            return;
+        }
+        log.info("스피드 터치 게임 타임아웃: joinCode={}", joinCode);
+        finishGame(game, joinCode);
+    }
+
+    void finishGame(SpeedTouchGame game, String joinCode) {
+        game.updateState(SpeedTouchGameState.DONE);
+        game.cancelTimeout();
+
+        final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
+        room.applyMiniGameResult(game.getResult());
+
+        eventPublisher.publishEvent(SpeedTouchProgressEvent.of(game, joinCode));
+        taskScheduler.schedule(
+                () -> eventPublisher.publishEvent(SpeedTouchFinishedEvent.of(game, joinCode)),
+                Instant.now().plusSeconds(2)
+        );
+        eventPublisher.publishEvent(new MiniGameFinishedEvent(joinCode, MiniGameType.SPEED_TOUCH.name()));
+        log.info("스피드 터치 게임 종료: joinCode={}", joinCode);
+    }
+
+    SpeedTouchGame getSpeedTouchGame(Room room) {
+        return (SpeedTouchGame) room.findMiniGame(MiniGameType.SPEED_TOUCH);
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
@@ -102,7 +102,6 @@ public class SpeedTouchGameService implements MiniGameService {
         if (!game.tryFinish()) {
             return;
         }
-        game.updateState(SpeedTouchGameState.DONE);
         game.cancelTimeout();
 
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));

--- a/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/application/SpeedTouchGameService.java
@@ -94,14 +94,14 @@ public class SpeedTouchGameService implements MiniGameService {
     }
 
     private void handleTimeout(SpeedTouchGame game, String joinCode) {
-        if (game.isDone()) {
-            return;
-        }
         log.info("스피드 터치 게임 타임아웃: joinCode={}", joinCode);
         finishGame(game, joinCode);
     }
 
     void finishGame(SpeedTouchGame game, String joinCode) {
+        if (!game.tryFinish()) {
+            return;
+        }
         game.updateState(SpeedTouchGameState.DONE);
         game.cancelTimeout();
 

--- a/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameSchedulerConfig.java
@@ -1,0 +1,29 @@
+package coffeeshout.speedtouch.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@Slf4j
+public class SpeedTouchGameSchedulerConfig {
+
+    @Bean(name = "speedTouchGameScheduler")
+    @Profile("!test")
+    public TaskScheduler speedTouchGameScheduler() {
+        final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        scheduler.setThreadNamePrefix("speed-touch-");
+        scheduler.setDaemon(false);
+        scheduler.setErrorHandler(t ->
+                log.error("스피드 터치 스케줄 실행 중 예외가 발생했습니다.", t)
+        );
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameTimingProperties.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameTimingProperties.java
@@ -12,4 +12,16 @@ public record SpeedTouchGameTimingProperties(
         @NotNull Duration prepare,
         @NotNull Duration playing
 ) {
+
+    public SpeedTouchGameTimingProperties {
+        validatePositive(description, "description");
+        validatePositive(prepare, "prepare");
+        validatePositive(playing, "playing");
+    }
+
+    private static void validatePositive(Duration duration, String name) {
+        if (duration != null && (duration.isZero() || duration.isNegative())) {
+            throw new IllegalArgumentException(name + " 타이밍은 0보다 커야 합니다: " + duration);
+        }
+    }
 }

--- a/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameTimingProperties.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/config/SpeedTouchGameTimingProperties.java
@@ -1,0 +1,15 @@
+package coffeeshout.speedtouch.config;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "speed-touch.timing")
+public record SpeedTouchGameTimingProperties(
+        @NotNull Duration description,
+        @NotNull Duration prepare,
+        @NotNull Duration playing
+) {
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
@@ -20,8 +20,8 @@ import lombok.Setter;
 public class SpeedTouchGame implements Playable {
 
     private SpeedTouchPlayers players;
-    private SpeedTouchGameState state;
-    private Instant startTime;
+    private volatile SpeedTouchGameState state;
+    private volatile Instant startTime;
     private final AtomicBoolean finished = new AtomicBoolean(false);
 
     @Setter

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
@@ -1,0 +1,108 @@
+package coffeeshout.speedtouch.domain;
+
+import coffeeshout.global.exception.custom.InvalidStateException;
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.room.domain.Playable;
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class SpeedTouchGame implements Playable {
+
+    private SpeedTouchPlayers players;
+    private SpeedTouchGameState state;
+    private Instant startTime;
+
+    @Setter
+    private ScheduledFuture<?> timeoutFuture;
+
+    public SpeedTouchGame() {
+        this.state = SpeedTouchGameState.DESCRIPTION;
+    }
+
+    @Override
+    public void setUp(List<Player> playerList) {
+        this.players = new SpeedTouchPlayers(playerList);
+    }
+
+    @Override
+    public MiniGameResult getResult() {
+        return MiniGameResult.fromAscending(getScores());
+    }
+
+    @Override
+    public Map<Player, MiniGameScore> getScores() {
+        return players.stream()
+                .collect(Collectors.toMap(
+                        SpeedTouchPlayer::getPlayer,
+                        this::calculateScore
+                ));
+    }
+
+    @Override
+    public MiniGameType getMiniGameType() {
+        return MiniGameType.SPEED_TOUCH;
+    }
+
+    public boolean touch(PlayerName playerName, int number, Instant now) {
+        validatePlaying();
+        final SpeedTouchPlayer player = players.findByName(playerName);
+        return player.touch(number, now);
+    }
+
+    public boolean isAllFinished() {
+        return players.isAllFinished();
+    }
+
+    public void startPlaying() {
+        this.state = SpeedTouchGameState.PLAYING;
+        this.startTime = Instant.now();
+    }
+
+    public void updateState(SpeedTouchGameState state) {
+        this.state = state;
+    }
+
+    public boolean isPlaying() {
+        return state == SpeedTouchGameState.PLAYING;
+    }
+
+    public boolean isDone() {
+        return state == SpeedTouchGameState.DONE;
+    }
+
+    public void cancelTimeout() {
+        if (timeoutFuture != null && !timeoutFuture.isDone()) {
+            timeoutFuture.cancel(false);
+        }
+    }
+
+    public SpeedTouchPlayer findPlayer(PlayerName name) {
+        return players.findByName(name);
+    }
+
+    private MiniGameScore calculateScore(SpeedTouchPlayer player) {
+        if (player.isFinished()) {
+            return SpeedTouchScore.ofFinished(player.calculateFinishMillis(startTime));
+        }
+        return SpeedTouchScore.ofDnf(player.getProgress());
+    }
+
+    private void validatePlaying() {
+        if (state != SpeedTouchGameState.PLAYING) {
+            throw new InvalidStateException(
+                    SpeedTouchGameErrorCode.NOT_PLAYING_STATE,
+                    "현재 게임 상태가 플레이 중이 아닙니다: " + state
+            );
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +22,7 @@ public class SpeedTouchGame implements Playable {
     private SpeedTouchPlayers players;
     private SpeedTouchGameState state;
     private Instant startTime;
+    private final AtomicBoolean finished = new AtomicBoolean(false);
 
     @Setter
     private ScheduledFuture<?> timeoutFuture;
@@ -78,6 +80,10 @@ public class SpeedTouchGame implements Playable {
 
     public boolean isDone() {
         return state == SpeedTouchGameState.DONE;
+    }
+
+    public boolean tryFinish() {
+        return finished.compareAndSet(false, true);
     }
 
     public void cancelTimeout() {

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGame.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,16 +20,12 @@ import lombok.Setter;
 public class SpeedTouchGame implements Playable {
 
     private SpeedTouchPlayers players;
-    private volatile SpeedTouchGameState state;
+    private final AtomicReference<SpeedTouchGameState> state =
+            new AtomicReference<>(SpeedTouchGameState.DESCRIPTION);
     private volatile Instant startTime;
-    private final AtomicBoolean finished = new AtomicBoolean(false);
 
     @Setter
     private ScheduledFuture<?> timeoutFuture;
-
-    public SpeedTouchGame() {
-        this.state = SpeedTouchGameState.DESCRIPTION;
-    }
 
     @Override
     public void setUp(List<Player> playerList) {
@@ -66,24 +62,28 @@ public class SpeedTouchGame implements Playable {
     }
 
     public void startPlaying() {
-        this.state = SpeedTouchGameState.PLAYING;
+        state.set(SpeedTouchGameState.PLAYING);
         this.startTime = Instant.now();
     }
 
-    public void updateState(SpeedTouchGameState state) {
-        this.state = state;
+    public void updateState(SpeedTouchGameState newState) {
+        state.set(newState);
+    }
+
+    public SpeedTouchGameState getState() {
+        return state.get();
     }
 
     public boolean isPlaying() {
-        return state == SpeedTouchGameState.PLAYING;
+        return state.get() == SpeedTouchGameState.PLAYING;
     }
 
     public boolean isDone() {
-        return state == SpeedTouchGameState.DONE;
+        return state.get() == SpeedTouchGameState.DONE;
     }
 
     public boolean tryFinish() {
-        return finished.compareAndSet(false, true);
+        return state.compareAndSet(SpeedTouchGameState.PLAYING, SpeedTouchGameState.DONE);
     }
 
     public void cancelTimeout() {
@@ -104,10 +104,10 @@ public class SpeedTouchGame implements Playable {
     }
 
     private void validatePlaying() {
-        if (state != SpeedTouchGameState.PLAYING) {
+        if (state.get() != SpeedTouchGameState.PLAYING) {
             throw new InvalidStateException(
                     SpeedTouchGameErrorCode.NOT_PLAYING_STATE,
-                    "현재 게임 상태가 플레이 중이 아닙니다: " + state
+                    "현재 게임 상태가 플레이 중이 아닙니다: " + state.get()
             );
         }
     }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameErrorCode.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameErrorCode.java
@@ -1,0 +1,22 @@
+package coffeeshout.speedtouch.domain;
+
+import coffeeshout.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum SpeedTouchGameErrorCode implements ErrorCode {
+
+    NOT_PLAYING_STATE("게임이 진행 중이 아닙니다."),
+    INVALID_TOUCH_NUMBER("터치 순서가 올바르지 않습니다."),
+    ALREADY_FINISHED("이미 완주한 플레이어입니다."),
+    ;
+
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameState.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameState.java
@@ -1,0 +1,19 @@
+package coffeeshout.speedtouch.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SpeedTouchGameState {
+
+    DESCRIPTION(4000L),
+    PREPARE(2000L),
+    PLAYING(0L),
+    DONE(0L),
+    ;
+
+    private final long duration;
+
+    SpeedTouchGameState(long duration) {
+        this.duration = duration;
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameState.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchGameState.java
@@ -1,19 +1,10 @@
 package coffeeshout.speedtouch.domain;
 
-import lombok.Getter;
-
-@Getter
 public enum SpeedTouchGameState {
 
-    DESCRIPTION(4000L),
-    PREPARE(2000L),
-    PLAYING(0L),
-    DONE(0L),
+    DESCRIPTION,
+    PREPARE,
+    PLAYING,
+    DONE,
     ;
-
-    private final long duration;
-
-    SpeedTouchGameState(long duration) {
-        this.duration = duration;
-    }
 }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
@@ -1,0 +1,51 @@
+package coffeeshout.speedtouch.domain;
+
+import coffeeshout.room.domain.player.Player;
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public class SpeedTouchPlayer {
+
+    public static final int FIRST_NUMBER = 1;
+    public static final int LAST_NUMBER = 25;
+
+    private final Player player;
+    private int currentNumber;
+    private Instant finishTime;
+
+    public SpeedTouchPlayer(Player player) {
+        this.player = player;
+        this.currentNumber = FIRST_NUMBER;
+    }
+
+    public boolean touch(int number, Instant now) {
+        if (isFinished()) {
+            return false;
+        }
+        if (number != currentNumber) {
+            return false;
+        }
+        currentNumber++;
+        if (currentNumber > LAST_NUMBER) {
+            finishTime = now;
+        }
+        return true;
+    }
+
+    public boolean isFinished() {
+        return finishTime != null;
+    }
+
+    public int getProgress() {
+        return currentNumber - FIRST_NUMBER;
+    }
+
+    public long calculateFinishMillis(Instant startTime) {
+        if (!isFinished()) {
+            throw new IllegalStateException("완주하지 않은 플레이어의 완주 시간을 계산할 수 없습니다.");
+        }
+        return Duration.between(startTime, finishTime).toMillis();
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
@@ -5,15 +5,15 @@ import java.time.Duration;
 import java.time.Instant;
 import lombok.Getter;
 
-@Getter
 public class SpeedTouchPlayer {
 
     public static final int FIRST_NUMBER = 1;
     public static final int LAST_NUMBER = 25;
 
+    @Getter
     private final Player player;
-    private volatile int currentNumber;
-    private volatile Instant finishTime;
+    private int currentNumber;
+    private Instant finishTime;
 
     public SpeedTouchPlayer(Player player) {
         this.player = player;
@@ -34,15 +34,23 @@ public class SpeedTouchPlayer {
         return true;
     }
 
-    public boolean isFinished() {
+    public synchronized boolean isFinished() {
         return finishTime != null;
     }
 
-    public int getProgress() {
+    public synchronized int getCurrentNumber() {
+        return currentNumber;
+    }
+
+    public synchronized int getProgress() {
         return currentNumber - FIRST_NUMBER;
     }
 
-    public long calculateFinishMillis(Instant startTime) {
+    public synchronized Instant getFinishTime() {
+        return finishTime;
+    }
+
+    public synchronized long calculateFinishMillis(Instant startTime) {
         if (!isFinished()) {
             throw new IllegalStateException("완주하지 않은 플레이어의 완주 시간을 계산할 수 없습니다.");
         }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
@@ -12,8 +12,8 @@ public class SpeedTouchPlayer {
     public static final int LAST_NUMBER = 25;
 
     private final Player player;
-    private int currentNumber;
-    private Instant finishTime;
+    private volatile int currentNumber;
+    private volatile Instant finishTime;
 
     public SpeedTouchPlayer(Player player) {
         this.player = player;

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayer.java
@@ -20,7 +20,7 @@ public class SpeedTouchPlayer {
         this.currentNumber = FIRST_NUMBER;
     }
 
-    public boolean touch(int number, Instant now) {
+    public synchronized boolean touch(int number, Instant now) {
         if (isFinished()) {
             return false;
         }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayers.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayers.java
@@ -13,10 +13,10 @@ public class SpeedTouchPlayers {
     private final List<SpeedTouchPlayer> players;
 
     public SpeedTouchPlayers(List<Player> roomPlayers) {
-        this.players = Collections.synchronizedList(
+        this.players = List.copyOf(
                 roomPlayers.stream()
                         .map(SpeedTouchPlayer::new)
-                        .collect(Collectors.toList())
+                        .toList()
         );
     }
 
@@ -27,7 +27,7 @@ public class SpeedTouchPlayers {
                 .orElseThrow(() -> new IllegalArgumentException("해당 플레이어를 찾을 수 없습니다: " + name.value()));
     }
 
-    public boolean isAllFinished() {
+    public synchronized boolean isAllFinished() {
         return players.stream().allMatch(SpeedTouchPlayer::isFinished);
     }
 
@@ -41,6 +41,6 @@ public class SpeedTouchPlayers {
     }
 
     public List<SpeedTouchPlayer> getPlayers() {
-        return Collections.unmodifiableList(players);
+        return players;
     }
 }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayers.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchPlayers.java
@@ -1,0 +1,46 @@
+package coffeeshout.speedtouch.domain;
+
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SpeedTouchPlayers {
+
+    private final List<SpeedTouchPlayer> players;
+
+    public SpeedTouchPlayers(List<Player> roomPlayers) {
+        this.players = Collections.synchronizedList(
+                roomPlayers.stream()
+                        .map(SpeedTouchPlayer::new)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public SpeedTouchPlayer findByName(PlayerName name) {
+        return players.stream()
+                .filter(p -> p.getPlayer().sameName(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 플레이어를 찾을 수 없습니다: " + name.value()));
+    }
+
+    public boolean isAllFinished() {
+        return players.stream().allMatch(SpeedTouchPlayer::isFinished);
+    }
+
+    public Map<Player, SpeedTouchPlayer> toPlayerMap() {
+        return players.stream()
+                .collect(Collectors.toMap(SpeedTouchPlayer::getPlayer, p -> p));
+    }
+
+    public Stream<SpeedTouchPlayer> stream() {
+        return players.stream();
+    }
+
+    public List<SpeedTouchPlayer> getPlayers() {
+        return Collections.unmodifiableList(players);
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchScore.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/SpeedTouchScore.java
@@ -1,0 +1,36 @@
+package coffeeshout.speedtouch.domain;
+
+import coffeeshout.minigame.domain.MiniGameScore;
+
+/**
+ * 단일 long 값으로 완주자/DNF를 모두 표현하는 점수 체계.
+ *
+ * - 완주자: finishMillis (0 ~ 제한시간). 값이 작을수록 빠르게 완주 → 높은 순위.
+ * - DNF: DNF_BASE - progress. progress가 높을수록 값이 작아져 → DNF 내에서 높은 순위.
+ * - 완주자의 최댓값(제한시간 ms)은 DNF_BASE보다 항상 작으므로, 완주자는 무조건 DNF보다 앞선다.
+ *
+ * MiniGameResult.fromAscending()으로 오름차순 정렬하면 원하는 랭킹이 나온다.
+ */
+public class SpeedTouchScore extends MiniGameScore {
+
+    private static final long DNF_BASE = 1_000_000_000L;
+
+    private final long value;
+
+    private SpeedTouchScore(long value) {
+        this.value = value;
+    }
+
+    public static SpeedTouchScore ofFinished(long finishMillis) {
+        return new SpeedTouchScore(finishMillis);
+    }
+
+    public static SpeedTouchScore ofDnf(int progress) {
+        return new SpeedTouchScore(DNF_BASE - progress);
+    }
+
+    @Override
+    public long getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchFinishedEvent.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchFinishedEvent.java
@@ -1,0 +1,10 @@
+package coffeeshout.speedtouch.domain.event;
+
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+
+public record SpeedTouchFinishedEvent(String state, String joinCode) {
+
+    public static SpeedTouchFinishedEvent of(SpeedTouchGame game, String joinCode) {
+        return new SpeedTouchFinishedEvent(game.getState().name(), joinCode);
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchFinishedEvent.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchFinishedEvent.java
@@ -2,9 +2,9 @@ package coffeeshout.speedtouch.domain.event;
 
 import coffeeshout.speedtouch.domain.SpeedTouchGame;
 
-public record SpeedTouchFinishedEvent(String state, String joinCode) {
+public record SpeedTouchFinishedEvent(String joinCode, String state) {
 
     public static SpeedTouchFinishedEvent of(SpeedTouchGame game, String joinCode) {
-        return new SpeedTouchFinishedEvent(game.getState().name(), joinCode);
+        return new SpeedTouchFinishedEvent(joinCode, game.getState().name());
     }
 }

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchProgressEvent.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchProgressEvent.java
@@ -1,0 +1,22 @@
+package coffeeshout.speedtouch.domain.event;
+
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.SpeedTouchPlayer;
+import java.util.List;
+
+public record SpeedTouchProgressEvent(String joinCode, List<PlayerProgress> players) {
+
+    public record PlayerProgress(String playerName, int currentNumber, boolean finished) {
+    }
+
+    public static SpeedTouchProgressEvent of(SpeedTouchGame game, String joinCode) {
+        final List<PlayerProgress> progresses = game.getPlayers().stream()
+                .map(p -> new PlayerProgress(
+                        p.getPlayer().getName().value(),
+                        p.getCurrentNumber(),
+                        p.isFinished()
+                ))
+                .toList();
+        return new SpeedTouchProgressEvent(joinCode, progresses);
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchStateChangedEvent.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchStateChangedEvent.java
@@ -1,0 +1,10 @@
+package coffeeshout.speedtouch.domain.event;
+
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+
+public record SpeedTouchStateChangedEvent(String joinCode, String state) {
+
+    public static SpeedTouchStateChangedEvent of(SpeedTouchGame game, String joinCode) {
+        return new SpeedTouchStateChangedEvent(joinCode, game.getState().name());
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/domain/event/TouchProgressCommandEvent.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/domain/event/TouchProgressCommandEvent.java
@@ -1,0 +1,29 @@
+package coffeeshout.speedtouch.domain.event;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.trace.TraceInfo;
+import coffeeshout.global.trace.TraceInfoExtractor;
+import coffeeshout.global.trace.Traceable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record TouchProgressCommandEvent(
+        String eventId,
+        String joinCode,
+        String playerName,
+        int touchedNumber,
+        Instant timestamp,
+        TraceInfo traceInfo
+) implements BaseEvent, Traceable {
+
+    public static TouchProgressCommandEvent create(String joinCode, String playerName, int touchedNumber) {
+        return new TouchProgressCommandEvent(
+                UUID.randomUUID().toString(),
+                joinCode,
+                playerName,
+                touchedNumber,
+                Instant.now(),
+                TraceInfoExtractor.extract()
+        );
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/infra/messaging/SpeedTouchGameMessagePublisher.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/infra/messaging/SpeedTouchGameMessagePublisher.java
@@ -1,0 +1,46 @@
+package coffeeshout.speedtouch.infra.messaging;
+
+import coffeeshout.global.websocket.LoggingSimpMessagingTemplate;
+import coffeeshout.global.websocket.ui.WebSocketResponse;
+import coffeeshout.speedtouch.domain.event.SpeedTouchFinishedEvent;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
+import coffeeshout.speedtouch.domain.event.SpeedTouchStateChangedEvent;
+import coffeeshout.speedtouch.ui.response.SpeedTouchProgressResponse;
+import coffeeshout.speedtouch.ui.response.SpeedTouchStateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpeedTouchGameMessagePublisher {
+
+    private static final String PROGRESS_DESTINATION_FORMAT = "/topic/room/%s/speed-touch/progress";
+    private static final String STATE_DESTINATION_FORMAT = "/topic/room/%s/speed-touch/state";
+
+    private final LoggingSimpMessagingTemplate messagingTemplate;
+
+    @EventListener
+    public void publishProgress(SpeedTouchProgressEvent event) {
+        messagingTemplate.convertAndSend(
+                String.format(PROGRESS_DESTINATION_FORMAT, event.joinCode()),
+                WebSocketResponse.success(SpeedTouchProgressResponse.from(event))
+        );
+    }
+
+    @EventListener
+    public void publishStateChanged(SpeedTouchStateChangedEvent event) {
+        messagingTemplate.convertAndSend(
+                String.format(STATE_DESTINATION_FORMAT, event.joinCode()),
+                WebSocketResponse.success(new SpeedTouchStateResponse(event.state()))
+        );
+    }
+
+    @EventListener
+    public void publishFinished(SpeedTouchFinishedEvent event) {
+        messagingTemplate.convertAndSend(
+                String.format(STATE_DESTINATION_FORMAT, event.joinCode()),
+                WebSocketResponse.success(new SpeedTouchStateResponse(event.state()))
+        );
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/infra/messaging/consumer/TouchProgressEventConsumer.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/infra/messaging/consumer/TouchProgressEventConsumer.java
@@ -1,0 +1,34 @@
+package coffeeshout.speedtouch.infra.messaging.consumer;
+
+import coffeeshout.global.exception.custom.InvalidStateException;
+import coffeeshout.speedtouch.application.SpeedTouchGameProgressHandler;
+import coffeeshout.speedtouch.domain.event.TouchProgressCommandEvent;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TouchProgressEventConsumer implements Consumer<TouchProgressCommandEvent> {
+
+    private final SpeedTouchGameProgressHandler progressHandler;
+
+    @Override
+    public void accept(TouchProgressCommandEvent event) {
+        try {
+            progressHandler.handleTouch(
+                    event.joinCode(),
+                    event.playerName(),
+                    event.touchedNumber()
+            );
+        } catch (InvalidStateException e) {
+            log.warn("터치 이벤트 처리 중 상태 오류: eventId={}, joinCode={}",
+                    event.eventId(), event.joinCode(), e);
+        } catch (Exception e) {
+            log.error("터치 이벤트 처리 실패: eventId={}, joinCode={}",
+                    event.eventId(), event.joinCode(), e);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/ui/SpeedTouchGameWebSocketController.java
@@ -1,0 +1,42 @@
+package coffeeshout.speedtouch.ui;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.speedtouch.domain.event.TouchProgressCommandEvent;
+import coffeeshout.speedtouch.ui.request.TouchCommand;
+import generator.annotaions.MessageResponse;
+import generator.annotaions.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class SpeedTouchGameWebSocketController {
+
+    private final StreamPublisher streamPublisher;
+
+    @MessageMapping("/room/{joinCode}/speed-touch/touch")
+    @Operation(
+            summary = "스피드 터치 게임 터치",
+            description = "1 to 25 스피드 터치 게임에서 플레이어가 숫자를 터치하는 웹소켓 요청입니다."
+    )
+    @MessageResponse(
+            path = "/topic/room/{joinCode}/speed-touch/progress",
+            returnType = Object.class
+    )
+    public void touch(@DestinationVariable String joinCode, @Payload @Valid TouchCommand command) {
+        final BaseEvent event = TouchProgressCommandEvent.create(
+                joinCode, command.playerName(), command.touchedNumber()
+        );
+        streamPublisher.publish(StreamKey.SPEED_TOUCH_EVENTS, event);
+        log.debug("터치 이벤트 발행: joinCode={}, player={}, number={}, eventId={}",
+                joinCode, command.playerName(), command.touchedNumber(), event.eventId());
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/ui/request/TouchCommand.java
@@ -1,0 +1,13 @@
+package coffeeshout.speedtouch.ui.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record TouchCommand(
+        @NotBlank(message = "플레이어 이름은 필수입니다") String playerName,
+        @Min(value = 1, message = "터치 번호는 1 이상이어야 합니다")
+        @Max(value = 25, message = "터치 번호는 25 이하여야 합니다")
+        int touchedNumber
+) {
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchProgressResponse.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchProgressResponse.java
@@ -1,0 +1,12 @@
+package coffeeshout.speedtouch.ui.response;
+
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent.PlayerProgress;
+import java.util.List;
+
+public record SpeedTouchProgressResponse(List<PlayerProgress> players) {
+
+    public static SpeedTouchProgressResponse from(SpeedTouchProgressEvent event) {
+        return new SpeedTouchProgressResponse(event.players());
+    }
+}

--- a/backend/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchStateResponse.java
+++ b/backend/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchStateResponse.java
@@ -1,0 +1,4 @@
+package coffeeshout.speedtouch.ui.response;
+
+public record SpeedTouchStateResponse(String state) {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,6 +54,8 @@ redis:
         thread-pool-name: concurrent
       "[racinggame]":
         thread-pool-name: concurrent
+      "[speedtouch]":
+        thread-pool-name: concurrent
 
 redisson:
   enabled: true
@@ -77,6 +79,12 @@ card-game:
     playing: 10250ms
     score-board: 1500ms
     early-finish-delay: 2000ms
+
+speed-touch:
+  timing:
+    description: 4000ms
+    prepare: 2000ms
+    playing: 30000ms
 
 room:
   removalDelay: 1h

--- a/backend/src/test/java/coffeeshout/global/config/IntegrationTestConfig.java
+++ b/backend/src/test/java/coffeeshout/global/config/IntegrationTestConfig.java
@@ -33,4 +33,9 @@ public class IntegrationTestConfig {
     public TaskScheduler testIntegrationRacingGameScheduler() {
         return new ShutDownTestScheduler();
     }
+
+    @Bean(name = "speedTouchGameScheduler")
+    public TaskScheduler testIntegrationSpeedTouchGameScheduler() {
+        return new ShutDownTestScheduler();
+    }
 }

--- a/backend/src/test/java/coffeeshout/global/config/ServiceTestConfig.java
+++ b/backend/src/test/java/coffeeshout/global/config/ServiceTestConfig.java
@@ -30,6 +30,11 @@ public class ServiceTestConfig {
         return new TestTaskScheduler();
     }
 
+    @Bean(name = "speedTouchGameScheduler")
+    public TaskScheduler testSpeedTouchGameScheduler() {
+        return new TestTaskScheduler();
+    }
+
     @Bean
     @Primary
     public SimpMessagingTemplate mockMessagingTemplate() {

--- a/backend/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
+++ b/backend/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
@@ -99,6 +99,11 @@ class OutboxE2ETest {
             return new coffeeshout.global.config.ShutDownTestScheduler();
         }
 
+        @Bean(name = "speedTouchGameScheduler")
+        public TaskScheduler speedTouchGameScheduler() {
+            return new coffeeshout.global.config.ShutDownTestScheduler();
+        }
+
         /**
          * 기본 taskScheduler를 no-op으로 덮어써서 @Scheduled 메서드 실행을 막는다.
          * OutboxRelayWorker의 relay(), recoverStaleEvents(), cleanup()이

--- a/backend/src/test/java/coffeeshout/speedtouch/application/SpeedTouchGameProgressHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/application/SpeedTouchGameProgressHandlerTest.java
@@ -1,0 +1,91 @@
+package coffeeshout.speedtouch.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.fixture.RoomFixture;
+import coffeeshout.global.ServiceTest;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.SpeedTouchGameState;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SpeedTouchGameProgressHandlerTest extends ServiceTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private SpeedTouchGameProgressHandler progressHandler;
+
+    private static final String HOST_NAME = "꾹이";
+
+    private Room room;
+    private SpeedTouchGame game;
+    private String joinCode;
+
+    @BeforeEach
+    void setUp() {
+        room = RoomFixture.호스트_꾹이();
+        room.getPlayers().forEach(player -> player.updateReadyState(true));
+        roomRepository.save(room);
+        game = new SpeedTouchGame();
+        room.addMiniGame(new PlayerName(HOST_NAME), game);
+        room.startNextGame(HOST_NAME);
+        joinCode = room.getJoinCode().getValue();
+
+        // TestTaskScheduler를 우회하여 직접 PLAYING 상태로 세팅
+        game.setUp(room.getPlayers());
+        game.startPlaying();
+    }
+
+    @Nested
+    class 터치_처리 {
+
+        @Test
+        void 올바른_번호를_터치하면_진행도_이벤트가_발행된다() {
+            // when
+            progressHandler.handleTouch(joinCode, "꾹이", 1);
+
+            // then
+            verify(eventPublisher, atLeastOnce()).publishEvent(any(SpeedTouchProgressEvent.class));
+        }
+
+        @Test
+        void 잘못된_번호를_터치하면_진행도가_변하지_않는다() {
+            // when
+            progressHandler.handleTouch(joinCode, "꾹이", 10);
+
+            // then
+            final var player = game.findPlayer(new PlayerName("꾹이"));
+            assertThat(player.getCurrentNumber()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    class 전원_완주_시_게임_종료 {
+
+        @Test
+        void 모든_플레이어가_완주하면_게임이_종료된다() {
+            // given
+            for (var player : room.getPlayers()) {
+                final String name = player.getName().value();
+                for (int i = 1; i <= 25; i++) {
+                    progressHandler.handleTouch(joinCode, name, i);
+                }
+            }
+
+            // then
+            assertThat(game.getState()).isEqualTo(SpeedTouchGameState.DONE);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/application/SpeedTouchGameServiceTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/application/SpeedTouchGameServiceTest.java
@@ -1,0 +1,63 @@
+package coffeeshout.speedtouch.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import coffeeshout.fixture.RoomFixture;
+import coffeeshout.global.ServiceTest;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import coffeeshout.speedtouch.domain.SpeedTouchGameState;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SpeedTouchGameServiceTest extends ServiceTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private SpeedTouchGameService speedTouchGameService;
+
+    private static final String HOST_NAME = "꾹이";
+
+    private Room room;
+    private SpeedTouchGame game;
+
+    @BeforeEach
+    void setUp() {
+        room = RoomFixture.호스트_꾹이();
+        room.getPlayers().forEach(player -> player.updateReadyState(true));
+        roomRepository.save(room);
+        game = new SpeedTouchGame();
+    }
+
+    @Test
+    void 스피드터치_게임을_시작하면_타임아웃으로_DONE까지_전환된다() {
+        // given
+        room.addMiniGame(new PlayerName(HOST_NAME), game);
+        room.startNextGame(HOST_NAME);
+
+        // when - TestTaskScheduler는 모든 schedule을 즉시 실행하므로
+        // DESCRIPTION → PREPARE → PLAYING → timeout → DONE까지 한번에 진행됨
+        speedTouchGameService.start(room.getJoinCode().getValue(), HOST_NAME);
+
+        // then - 비동기 스케줄러가 상태 전이를 완료할 때까지 대기
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> {
+                    assertThat(game.getState()).isEqualTo(SpeedTouchGameState.DONE);
+                    assertThat(game.getStartTime()).isNotNull();
+                });
+    }
+
+    @Test
+    void getMiniGameType은_SPEED_TOUCH를_반환한다() {
+        // when & then
+        assertThat(speedTouchGameService.getMiniGameType()).isEqualTo(MiniGameType.SPEED_TOUCH);
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
@@ -6,13 +6,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import coffeeshout.fixture.PlayerFixture;
 import coffeeshout.global.exception.custom.InvalidStateException;
 import coffeeshout.minigame.domain.MiniGameResult;
-import coffeeshout.minigame.domain.MiniGameScore;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,8 +46,6 @@ class SpeedTouchGameTest {
 
         @Test
         void startPlaying_호출시_PLAYING_상태가_된다() {
-            // given - setUp에서 이미 startPlaying 호출됨
-
             // when & then
             assertThat(game.isPlaying()).isTrue();
             assertThat(game.getStartTime()).isNotNull();
@@ -72,14 +68,14 @@ class SpeedTouchGameTest {
             newGame.setUp(List.of(한스));
 
             // when & then
-            assertThatThrownBy(() -> newGame.touch(new PlayerName("한스"), 1, Instant.now()))
+            assertThatThrownBy(() -> newGame.touch(new PlayerName("한스"), SpeedTouchPlayer.FIRST_NUMBER, Instant.now()))
                     .isInstanceOf(InvalidStateException.class);
         }
 
         @Test
         void 올바른_번호_터치시_true를_반환한다() {
             // when
-            final boolean result = game.touch(new PlayerName("한스"), 1, Instant.now());
+            final boolean result = game.touch(new PlayerName("한스"), SpeedTouchPlayer.FIRST_NUMBER, Instant.now());
 
             // then
             assertThat(result).isTrue();
@@ -126,8 +122,9 @@ class SpeedTouchGameTest {
         @Test
         void 완주자는_소요시간이_짧은_순서대로_높은_순위를_받는다() {
             // given
-            final Instant time1 = Instant.parse("2025-01-01T00:00:10Z");
-            final Instant time2 = Instant.parse("2025-01-01T00:00:20Z");
+            final Instant startTime = game.getStartTime();
+            final Instant time1 = startTime.plusSeconds(10);
+            final Instant time2 = startTime.plusSeconds(20);
 
             finishPlayerAt("한스", time1);
             finishPlayerAt("꾹이", time2);
@@ -161,10 +158,10 @@ class SpeedTouchGameTest {
         @Test
         void 완주자는_항상_DNF보다_높은_순위를_받는다() {
             // given
-            final Instant finishTime = Instant.parse("2025-01-01T00:00:29Z");
+            final Instant finishTime = game.getStartTime().plusSeconds(29);
             finishPlayerAt("한스", finishTime); // 29초 완주
-            touchUpTo("꾹이", 24); // 24/25 DNF
-            touchUpTo("루키", 1); // 1/25 DNF
+            touchUpTo("꾹이", SpeedTouchPlayer.LAST_NUMBER - 1); // 24/25 DNF
+            touchUpTo("루키", SpeedTouchPlayer.FIRST_NUMBER); // 1/25 DNF
 
             // when
             final MiniGameResult result = game.getResult();
@@ -176,22 +173,41 @@ class SpeedTouchGameTest {
         }
     }
 
+    @Nested
+    class 종료_원자성 {
+
+        @Test
+        void tryFinish는_처음_호출시_true를_반환한다() {
+            // when & then
+            assertThat(game.tryFinish()).isTrue();
+        }
+
+        @Test
+        void tryFinish는_두번째_호출부터_false를_반환한다() {
+            // given
+            game.tryFinish();
+
+            // when & then
+            assertThat(game.tryFinish()).isFalse();
+        }
+    }
+
     private void finishPlayer(String name) {
         final Instant now = Instant.now();
-        for (int i = 1; i <= 25; i++) {
+        for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
             game.touch(new PlayerName(name), i, now);
         }
     }
 
     private void finishPlayerAt(String name, Instant finishTime) {
-        for (int i = 1; i <= 25; i++) {
+        for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
             game.touch(new PlayerName(name), i, finishTime);
         }
     }
 
     private void touchUpTo(String name, int upTo) {
         final Instant now = Instant.now();
-        for (int i = 1; i <= upTo; i++) {
+        for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= upTo; i++) {
             game.touch(new PlayerName(name), i, now);
         }
     }

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
@@ -1,0 +1,198 @@
+package coffeeshout.speedtouch.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coffeeshout.fixture.PlayerFixture;
+import coffeeshout.global.exception.custom.InvalidStateException;
+import coffeeshout.minigame.domain.MiniGameResult;
+import coffeeshout.minigame.domain.MiniGameScore;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SpeedTouchGameTest {
+
+    private SpeedTouchGame game;
+    private Player 한스;
+    private Player 꾹이;
+    private Player 루키;
+
+    @BeforeEach
+    void setUp() {
+        game = new SpeedTouchGame();
+        한스 = PlayerFixture.게스트한스();
+        꾹이 = PlayerFixture.게스트꾹이();
+        루키 = PlayerFixture.게스트루키();
+        game.setUp(List.of(한스, 꾹이, 루키));
+        game.startPlaying();
+    }
+
+    @Nested
+    class 게임_상태 {
+
+        @Test
+        void 초기_상태는_DESCRIPTION이다() {
+            // given
+            final SpeedTouchGame newGame = new SpeedTouchGame();
+
+            // when & then
+            assertThat(newGame.getState()).isEqualTo(SpeedTouchGameState.DESCRIPTION);
+        }
+
+        @Test
+        void startPlaying_호출시_PLAYING_상태가_된다() {
+            // given - setUp에서 이미 startPlaying 호출됨
+
+            // when & then
+            assertThat(game.isPlaying()).isTrue();
+            assertThat(game.getStartTime()).isNotNull();
+        }
+
+        @Test
+        void getMiniGameType은_SPEED_TOUCH를_반환한다() {
+            // when & then
+            assertThat(game.getMiniGameType()).isEqualTo(MiniGameType.SPEED_TOUCH);
+        }
+    }
+
+    @Nested
+    class 터치_처리 {
+
+        @Test
+        void PLAYING_상태가_아니면_터치시_예외가_발생한다() {
+            // given
+            final SpeedTouchGame newGame = new SpeedTouchGame();
+            newGame.setUp(List.of(한스));
+
+            // when & then
+            assertThatThrownBy(() -> newGame.touch(new PlayerName("한스"), 1, Instant.now()))
+                    .isInstanceOf(InvalidStateException.class);
+        }
+
+        @Test
+        void 올바른_번호_터치시_true를_반환한다() {
+            // when
+            final boolean result = game.touch(new PlayerName("한스"), 1, Instant.now());
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void 잘못된_번호_터치시_false를_반환한다() {
+            // when
+            final boolean result = game.touch(new PlayerName("한스"), 5, Instant.now());
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class 전원_완주_판정 {
+
+        @Test
+        void 한명이라도_완주하지_않으면_false이다() {
+            // given
+            finishPlayer("한스");
+            finishPlayer("꾹이");
+
+            // when & then
+            assertThat(game.isAllFinished()).isFalse();
+        }
+
+        @Test
+        void 전원_완주하면_true이다() {
+            // given
+            finishPlayer("한스");
+            finishPlayer("꾹이");
+            finishPlayer("루키");
+
+            // when & then
+            assertThat(game.isAllFinished()).isTrue();
+        }
+    }
+
+    @Nested
+    class 랭킹_산정 {
+
+        @Test
+        void 완주자는_소요시간이_짧은_순서대로_높은_순위를_받는다() {
+            // given
+            final Instant time1 = Instant.parse("2025-01-01T00:00:10Z");
+            final Instant time2 = Instant.parse("2025-01-01T00:00:20Z");
+
+            finishPlayerAt("한스", time1);
+            finishPlayerAt("꾹이", time2);
+            // 루키는 DNF
+
+            // when
+            final MiniGameResult result = game.getResult();
+
+            // then - 한스(10초) > 꾹이(20초) > 루키(DNF)
+            assertThat(result.getPlayerRank(한스)).isEqualTo(1);
+            assertThat(result.getPlayerRank(꾹이)).isEqualTo(2);
+            assertThat(result.getPlayerRank(루키)).isEqualTo(3);
+        }
+
+        @Test
+        void DNF끼리는_진행도가_높은_사람이_더_높은_순위를_받는다() {
+            // given - 전원 DNF, 진행도만 다름
+            touchUpTo("한스", 20);
+            touchUpTo("꾹이", 10);
+            touchUpTo("루키", 5);
+
+            // when
+            final MiniGameResult result = game.getResult();
+
+            // then
+            assertThat(result.getPlayerRank(한스)).isEqualTo(1);
+            assertThat(result.getPlayerRank(꾹이)).isEqualTo(2);
+            assertThat(result.getPlayerRank(루키)).isEqualTo(3);
+        }
+
+        @Test
+        void 완주자는_항상_DNF보다_높은_순위를_받는다() {
+            // given
+            final Instant finishTime = Instant.parse("2025-01-01T00:00:29Z");
+            finishPlayerAt("한스", finishTime); // 29초 완주
+            touchUpTo("꾹이", 24); // 24/25 DNF
+            touchUpTo("루키", 1); // 1/25 DNF
+
+            // when
+            final MiniGameResult result = game.getResult();
+
+            // then
+            assertThat(result.getPlayerRank(한스)).isEqualTo(1);
+            assertThat(result.getPlayerRank(꾹이)).isEqualTo(2);
+            assertThat(result.getPlayerRank(루키)).isEqualTo(3);
+        }
+    }
+
+    private void finishPlayer(String name) {
+        final Instant now = Instant.now();
+        for (int i = 1; i <= 25; i++) {
+            game.touch(new PlayerName(name), i, now);
+        }
+    }
+
+    private void finishPlayerAt(String name, Instant finishTime) {
+        for (int i = 1; i <= 25; i++) {
+            game.touch(new PlayerName(name), i, finishTime);
+        }
+    }
+
+    private void touchUpTo(String name, int upTo) {
+        final Instant now = Instant.now();
+        for (int i = 1; i <= upTo; i++) {
+            game.touch(new PlayerName(name), i, now);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchGameTest.java
@@ -177,9 +177,13 @@ class SpeedTouchGameTest {
     class 종료_원자성 {
 
         @Test
-        void tryFinish는_처음_호출시_true를_반환한다() {
-            // when & then
-            assertThat(game.tryFinish()).isTrue();
+        void tryFinish는_처음_호출시_true를_반환하고_DONE_상태가_된다() {
+            // when
+            final boolean result = game.tryFinish();
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(game.getState()).isEqualTo(SpeedTouchGameState.DONE);
         }
 
         @Test

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayerTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayerTest.java
@@ -19,11 +19,11 @@ class SpeedTouchPlayerTest {
             final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
 
             // when
-            final boolean result = player.touch(1, Instant.now());
+            final boolean result = player.touch(SpeedTouchPlayer.FIRST_NUMBER, Instant.now());
 
             // then
             assertThat(result).isTrue();
-            assertThat(player.getCurrentNumber()).isEqualTo(2);
+            assertThat(player.getCurrentNumber()).isEqualTo(SpeedTouchPlayer.FIRST_NUMBER + 1);
         }
 
         @Test
@@ -36,17 +36,17 @@ class SpeedTouchPlayerTest {
 
             // then
             assertThat(result).isFalse();
-            assertThat(player.getCurrentNumber()).isEqualTo(1);
+            assertThat(player.getCurrentNumber()).isEqualTo(SpeedTouchPlayer.FIRST_NUMBER);
         }
 
         @Test
-        void 순서대로_1부터_25까지_터치하면_완주한다() {
+        void 순서대로_처음부터_끝까지_터치하면_완주한다() {
             // given
             final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
             final Instant now = Instant.now();
 
             // when
-            for (int i = 1; i <= 25; i++) {
+            for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
                 player.touch(i, now);
             }
 
@@ -60,12 +60,12 @@ class SpeedTouchPlayerTest {
             // given
             final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
             final Instant now = Instant.now();
-            for (int i = 1; i <= 25; i++) {
+            for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
                 player.touch(i, now);
             }
 
             // when
-            final boolean result = player.touch(25, now);
+            final boolean result = player.touch(SpeedTouchPlayer.LAST_NUMBER, now);
 
             // then
             assertThat(result).isFalse();
@@ -89,7 +89,7 @@ class SpeedTouchPlayerTest {
             // given
             final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
             final Instant now = Instant.now();
-            for (int i = 1; i <= 5; i++) {
+            for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= 5; i++) {
                 player.touch(i, now);
             }
 
@@ -107,7 +107,7 @@ class SpeedTouchPlayerTest {
             final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
             final Instant startTime = Instant.parse("2025-01-01T00:00:00Z");
             final Instant finishTime = Instant.parse("2025-01-01T00:00:15.500Z");
-            for (int i = 1; i <= 25; i++) {
+            for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
                 player.touch(i, finishTime);
             }
 

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayerTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayerTest.java
@@ -1,0 +1,132 @@
+package coffeeshout.speedtouch.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coffeeshout.fixture.PlayerFixture;
+import java.time.Instant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SpeedTouchPlayerTest {
+
+    @Nested
+    class 터치_처리 {
+
+        @Test
+        void 올바른_번호를_터치하면_true를_반환한다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+
+            // when
+            final boolean result = player.touch(1, Instant.now());
+
+            // then
+            assertThat(result).isTrue();
+            assertThat(player.getCurrentNumber()).isEqualTo(2);
+        }
+
+        @Test
+        void 잘못된_번호를_터치하면_false를_반환한다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+
+            // when
+            final boolean result = player.touch(3, Instant.now());
+
+            // then
+            assertThat(result).isFalse();
+            assertThat(player.getCurrentNumber()).isEqualTo(1);
+        }
+
+        @Test
+        void 순서대로_1부터_25까지_터치하면_완주한다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+            final Instant now = Instant.now();
+
+            // when
+            for (int i = 1; i <= 25; i++) {
+                player.touch(i, now);
+            }
+
+            // then
+            assertThat(player.isFinished()).isTrue();
+            assertThat(player.getFinishTime()).isNotNull();
+        }
+
+        @Test
+        void 완주_후_추가_터치는_무시된다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+            final Instant now = Instant.now();
+            for (int i = 1; i <= 25; i++) {
+                player.touch(i, now);
+            }
+
+            // when
+            final boolean result = player.touch(25, now);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class 진행도 {
+
+        @Test
+        void 초기_진행도는_0이다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+
+            // when & then
+            assertThat(player.getProgress()).isEqualTo(0);
+        }
+
+        @Test
+        void 다섯번까지_터치하면_진행도는_5이다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+            final Instant now = Instant.now();
+            for (int i = 1; i <= 5; i++) {
+                player.touch(i, now);
+            }
+
+            // when & then
+            assertThat(player.getProgress()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    class 완주시간_계산 {
+
+        @Test
+        void 완주한_플레이어의_소요시간을_밀리초로_계산한다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+            final Instant startTime = Instant.parse("2025-01-01T00:00:00Z");
+            final Instant finishTime = Instant.parse("2025-01-01T00:00:15.500Z");
+            for (int i = 1; i <= 25; i++) {
+                player.touch(i, finishTime);
+            }
+
+            // when
+            final long millis = player.calculateFinishMillis(startTime);
+
+            // then
+            assertThat(millis).isEqualTo(15500L);
+        }
+
+        @Test
+        void 완주하지_않은_플레이어의_소요시간_계산은_예외가_발생한다() {
+            // given
+            final SpeedTouchPlayer player = new SpeedTouchPlayer(PlayerFixture.게스트한스());
+            final Instant startTime = Instant.now();
+
+            // when & then
+            assertThatThrownBy(() -> player.calculateFinishMillis(startTime))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayersTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayersTest.java
@@ -1,0 +1,108 @@
+package coffeeshout.speedtouch.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coffeeshout.fixture.PlayerFixture;
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SpeedTouchPlayersTest {
+
+    private Player 한스;
+    private Player 꾹이;
+    private SpeedTouchPlayers players;
+
+    @BeforeEach
+    void setUp() {
+        한스 = PlayerFixture.게스트한스();
+        꾹이 = PlayerFixture.게스트꾹이();
+        players = new SpeedTouchPlayers(List.of(한스, 꾹이));
+    }
+
+    @Nested
+    class 플레이어_조회 {
+
+        @Test
+        void 이름으로_플레이어를_찾을_수_있다() {
+            // when
+            final SpeedTouchPlayer found = players.findByName(new PlayerName("한스"));
+
+            // then
+            assertThat(found.getPlayer()).isEqualTo(한스);
+        }
+
+        @Test
+        void 존재하지_않는_이름으로_조회하면_예외가_발생한다() {
+            // when & then
+            assertThatThrownBy(() -> players.findByName(new PlayerName("없는사람")))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    class 전원_완주_판정 {
+
+        @Test
+        void 아무도_완주하지_않으면_false를_반환한다() {
+            // when & then
+            assertThat(players.isAllFinished()).isFalse();
+        }
+
+        @Test
+        void 일부만_완주하면_false를_반환한다() {
+            // given
+            final SpeedTouchPlayer 한스플레이어 = players.findByName(new PlayerName("한스"));
+            final Instant now = Instant.now();
+            for (int i = 1; i <= 25; i++) {
+                한스플레이어.touch(i, now);
+            }
+
+            // when & then
+            assertThat(players.isAllFinished()).isFalse();
+        }
+
+        @Test
+        void 전원_완주하면_true를_반환한다() {
+            // given
+            final Instant now = Instant.now();
+            for (SpeedTouchPlayer player : players.getPlayers()) {
+                for (int i = 1; i <= 25; i++) {
+                    player.touch(i, now);
+                }
+            }
+
+            // when & then
+            assertThat(players.isAllFinished()).isTrue();
+        }
+    }
+
+    @Nested
+    class 스트림_및_맵_변환 {
+
+        @Test
+        void stream으로_모든_플레이어를_순회할_수_있다() {
+            // when
+            final long count = players.stream().count();
+
+            // then
+            assertThat(count).isEqualTo(2);
+        }
+
+        @Test
+        void toPlayerMap으로_Player_키_맵을_생성할_수_있다() {
+            // when
+            final var map = players.toPlayerMap();
+
+            // then
+            assertThat(map).hasSize(2);
+            assertThat(map).containsKey(한스);
+            assertThat(map).containsKey(꾹이);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayersTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchPlayersTest.java
@@ -59,7 +59,7 @@ class SpeedTouchPlayersTest {
             // given
             final SpeedTouchPlayer 한스플레이어 = players.findByName(new PlayerName("한스"));
             final Instant now = Instant.now();
-            for (int i = 1; i <= 25; i++) {
+            for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
                 한스플레이어.touch(i, now);
             }
 
@@ -72,7 +72,7 @@ class SpeedTouchPlayersTest {
             // given
             final Instant now = Instant.now();
             for (SpeedTouchPlayer player : players.getPlayers()) {
-                for (int i = 1; i <= 25; i++) {
+                for (int i = SpeedTouchPlayer.FIRST_NUMBER; i <= SpeedTouchPlayer.LAST_NUMBER; i++) {
                     player.touch(i, now);
                 }
             }

--- a/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchScoreTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/domain/SpeedTouchScoreTest.java
@@ -1,0 +1,65 @@
+package coffeeshout.speedtouch.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SpeedTouchScoreTest {
+
+    @Nested
+    class 완주자_점수 {
+
+        @Test
+        void 완주_시간이_짧을수록_값이_작다() {
+            // given
+            final SpeedTouchScore fast = SpeedTouchScore.ofFinished(5000L);
+            final SpeedTouchScore slow = SpeedTouchScore.ofFinished(15000L);
+
+            // when & then
+            assertThat(fast.getValue()).isLessThan(slow.getValue());
+        }
+    }
+
+    @Nested
+    class DNF_점수 {
+
+        @Test
+        void 진행도가_높을수록_값이_작다() {
+            // given
+            final SpeedTouchScore moreProgress = SpeedTouchScore.ofDnf(20);
+            final SpeedTouchScore lessProgress = SpeedTouchScore.ofDnf(10);
+
+            // when & then
+            assertThat(moreProgress.getValue()).isLessThan(lessProgress.getValue());
+        }
+    }
+
+    @Nested
+    class 완주자_vs_DNF {
+
+        @Test
+        void 완주자는_항상_DNF보다_값이_작다() {
+            // given - 가장 느린 완주자 (30초 = 30000ms)
+            final SpeedTouchScore slowestFinisher = SpeedTouchScore.ofFinished(30000L);
+            // given - 가장 많이 진행한 DNF (24/25)
+            final SpeedTouchScore bestDnf = SpeedTouchScore.ofDnf(24);
+
+            // when & then
+            assertThat(slowestFinisher.getValue()).isLessThan(bestDnf.getValue());
+        }
+
+        @Test
+        void fromAscending으로_정렬하면_완주자가_앞에_온다() {
+            // given
+            final SpeedTouchScore finisher = SpeedTouchScore.ofFinished(25000L);
+            final SpeedTouchScore dnf = SpeedTouchScore.ofDnf(24);
+
+            // when - compareTo 기준 오름차순
+            final int comparison = finisher.compareTo(dnf);
+
+            // then
+            assertThat(comparison).isLessThan(0);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
@@ -1,0 +1,173 @@
+package coffeeshout.speedtouch.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import coffeeshout.fixture.RoomFixture;
+import coffeeshout.fixture.TestStompSession;
+import coffeeshout.fixture.WebSocketIntegrationTestSupport;
+import coffeeshout.global.MessageResponse;
+import coffeeshout.room.domain.JoinCode;
+import coffeeshout.room.domain.Room;
+import coffeeshout.room.domain.player.Player;
+import coffeeshout.room.domain.player.PlayerName;
+import coffeeshout.room.domain.repository.RoomRepository;
+import coffeeshout.speedtouch.domain.SpeedTouchGame;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SpeedTouchGameIntegrationTest extends WebSocketIntegrationTestSupport {
+
+    JoinCode joinCode;
+    Player host;
+    TestStompSession session;
+    Room room;
+    SpeedTouchGame game;
+
+    @BeforeEach
+    void setUp(@Autowired RoomRepository roomRepository) throws Exception {
+        joinCode = new JoinCode("A4BX");
+        room = RoomFixture.호스트_꾹이();
+        room.getPlayers().forEach(player -> player.updateReadyState(true));
+        host = room.getHost();
+        game = new SpeedTouchGame();
+        room.addMiniGame(new PlayerName(host.getName().value()), game);
+        roomRepository.save(room);
+        session = createSession();
+    }
+
+    @Test
+    void 스피드터치_게임을_시작하면_상태_변경_메시지가_전송된다() {
+        // given
+        final String joinCodeValue = joinCode.getValue();
+        final String subscribeStateUrl = String.format("/topic/room/%s/speed-touch/state", joinCodeValue);
+        final String subscribeProgressUrl = String.format("/topic/room/%s/speed-touch/progress", joinCodeValue);
+        final String requestUrl = String.format("/app/room/%s/minigame/command", joinCodeValue);
+
+        var stateResponses = session.subscribe(subscribeStateUrl);
+        var progressResponses = session.subscribe(subscribeProgressUrl);
+
+        // when
+        session.send(requestUrl, String.format("""
+                {
+                  "commandRequest": {
+                    "hostName": "%s"
+                  },
+                  "commandType": "START_MINI_GAME"
+                }
+                """, host.getName().value()));
+
+        // then - DESCRIPTION 상태
+        MessageResponse descriptionState = stateResponses.get(2, TimeUnit.SECONDS);
+        assertMessageContains(descriptionState, "\"state\":\"DESCRIPTION\"");
+        assertMessageContains(descriptionState, "\"success\":true");
+
+        // PREPARE 상태
+        MessageResponse prepareState = stateResponses.get(6, TimeUnit.SECONDS);
+        assertMessageContains(prepareState, "\"state\":\"PREPARE\"");
+
+        // PLAYING 상태
+        MessageResponse playingState = stateResponses.get(4, TimeUnit.SECONDS);
+        assertMessageContains(playingState, "\"state\":\"PLAYING\"");
+    }
+
+    @Test
+    void 터치하면_진행도_브로드캐스트_메시지가_전송된다() {
+        // given
+        final String joinCodeValue = joinCode.getValue();
+        final String subscribeStateUrl = String.format("/topic/room/%s/speed-touch/state", joinCodeValue);
+        final String subscribeProgressUrl = String.format("/topic/room/%s/speed-touch/progress", joinCodeValue);
+        final String startUrl = String.format("/app/room/%s/minigame/command", joinCodeValue);
+        final String touchUrl = String.format("/app/room/%s/speed-touch/touch", joinCodeValue);
+
+        var stateResponses = session.subscribe(subscribeStateUrl);
+        var progressResponses = session.subscribe(subscribeProgressUrl);
+
+        // 게임 시작
+        session.send(startUrl, String.format("""
+                {
+                  "commandRequest": {
+                    "hostName": "%s"
+                  },
+                  "commandType": "START_MINI_GAME"
+                }
+                """, host.getName().value()));
+
+        stateResponses.get(2, TimeUnit.SECONDS); // DESCRIPTION
+        stateResponses.get(6, TimeUnit.SECONDS); // PREPARE
+        progressResponses.get(6, TimeUnit.SECONDS); // PREPARE 시 초기 progress
+        stateResponses.get(4, TimeUnit.SECONDS); // PLAYING
+
+        // when - 터치
+        session.send(touchUrl, String.format("""
+                {
+                  "playerName": "%s",
+                  "touchedNumber": 1
+                }
+                """, host.getName().value()));
+
+        // then - 진행도 응답 (blocking get으로 메시지 도착까지 대기)
+        MessageResponse progressUpdate = progressResponses.get(3, TimeUnit.SECONDS);
+        assertMessageContains(progressUpdate, "\"success\":true");
+        assertMessageContains(progressUpdate, "\"players\"");
+    }
+
+    @Test
+    void 전원_완주하면_DONE_상태가_전송된다() {
+        // given
+        final String joinCodeValue = joinCode.getValue();
+        final String subscribeStateUrl = String.format("/topic/room/%s/speed-touch/state", joinCodeValue);
+        final String subscribeProgressUrl = String.format("/topic/room/%s/speed-touch/progress", joinCodeValue);
+        final String startUrl = String.format("/app/room/%s/minigame/command", joinCodeValue);
+        final String touchUrl = String.format("/app/room/%s/speed-touch/touch", joinCodeValue);
+
+        var stateResponses = session.subscribe(subscribeStateUrl);
+        var progressResponses = session.subscribe(subscribeProgressUrl);
+
+        // 게임 시작 후 PLAYING 까지 대기
+        session.send(startUrl, String.format("""
+                {
+                  "commandRequest": {
+                    "hostName": "%s"
+                  },
+                  "commandType": "START_MINI_GAME"
+                }
+                """, host.getName().value()));
+
+        stateResponses.get(2, TimeUnit.SECONDS); // DESCRIPTION
+        stateResponses.get(6, TimeUnit.SECONDS); // PREPARE
+        progressResponses.get(6, TimeUnit.SECONDS); // initial progress
+        stateResponses.get(4, TimeUnit.SECONDS); // PLAYING
+
+        // when - 모든 플레이어 1~25 터치
+        // 각 플레이어별로 1~25를 순차 전송하되, 이전 터치 처리 완료를 Awaitility로 확인
+        for (Player player : room.getPlayers()) {
+            final String playerName = player.getName().value();
+            for (int i = 1; i <= 25; i++) {
+                final int expectedNext = i + 1;
+                session.send(touchUrl, String.format("""
+                        {
+                          "playerName": "%s",
+                          "touchedNumber": %d
+                        }
+                        """, playerName, i));
+
+                // 게임 도메인 객체의 currentNumber가 갱신될 때까지 대기
+                await().atMost(Duration.ofSeconds(5))
+                        .pollInterval(Duration.ofMillis(50))
+                        .untilAsserted(() ->
+                                assertThat(game.findPlayer(new PlayerName(playerName)).getCurrentNumber())
+                                        .isGreaterThanOrEqualTo(expectedNext)
+                        );
+            }
+        }
+
+        // then - DONE 상태 확인
+        MessageResponse doneState = stateResponses.get(10, TimeUnit.SECONDS);
+        assertMessageContains(doneState, "\"state\":\"DONE\"");
+        assertMessageContains(doneState, "\"success\":true");
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -77,3 +77,9 @@ card-game:
     playing: 2000ms
     score-board: 500ms
     early-finish-delay: 500ms
+
+speed-touch:
+  timing:
+    description: 500ms
+    prepare: 500ms
+    playing: 30000ms


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1110

# 🚀 작업 내용 (제가 하고 싶은 게임을 추가했어요)

## 개요

커피 내기 룰렛 확률에 영향을 주는 세 번째 미니게임 "1 to 25 스피드 터치"를 추가합니다.

## 게임 규칙

- 5×5 그리드에서 1부터 25까지 순서대로 터치
- 제한 시간 30초 내 전원 완주 또는 타임아웃 시 게임 종료
- 랭킹: 완주자(소요시간 오름차순) > DNF(진행도 내림차순)

## 주요 변경

- `speedtouch` 패키지 신규 생성 (domain / application / ui / infra / config)
- `Playable`, `MiniGameService`, `MiniGameScore` 기존 인터페이스 구현
- Redis Stream(`speedtouch` key) 통한 터치 이벤트 비동기 처리
- WebSocket STOMP 브로드캐스트로 실시간 진행도 중계
- `MiniGameType.SPEED_TOUCH`, `StreamKey.SPEED_TOUCH_EVENTS` 추가

## 파일 구성

- 변경 7 / 신규 27 (소스 19 + 테스트 7 + 설정 1)

## 테스트

- domain 단위 테스트 20개
- application 서비스 테스트 5개
- WebSocket Integration 테스트 3개
- `Thread.sleep` 제거, Awaitility 기반 비동기 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
* Speed Touch 미니게임 추가: 1~25 순차 터치 기반 실시간 경기, 점수·랭킹 산출 및 상태 전환 지원.

## 실시간/통신
* 게임 상태·진행을 WebSocket으로 실시간 전송 및 Redis 스트림 기반 이벤트 발행/구독 추가.

## 입력/유효성
* 터치 명령 서버측 검증(이름/번호) 및 이벤트화된 처리 흐름 도입.

## 테스트
* 단위·통합 테스트 및 테스트용 스케줄러 보강.

## 기타
* 게임 타이밍 설정 바인딩 및 런타임 검증, 빌드용 테스트 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->