### PR TITLE
[refactor] DelayedPlayerRemovalService 테스트 시간 외부 변수화

### DIFF
--- a/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/DelayedPlayerRemovalService.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +15,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class DelayedPlayerRemovalService {
 
-    private static final Duration REMOVAL_DELAY = Duration.ofSeconds(15);
-
     private final TaskScheduler taskScheduler;
+    private final Duration removalDelay;
     private final PlayerDisconnectionService playerDisconnectionService;
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduledTasks;
     private final RoomService roomService;
@@ -24,15 +24,24 @@ public class DelayedPlayerRemovalService {
 
     public DelayedPlayerRemovalService(
             @Qualifier("delayRemovalScheduler") TaskScheduler taskScheduler,
+            @Value("${player.removalDelay}") Duration removalDelay,
             PlayerDisconnectionService playerDisconnectionService,
             StompSessionManager stompSessionManager,
             RoomService roomService
     ) {
+        validateRemovalDuration(removalDelay);
         this.taskScheduler = taskScheduler;
+        this.removalDelay = removalDelay;
         this.playerDisconnectionService = playerDisconnectionService;
         this.scheduledTasks = new ConcurrentHashMap<>();
         this.roomService = roomService;
         this.stompSessionManager = stompSessionManager;
+    }
+
+    private void validateRemovalDuration(Duration removalDelay) {
+        if (removalDelay == null || removalDelay.isNegative() || removalDelay.isZero()) {
+            throw new IllegalArgumentException("지연 삭제 시간은 양수여야 합니다.");
+        }
     }
 
     public void schedulePlayerRemoval(String playerKey, String sessionId, String reason) {
@@ -42,7 +51,7 @@ public class DelayedPlayerRemovalService {
         }
 
         log.info("플레이어 지연 삭제 스케줄링: playerKey={}, sessionId={}, delay={}초",
-                playerKey, sessionId, REMOVAL_DELAY.getSeconds());
+                playerKey, sessionId, removalDelay.getSeconds());
 
         // disconnect 된 플레이어는 ready 상태 false로 변경
         playerDisconnectionService.cancelReady(playerKey);
@@ -53,7 +62,7 @@ public class DelayedPlayerRemovalService {
                     executePlayerRemoval(playerKey, sessionId, reason);
                     stompSessionManager.removeSession(sessionId);
                 },
-                Instant.now().plus(REMOVAL_DELAY)
+                Instant.now().plus(removalDelay)
         );
 
         scheduledTasks.put(playerKey, future);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -121,6 +121,9 @@ room:
   event:
     timeout: 5s
 
+player:
+  removalDelay: 15s
+
 logging:
   level:
     root: info

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceIntegrationTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.never;
 
 import coffeeshout.room.application.service.RoomService;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,6 +20,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  */
 @ExtendWith(MockitoExtension.class)
 class DelayedPlayerRemovalServiceIntegrationTest {
+
+    private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(500);
 
     @Mock
     private PlayerDisconnectionService playerDisconnectionService;
@@ -44,8 +45,8 @@ class DelayedPlayerRemovalServiceIntegrationTest {
         taskScheduler.initialize();
         stompSessionManager = new StompSessionManager();
 
-        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService,
-                stompSessionManager, roomService);
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, TEST_REMOVAL_DELAY,
+                playerDisconnectionService, stompSessionManager, roomService);
     }
 
     @Nested
@@ -59,9 +60,8 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             // when
             delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
 
-            // then - 15초 후 실행을 기다림 (테스트에서는 짧게 조정할 수 없어서 긴 시간이 필요)
-            // 실제 운영에서는 15초지만, 테스트에서는 적절한 시간으로 조정 필요
-            await().atMost(20, TimeUnit.SECONDS)
+            // then
+            await().atMost(Duration.ofSeconds(2))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
@@ -77,9 +77,9 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             // when - 즉시 취소
             delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
-            // then - 15초 기다려도 실행되지 않음
-            await().during(Duration.ofSeconds(2)) // 2초 동안 호출되지 않음을 확인
-                    .atMost(Duration.ofSeconds(3))
+            // then - 지연시간이 지나도 실행되지 않음
+            await().during(Duration.ofMillis(700))
+                    .atMost(Duration.ofSeconds(1))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should(never())
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
@@ -107,7 +107,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.schedulePlayerRemoval(player3, "session-3", reason);
 
             // then - 모든 플레이어가 독립적으로 처리됨
