### PR TITLE
[fix] 미니게임 선택 화면 스크롤 불가 문제 수정

### DIFF
--- a/frontend/src/features/room/lobby/pages/LobbyPage.styled.ts
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.styled.ts
@@ -5,11 +5,13 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow-y: auto;
+  padding-bottom: 4rem;
 `;
 
 export const Wrapper = styled.div`
-  position: absolute;
+  position: sticky;
   bottom: 1rem;
-  left: 2rem;
-  right: 2rem;
+  margin: 0 2rem;
+  z-index: 1;
 `;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1121

# 🚀 작업 내용
## 개요
미니게임이 4개로 늘어나면서 미니게임 선택 화면에서 하단 게임 카드가 잘리고 스크롤이 되지 않는 문제를 수정합니다.

## 원인
- `LobbyPage.styled.ts`의 `Container`에 `overflow-y` 설정이 없어서 콘텐츠가 넘쳐도 스크롤 불가
- 하단 `ToggleButton`이 `position: absolute`로 잡혀 있어서 스크롤 시 같이 올라감

## 수정 내용 (`LobbyPage.styled.ts`)
- `Container`: `overflow-y: auto` 추가 + `padding-bottom: 4rem` (ToggleButton에 가려지는 영역 확보)
- `Wrapper`: `position: absolute` → `position: sticky; bottom: 1rem` (스크롤해도 하단 고정)