-            await().atMost(20, TimeUnit.SECONDS)
+            await().atMost(Duration.ofSeconds(2))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(player1, "session-1", reason);
@@ -131,7 +131,7 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.schedulePlayerRemoval(playerKey, sessionId, reason);
 
             // then - 실행 완료 후 PlayerDisconnectionService 호출됨을 확인
-            await().atMost(20, TimeUnit.SECONDS)
+            await().atMost(Duration.ofSeconds(2))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should()
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
@@ -148,30 +148,12 @@ class DelayedPlayerRemovalServiceIntegrationTest {
             delayedPlayerRemovalService.cancelScheduledRemoval(playerKey);
 
             // then - 취소 후 일정 시간이 지나도 호출되지 않음
-            await().during(Duration.ofSeconds(2))
-                    .atMost(Duration.ofSeconds(3))
+            await().during(Duration.ofMillis(700))
+                    .atMost(Duration.ofSeconds(1))
                     .untilAsserted(() -> {
                         then(playerDisconnectionService).should(never())
                                 .handlePlayerDisconnection(playerKey, sessionId, reason);
                     });
         }
-    }
-
-    /**
-     * 테스트용 DelayedPlayerRemovalService 실제 15초 대신 짧은 시간으로 테스트할 수 있도록 오버라이드
-     */
-    private static class TestDelayedPlayerRemovalService extends DelayedPlayerRemovalService {
-        private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(500); // 500ms로 단축
-
-        public TestDelayedPlayerRemovalService(ThreadPoolTaskScheduler taskScheduler,
-                                               PlayerDisconnectionService playerDisconnectionService,
-                                               StompSessionManager stompSessionManager,
-                                               RoomService roomService) {
-            super(taskScheduler, playerDisconnectionService, stompSessionManager, roomService);
-        }
-
-        // 테스트에서는 더 짧은 지연시간 사용하고 싶다면 이런 식으로 오버라이드 가능
-        // 하지만 현재 구조상 REMOVAL_DELAY가 private static final이라 어렵다
-        // 실제로는 설정으로 빼거나 생성자 주입으로 받는 게 좋을 듯
     }
 }

--- a/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/DelayedPlayerRemovalServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import coffeeshout.room.application.service.RoomService;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,8 @@ import org.springframework.scheduling.TaskScheduler;
 
 @ExtendWith(MockitoExtension.class)
 class DelayedPlayerRemovalServiceTest {
+
+    private static final Duration TEST_REMOVAL_DELAY = Duration.ofMillis(100);
 
     @Mock
     private TaskScheduler taskScheduler;
@@ -45,8 +48,8 @@ class DelayedPlayerRemovalServiceTest {
 
     @BeforeEach
     void setUp() {
-        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, playerDisconnectionService,
-                sessionManager, roomService);
+        delayedPlayerRemovalService = new DelayedPlayerRemovalService(taskScheduler, TEST_REMOVAL_DELAY,
+                playerDisconnectionService, sessionManager, roomService);
     }
 
     @Nested


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1131

# 🚀 작업 내용

DelayedPlayerRemovalService — private static final Duration REMOVAL_DELAY = Duration.ofSeconds(15) 제거, `@Value("${player.removalDelay}")` 생성자 주입으로 교체 (DelayedRoomRemovalService 패턴 통일), 유효성 검증 추가

```java
public DelayedPlayerRemovalService(
        @Qualifier("delayRemovalScheduler") TaskScheduler taskScheduler,
        @Value("${player.removalDelay}") Duration removalDelay,
        ...
) {
    validateRemovalDuration(removalDelay);
    this.removalDelay = removalDelay;
    ...
}
```
application.yml — player.removalDelay: 15s 추가 (운영 동작 동일 유지)

DelayedPlayerRemovalServiceIntegrationTest — TEST_REMOVAL_DELAY = Duration.ofMillis(500) 상수 주입, atMost 20s → 2s 단축, 불필요한 TestDelayedPlayerRemovalService 내부 클래스 제거

DelayedPlayerRemovalServiceTest — TEST_REMOVAL_DELAY = Duration.ofMillis(100) 주입, 생성자 호출 업데이트

결과: 통합 테스트 클래스 실행 시간 ~49초 → ~5초

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 플레이어 제거 지연 시간을 이제 설정 파일을 통해 구성할 수 있습니다. 이전의 고정된 값에서 유연한 구성으로 변경되었으며, 입력 값의 유효성을 검증하여 시스템 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->