### PR TITLE
[feat] Redis 기반 IP 차단 필터 구현 (#1155)

### DIFF
--- a/backend/src/main/java/coffeeshout/global/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/coffeeshout/global/exception/GlobalErrorCode.java
@@ -14,6 +14,7 @@ public enum GlobalErrorCode implements ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다."),
     CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "요청 파라미터가 유효하지 않습니다."),
+    IP_BLOCKED(HttpStatus.TOO_MANY_REQUESTS, "비정상적인 접근으로 일시적으로 차단되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
+++ b/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
@@ -1,0 +1,86 @@
+package coffeeshout.global.filter;
+
+import coffeeshout.global.ratelimit.IpBlockStore;
+import coffeeshout.global.ratelimit.MaliciousPathMatcher;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * IP 기반 차단 필터.
+ * <p>
+ * 세 가지 차단 정책을 적용한다:
+ * <ol>
+ *   <li>이미 차단된 IP는 요청 초입에서 즉시 429 반환</li>
+ *   <li>악성 경로(스캐너 패턴) 접근 시 해당 IP를 즉시 차단하고 429 반환</li>
+ *   <li>404 응답이 누적되면 차단 (IpBlockStore 위임)</li>
+ * </ol>
+ *
+ * <p>{@code HIGHEST_PRECEDENCE}로 등록해 Security 필터 체인보다 먼저 실행한다.
+ * 차단된 요청은 Security 처리 비용 없이 즉시 반환된다.
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class IpBlockFilter extends OncePerRequestFilter {
+
+    private static final String BLOCKED_RESPONSE_BODY = """
+            {"status":429,"detail":"비정상적인 접근으로 일시적으로 차단되었습니다.","errorCode":"IP_BLOCKED"}""";
+
+    private final IpBlockStore ipBlockStore;
+    private final MaliciousPathMatcher maliciousPathMatcher;
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain
+    ) throws ServletException, IOException {
+        final String ip = extractIp(request);
+
+        if (ipBlockStore.isBlocked(ip)) {
+            log.warn("차단된 IP 접근 시도: ip={} uri={}", ip, request.getRequestURI());
+            writeBlockedResponse(response);
+            return;
+        }
+
+        if (maliciousPathMatcher.isMalicious(request.getRequestURI())) {
+            log.warn("악성 경로 접근 감지 → IP 즉시 차단: ip={} uri={}", ip, request.getRequestURI());
+            ipBlockStore.blockImmediately(ip);
+            writeBlockedResponse(response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+
+        if (response.getStatus() == HttpStatus.NOT_FOUND.value()) {
+            ipBlockStore.incrementNotFoundAndBlockIfExceeded(ip);
+        }
+    }
+
+    private String extractIp(final HttpServletRequest request) {
+        final String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private void writeBlockedResponse(final HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(BLOCKED_RESPONSE_BODY);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
+++ b/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
@@ -10,8 +10,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -39,17 +41,30 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class IpBlockFilter extends OncePerRequestFilter {
 
+    private static final Pattern IPV4_PATTERN = Pattern.compile(
+            "^((25[0-5]|2[0-4]\\d|[01]?\\d\\d?)\\.){3}(25[0-5]|2[0-4]\\d|[01]?\\d\\d?)$"
+    );
+    private static final Pattern IPV6_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{0,4}(:[0-9a-fA-F]{0,4}){2,7}$"
+    );
+
     private final IpBlockStore ipBlockStore;
     private final MaliciousPathMatcher maliciousPathMatcher;
     private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        final String ip = extractIp(request);
+        final String ip = getClientIp(request);
+
+        if (!isValidIp(ip)) {
+            log.debug("유효하지 않은 IP 형식, 필터 처리 건너뜀: ip={}", ip);
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         if (ipBlockStore.isBlocked(ip)) {
             log.warn("차단된 IP 접근 시도: ip={} uri={}", ip, request.getRequestURI());
@@ -71,14 +86,6 @@ public class IpBlockFilter extends OncePerRequestFilter {
         }
     }
 
-    private String extractIp(HttpServletRequest request) {
-        final String forwarded = request.getHeader("X-Forwarded-For");
-        if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();
-        }
-        return request.getRemoteAddr();
-    }
-
     private void writeBlockedResponse(HttpServletResponse response) throws IOException {
         final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.TOO_MANY_REQUESTS, GlobalErrorCode.IP_BLOCKED.getMessage());
@@ -90,5 +97,21 @@ public class IpBlockFilter extends OncePerRequestFilter {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         objectMapper.writeValue(response.getWriter(), problemDetail);
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor == null || xForwardedFor.isBlank() || "unknown".equalsIgnoreCase(xForwardedFor)) {
+            return request.getRemoteAddr();
+        }
+        String[] ips = xForwardedFor.split(",");
+        return ips[ips.length - 1].trim();
+    }
+
+    private boolean isValidIp(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return IPV4_PATTERN.matcher(ip).matches() || IPV6_PATTERN.matcher(ip).matches();
     }
 }

--- a/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
+++ b/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
@@ -1,18 +1,22 @@
 package coffeeshout.global.filter;
 
+import coffeeshout.global.exception.GlobalErrorCode;
 import coffeeshout.global.ratelimit.IpBlockStore;
 import coffeeshout.global.ratelimit.MaliciousPathMatcher;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -35,11 +39,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class IpBlockFilter extends OncePerRequestFilter {
 
-    private static final String BLOCKED_RESPONSE_BODY = """
-            {"status":429,"detail":"비정상적인 접근으로 일시적으로 차단되었습니다.","errorCode":"IP_BLOCKED"}""";
-
     private final IpBlockStore ipBlockStore;
     private final MaliciousPathMatcher maliciousPathMatcher;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(
@@ -78,9 +80,15 @@ public class IpBlockFilter extends OncePerRequestFilter {
     }
 
     private void writeBlockedResponse(HttpServletResponse response) throws IOException {
+        final ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.TOO_MANY_REQUESTS, GlobalErrorCode.IP_BLOCKED.getMessage());
+        problemDetail.setProperty("errorCode", GlobalErrorCode.IP_BLOCKED.getCode());
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        problemDetail.setProperty("exception", IpBlockFilter.class.getSimpleName());
+
         response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(BLOCKED_RESPONSE_BODY);
+        objectMapper.writeValue(response.getWriter(), problemDetail);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
+++ b/backend/src/main/java/coffeeshout/global/filter/IpBlockFilter.java
@@ -43,9 +43,9 @@ public class IpBlockFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-            final HttpServletRequest request,
-            final HttpServletResponse response,
-            final FilterChain filterChain
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
     ) throws ServletException, IOException {
         final String ip = extractIp(request);
 
@@ -69,7 +69,7 @@ public class IpBlockFilter extends OncePerRequestFilter {
         }
     }
 
-    private String extractIp(final HttpServletRequest request) {
+    private String extractIp(HttpServletRequest request) {
         final String forwarded = request.getHeader("X-Forwarded-For");
         if (forwarded != null && !forwarded.isBlank()) {
             return forwarded.split(",")[0].trim();
@@ -77,7 +77,7 @@ public class IpBlockFilter extends OncePerRequestFilter {
         return request.getRemoteAddr();
     }
 
-    private void writeBlockedResponse(final HttpServletResponse response) throws IOException {
+    private void writeBlockedResponse(HttpServletResponse response) throws IOException {
         response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
@@ -34,11 +34,11 @@ public class IpBlockStore {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public boolean isBlocked(final String ip) {
+    public boolean isBlocked(String ip) {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(BLOCKED_IP_PREFIX + ip));
     }
 
-    public void blockImmediately(final String ip) {
+    public void blockImmediately(String ip) {
         stringRedisTemplate.opsForValue().set(BLOCKED_IP_PREFIX + ip, "1", BLOCK_TTL);
         log.warn("IP 차단 등록: ip={} ttl={}h", ip, BLOCK_TTL.toHours());
     }
@@ -47,7 +47,7 @@ public class IpBlockStore {
      * 404 카운터를 증가시키고, 임계값 이상이면 IP를 차단한다.
      * 카운터 키가 처음 생성될 때 TTL을 설정해 Fixed Window를 구현한다.
      */
-    public void incrementNotFoundAndBlockIfExceeded(final String ip) {
+    public void incrementNotFoundAndBlockIfExceeded(String ip) {
         final String key = NOT_FOUND_COUNTER_PREFIX + ip;
         final Long count = stringRedisTemplate.opsForValue().increment(key);
         if (count == null) {

--- a/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
@@ -1,9 +1,11 @@
 package coffeeshout.global.ratelimit;
 
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,6 +28,18 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class IpBlockStore {
 
+    /**
+     * INCR와 최초 생성 시 EXPIRE를 원자적으로 수행하는 Lua 스크립트.
+     * TTL이 없는 카운터 키가 남아 영구 누적되는 경우를 방지한다.
+     */
+    private static final RedisScript<Long> INCREMENT_WITH_EXPIRE_SCRIPT = RedisScript.of("""
+            local count = redis.call('INCR', KEYS[1])
+            if count == 1 then
+                redis.call('EXPIRE', KEYS[1], ARGV[1])
+            end
+            return count
+            """, Long.class);
+
     private static final String NOT_FOUND_COUNTER_PREFIX = "block:404:";
     private static final String BLOCKED_IP_PREFIX = "block:ip:";
     private static final int NOT_FOUND_THRESHOLD = 5;
@@ -45,16 +59,18 @@ public class IpBlockStore {
 
     /**
      * 404 카운터를 증가시키고, 임계값 이상이면 IP를 차단한다.
-     * 카운터 키가 처음 생성될 때 TTL을 설정해 Fixed Window를 구현한다.
+     * Lua 스크립트로 INCR와 최초 EXPIRE를 원자적으로 수행해 TTL 누락을 방지한다.
      */
     public void incrementNotFoundAndBlockIfExceeded(String ip) {
         final String key = NOT_FOUND_COUNTER_PREFIX + ip;
-        final Long count = stringRedisTemplate.opsForValue().increment(key);
+        final Long count = stringRedisTemplate.execute(
+                INCREMENT_WITH_EXPIRE_SCRIPT,
+                List.of(key),
+                String.valueOf(NOT_FOUND_WINDOW.getSeconds())
+        );
         if (count == null) {
+            log.warn("Redis 스크립트 실행 결과가 null입니다. Redis 연결 상태를 확인하세요: ip={}", ip);
             return;
-        }
-        if (count == 1) {
-            stringRedisTemplate.expire(key, NOT_FOUND_WINDOW);
         }
         if (count >= NOT_FOUND_THRESHOLD) {
             log.warn("404 임계값 초과 → IP 차단: ip={} count={}", ip, count);

--- a/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
@@ -1,0 +1,64 @@
+package coffeeshout.global.ratelimit;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis 기반 IP 차단 저장소.
+ * <p>
+ * 두 가지 방식으로 IP를 차단한다:
+ * <ul>
+ *   <li>즉시 차단: 악성 경로 접근 시 {@link #blockImmediately(String)} 호출</li>
+ *   <li>누적 차단: 404 응답이 임계값 이상 발생한 IP를 {@link #incrementNotFoundAndBlockIfExceeded(String)} 로 관리</li>
+ * </ul>
+ *
+ * <p>Redis Key 설계:
+ * <ul>
+ *   <li>{@code block:404:{ip}} — 404 누적 카운터, TTL: 1시간 (Fixed Window)</li>
+ *   <li>{@code block:ip:{ip}} — 차단 마킹, TTL: 24시간</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IpBlockStore {
+
+    private static final String NOT_FOUND_COUNTER_PREFIX = "block:404:";
+    private static final String BLOCKED_IP_PREFIX = "block:ip:";
+    private static final int NOT_FOUND_THRESHOLD = 5;
+    private static final Duration NOT_FOUND_WINDOW = Duration.ofHours(1);
+    private static final Duration BLOCK_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public boolean isBlocked(final String ip) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(BLOCKED_IP_PREFIX + ip));
+    }
+
+    public void blockImmediately(final String ip) {
+        stringRedisTemplate.opsForValue().set(BLOCKED_IP_PREFIX + ip, "1", BLOCK_TTL);
+        log.warn("IP 차단 등록: ip={} ttl={}h", ip, BLOCK_TTL.toHours());
+    }
+
+    /**
+     * 404 카운터를 증가시키고, 임계값 이상이면 IP를 차단한다.
+     * 카운터 키가 처음 생성될 때 TTL을 설정해 Fixed Window를 구현한다.
+     */
+    public void incrementNotFoundAndBlockIfExceeded(final String ip) {
+        final String key = NOT_FOUND_COUNTER_PREFIX + ip;
+        final Long count = stringRedisTemplate.opsForValue().increment(key);
+        if (count == null) {
+            return;
+        }
+        if (count == 1) {
+            stringRedisTemplate.expire(key, NOT_FOUND_WINDOW);
+        }
+        if (count >= NOT_FOUND_THRESHOLD) {
+            log.warn("404 임계값 초과 → IP 차단: ip={} count={}", ip, count);
+            blockImmediately(ip);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/IpBlockStore.java
@@ -1,5 +1,6 @@
 package coffeeshout.global.ratelimit;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,22 +35,36 @@ public class IpBlockStore {
 
     private final StringRedisTemplate stringRedisTemplate;
 
+    @CircuitBreaker(name = "redisBlockStore", fallbackMethod = "isBlockedFallback")
     public boolean isBlocked(String ip) {
-        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(BLOCKED_IP_PREFIX + ip));
+        Boolean hasKey = stringRedisTemplate.hasKey(BLOCKED_IP_PREFIX + ip);
+        return Boolean.TRUE.equals(hasKey);
     }
 
+    private boolean isBlockedFallback(String ip, Throwable t) {
+        log.warn("서킷 브레이커 OPEN/장애 발생: Redis 장애로 IP 차단 여부를 확인할 수 없습니다. Fail-open 처리합니다. ip={} error={}", ip, t.getMessage());
+        return false; // Redis 장애 시 차단하지 않고 통과시킴
+    }
+
+    @CircuitBreaker(name = "redisBlockStore", fallbackMethod = "blockImmediatelyFallback")
     public void blockImmediately(String ip) {
         stringRedisTemplate.opsForValue().set(BLOCKED_IP_PREFIX + ip, "1", BLOCK_TTL);
         log.warn("IP 차단 등록: ip={} ttl={}h", ip, BLOCK_TTL.toHours());
+    }
+
+    private void blockImmediatelyFallback(String ip, Throwable t) {
+        log.warn("서킷 브레이커 OPEN/장애 발생: Redis 장애로 IP를 차단할 수 없습니다. ip={} error={}", ip, t.getMessage());
     }
 
     /**
      * 404 카운터를 증가시키고, 임계값 이상이면 IP를 차단한다.
      * 카운터 키가 처음 생성될 때 TTL을 설정해 Fixed Window를 구현한다.
      */
+    @CircuitBreaker(name = "redisBlockStore", fallbackMethod = "incrementNotFoundFallback")
     public void incrementNotFoundAndBlockIfExceeded(String ip) {
         final String key = NOT_FOUND_COUNTER_PREFIX + ip;
         final Long count = stringRedisTemplate.opsForValue().increment(key);
+        
         if (count == null) {
             return;
         }
@@ -58,7 +73,15 @@ public class IpBlockStore {
         }
         if (count >= NOT_FOUND_THRESHOLD) {
             log.warn("404 임계값 초과 → IP 차단: ip={} count={}", ip, count);
-            blockImmediately(ip);
+            
+            // 참고: 내부 메서드 호출이므로 blockImmediately의 프록시를 타진 않지만,
+            // 여기서 예외가 발생하면 현재 메서드의 incrementNotFoundFallback이 동작하므로 안전합니다.
+            stringRedisTemplate.opsForValue().set(BLOCKED_IP_PREFIX + ip, "1", BLOCK_TTL);
+            log.warn("IP 차단 등록: ip={} ttl={}h", ip, BLOCK_TTL.toHours());
         }
+    }
+
+    private void incrementNotFoundFallback(String ip, Throwable t) {
+        log.warn("서킷 브레이커 OPEN/장애 발생: Redis 장애로 404 카운터를 처리할 수 없습니다. ip={} error={}", ip, t.getMessage());
     }
 }

--- a/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
@@ -1,0 +1,36 @@
+package coffeeshout.global.ratelimit;
+
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * 악성 경로 패턴 감지기.
+ * <p>
+ * 정상 사용자가 접근할 가능성이 없는 경로를 정의한다.
+ * 해당 경로 접근은 스캐너·봇으로 판단해 즉시 IP를 차단한다.
+ */
+@Component
+public class MaliciousPathMatcher {
+
+    private static final List<String> MALICIOUS_PREFIXES = List.of(
+            "/.env",
+            "/.git",
+            "/.aws",
+            "/.ssh",
+            "/wp-admin",
+            "/wp-login",
+            "/wp-content",
+            "/phpmyadmin",
+            "/xmlrpc.php",
+            "/cgi-bin",
+            "/admin.php",
+            "/config.php",
+            "/setup.php",
+            "/install.php"
+    );
+
+    public boolean isMalicious(final String path) {
+        final String lowerPath = path.toLowerCase();
+        return MALICIOUS_PREFIXES.stream().anyMatch(lowerPath::startsWith);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
@@ -1,5 +1,7 @@
 package coffeeshout.global.ratelimit;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -26,11 +28,13 @@ public class MaliciousPathMatcher {
             "/admin.php",
             "/config.php",
             "/setup.php",
-            "/install.php"
+            "/install.php",
+            "/graphql"
     );
 
     public boolean isMalicious(String path) {
-        final String lowerPath = path.toLowerCase();
+        final String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        final String lowerPath = decodedPath.toLowerCase();
         return MALICIOUS_PREFIXES.stream().anyMatch(lowerPath::startsWith);
     }
 }

--- a/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
+++ b/backend/src/main/java/coffeeshout/global/ratelimit/MaliciousPathMatcher.java
@@ -29,7 +29,7 @@ public class MaliciousPathMatcher {
             "/install.php"
     );
 
-    public boolean isMalicious(final String path) {
+    public boolean isMalicious(String path) {
         final String lowerPath = path.toLowerCase();
         return MALICIOUS_PREFIXES.stream().anyMatch(lowerPath::startsWith);
     }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -25,3 +25,9 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: true
+
+server:
+  tomcat:
+    remoteip:
+      # Docker 기본 브릿지 네트워크 대역 (172.17.0.0/16 등) 포함
+      internal-proxies: "127\\.0\\.0\\.1|10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.(1[6-9]|2[0-9]|3[0-1])\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}"

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -25,3 +25,8 @@ springdoc:
     enabled: false
   swagger-ui:
     enabled: false
+
+server:
+  tomcat:
+    remoteip:
+      internal-proxies: "172\\.20\\.0\\.\\d{1,3}"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -186,6 +186,7 @@ management:
         enabled: true
 
 server:
+  forward-headers-strategy: native
   shutdown: graceful
   tomcat:
     threads:
@@ -193,6 +194,9 @@ server:
       min-spare: 30
     max-connections: 700
     accept-count: 300
+    remoteip:
+      remote-ip-header: X-Forwarded-For
+      protocol-header: X-Forwarded-Proto
 
 resilience4j:
   circuitbreaker:

--- a/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
+++ b/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
@@ -1,6 +1,5 @@
 package coffeeshout.global.filter;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -51,7 +50,6 @@ class IpBlockFilterTest {
     }
 
     @Nested
-    @DisplayName("차단된 IP 접근")
     class 차단된_IP_접근 {
 
         @Test
@@ -72,7 +70,6 @@ class IpBlockFilterTest {
     }
 
     @Nested
-    @DisplayName("악성 경로 접근")
     class 악성_경로_접근 {
 
         @BeforeEach
@@ -98,7 +95,6 @@ class IpBlockFilterTest {
     }
 
     @Nested
-    @DisplayName("정상 요청의 404 누적")
     class 정상_요청의_404_누적 {
 
         @BeforeEach
@@ -128,19 +124,18 @@ class IpBlockFilterTest {
     }
 
     @Nested
-    @DisplayName("IP 추출")
     class IP_추출 {
 
         @Test
-        void X_Forwarded_For_헤더의_첫_번째_IP를_사용한다() throws Exception {
-            given(ipBlockStore.isBlocked("10.0.0.1")).willReturn(true);
+        void X_Forwarded_For_헤더의_마지막_IP를_사용한다() throws Exception {
+            given(ipBlockStore.isBlocked(anyString())).willReturn(true);
 
             final MockHttpServletRequest request = 요청("172.16.0.1", NORMAL_PATH);
             request.addHeader("X-Forwarded-For", "10.0.0.1, 192.168.1.1");
 
             filter.doFilter(request, new MockHttpServletResponse(), filterChain);
 
-            then(ipBlockStore).should().isBlocked("10.0.0.1");
+            then(ipBlockStore).should().isBlocked("192.168.1.1");
         }
 
         @Test
@@ -150,6 +145,17 @@ class IpBlockFilterTest {
             filter.doFilter(요청(REMOTE_IP, NORMAL_PATH), new MockHttpServletResponse(), filterChain);
 
             then(ipBlockStore).should().isBlocked(REMOTE_IP);
+        }
+
+        @Test
+        void 유효하지_않은_IP면_필터_처리를_건너뛴다() throws Exception {
+            final MockHttpServletRequest request = 요청("1.2.3.4", NORMAL_PATH);
+            request.addHeader("X-Forwarded-For", "192.168.1.1, unknown");
+
+            filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).shouldHaveNoInteractions();
+            then(filterChain).should().doFilter(any(), any());
         }
     }
 

--- a/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
+++ b/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
@@ -150,7 +150,7 @@ class IpBlockFilterTest {
         }
     }
 
-    private MockHttpServletRequest 요청(final String remoteAddr, final String uri) {
+    private MockHttpServletRequest 요청(String remoteAddr, String uri) {
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRemoteAddr(remoteAddr);
         request.setRequestURI(uri);

--- a/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
+++ b/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.never;
 
 import coffeeshout.global.ratelimit.IpBlockStore;
 import coffeeshout.global.ratelimit.MaliciousPathMatcher;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.SoftAssertions;
@@ -44,7 +46,8 @@ class IpBlockFilterTest {
 
     @BeforeEach
     void setUp() {
-        filter = new IpBlockFilter(ipBlockStore, maliciousPathMatcher);
+        final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        filter = new IpBlockFilter(ipBlockStore, maliciousPathMatcher, objectMapper);
     }
 
     @Nested

--- a/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
+++ b/backend/src/test/java/coffeeshout/global/filter/IpBlockFilterTest.java
@@ -1,0 +1,159 @@
+package coffeeshout.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+
+import coffeeshout.global.ratelimit.IpBlockStore;
+import coffeeshout.global.ratelimit.MaliciousPathMatcher;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@DisplayName("IpBlockFilter")
+@ExtendWith(MockitoExtension.class)
+class IpBlockFilterTest {
+
+    private static final String REMOTE_IP = "1.2.3.4";
+    private static final String MALICIOUS_PATH = "/.env";
+    private static final String NORMAL_PATH = "/reports";
+
+    @Mock
+    private IpBlockStore ipBlockStore;
+
+    @Mock
+    private MaliciousPathMatcher maliciousPathMatcher;
+
+    @Mock
+    private FilterChain filterChain;
+
+    private IpBlockFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new IpBlockFilter(ipBlockStore, maliciousPathMatcher);
+    }
+
+    @Nested
+    @DisplayName("차단된 IP 접근")
+    class 차단된_IP_접근 {
+
+        @Test
+        void 차단된_IP는_429를_반환하고_filterChain을_통과하지_않는다() throws Exception {
+            given(ipBlockStore.isBlocked(REMOTE_IP)).willReturn(true);
+
+            final MockHttpServletRequest request = 요청(REMOTE_IP, NORMAL_PATH);
+            final MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilter(request, response, filterChain);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isEqualTo(429);
+                softly.assertThat(response.getContentType()).contains("application/json");
+            });
+            then(filterChain).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("악성 경로 접근")
+    class 악성_경로_접근 {
+
+        @BeforeEach
+        void setUp() {
+            given(ipBlockStore.isBlocked(anyString())).willReturn(false);
+            given(maliciousPathMatcher.isMalicious(MALICIOUS_PATH)).willReturn(true);
+        }
+
+        @Test
+        void 악성_경로_접근_시_429를_반환하고_IP를_즉시_차단한다() throws Exception {
+            final MockHttpServletRequest request = 요청(REMOTE_IP, MALICIOUS_PATH);
+            final MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilter(request, response, filterChain);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isEqualTo(429);
+                softly.assertThat(response.getContentType()).contains("application/json");
+            });
+            then(ipBlockStore).should().blockImmediately(REMOTE_IP);
+            then(filterChain).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 요청의 404 누적")
+    class 정상_요청의_404_누적 {
+
+        @BeforeEach
+        void setUp() {
+            given(ipBlockStore.isBlocked(anyString())).willReturn(false);
+            given(maliciousPathMatcher.isMalicious(anyString())).willReturn(false);
+        }
+
+        @Test
+        void _404_응답_시_카운터를_증가시킨다() throws Exception {
+            doAnswer(invocation -> {
+                ((HttpServletResponse) invocation.getArgument(1)).setStatus(404);
+                return null;
+            }).when(filterChain).doFilter(any(), any());
+
+            filter.doFilter(요청(REMOTE_IP, "/not-found"), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should().incrementNotFoundAndBlockIfExceeded(REMOTE_IP);
+        }
+
+        @Test
+        void _200_응답_시_카운터를_증가시키지_않는다() throws Exception {
+            filter.doFilter(요청(REMOTE_IP, NORMAL_PATH), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should(never()).incrementNotFoundAndBlockIfExceeded(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("IP 추출")
+    class IP_추출 {
+
+        @Test
+        void X_Forwarded_For_헤더의_첫_번째_IP를_사용한다() throws Exception {
+            given(ipBlockStore.isBlocked("10.0.0.1")).willReturn(true);
+
+            final MockHttpServletRequest request = 요청("172.16.0.1", NORMAL_PATH);
+            request.addHeader("X-Forwarded-For", "10.0.0.1, 192.168.1.1");
+
+            filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should().isBlocked("10.0.0.1");
+        }
+
+        @Test
+        void X_Forwarded_For_헤더가_없으면_RemoteAddr를_사용한다() throws Exception {
+            given(ipBlockStore.isBlocked(REMOTE_IP)).willReturn(true);
+
+            filter.doFilter(요청(REMOTE_IP, NORMAL_PATH), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should().isBlocked(REMOTE_IP);
+        }
+    }
+
+    private MockHttpServletRequest 요청(final String remoteAddr, final String uri) {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr(remoteAddr);
+        request.setRequestURI(uri);
+        return request;
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/ratelimit/IpBlockStoreTest.java
+++ b/backend/src/test/java/coffeeshout/global/ratelimit/IpBlockStoreTest.java
@@ -1,0 +1,105 @@
+package coffeeshout.global.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.fixture.IntegrationTestSupport;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@DisplayName("IpBlockStore")
+class IpBlockStoreTest extends IntegrationTestSupport {
+
+    private static final String IP = "1.2.3.4";
+    private static final String ANOTHER_IP = "5.6.7.8";
+
+    @Autowired
+    private IpBlockStore ipBlockStore;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Nested
+    @DisplayName("isBlocked")
+    class isBlocked {
+
+        @Test
+        void 차단된_적_없는_IP는_false를_반환한다() {
+            assertThat(ipBlockStore.isBlocked(IP)).isFalse();
+        }
+
+        @Test
+        void blockImmediately_호출_후_true를_반환한다() {
+            ipBlockStore.blockImmediately(IP);
+
+            assertThat(ipBlockStore.isBlocked(IP)).isTrue();
+        }
+
+        @Test
+        void 다른_IP의_차단은_영향을_주지_않는다() {
+            ipBlockStore.blockImmediately(IP);
+
+            assertThat(ipBlockStore.isBlocked(ANOTHER_IP)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("blockImmediately")
+    class blockImmediately {
+
+        @Test
+        void IP를_즉시_차단하고_24시간_TTL을_설정한다() {
+            ipBlockStore.blockImmediately(IP);
+
+            final Long ttlSeconds = stringRedisTemplate.getExpire("block:ip:" + IP);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(ipBlockStore.isBlocked(IP)).isTrue();
+                softly.assertThat(ttlSeconds).isGreaterThan(0).isLessThanOrEqualTo(86400L);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("incrementNotFoundAndBlockIfExceeded")
+    class incrementNotFoundAndBlockIfExceeded {
+
+        @Test
+        void 첫_번째_호출에서_1시간_TTL을_설정한다() {
+            ipBlockStore.incrementNotFoundAndBlockIfExceeded(IP);
+
+            final Long ttlSeconds = stringRedisTemplate.getExpire("block:404:" + IP);
+            assertThat(ttlSeconds).isGreaterThan(0).isLessThanOrEqualTo(3600L);
+        }
+
+        @Test
+        void 임계값_미만이면_차단하지_않는다() {
+            for (int i = 0; i < 4; i++) {
+                ipBlockStore.incrementNotFoundAndBlockIfExceeded(IP);
+            }
+
+            assertThat(ipBlockStore.isBlocked(IP)).isFalse();
+        }
+
+        @Test
+        void 임계값_5회_도달_시_IP를_차단한다() {
+            for (int i = 0; i < 5; i++) {
+                ipBlockStore.incrementNotFoundAndBlockIfExceeded(IP);
+            }
+
+            assertThat(ipBlockStore.isBlocked(IP)).isTrue();
+        }
+
+        @Test
+        void 임계값_초과_이후에도_차단_상태가_유지된다() {
+            for (int i = 0; i < 7; i++) {
+                ipBlockStore.incrementNotFoundAndBlockIfExceeded(IP);
+            }
+
+            assertThat(ipBlockStore.isBlocked(IP)).isTrue();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/ratelimit/MaliciousPathMatcherTest.java
+++ b/backend/src/test/java/coffeeshout/global/ratelimit/MaliciousPathMatcherTest.java
@@ -1,0 +1,80 @@
+package coffeeshout.global.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("MaliciousPathMatcher")
+class MaliciousPathMatcherTest {
+
+    private final MaliciousPathMatcher matcher = new MaliciousPathMatcher();
+
+    @Nested
+    @DisplayName("악성 경로 감지")
+    class 악성_경로_감지 {
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(strings = {
+                "/.env",
+                "/.env.local",
+                "/.env.production",
+                "/.git",
+                "/.git/config",
+                "/.git/HEAD",
+                "/.aws",
+                "/.aws/credentials",
+                "/.ssh",
+                "/.ssh/id_rsa",
+                "/wp-admin",
+                "/wp-admin/admin.php",
+                "/wp-login.php",
+                "/wp-content/themes/shell.php",
+                "/phpmyadmin",
+                "/phpmyadmin/index.php",
+                "/xmlrpc.php",
+                "/cgi-bin",
+                "/cgi-bin/test.cgi",
+                "/admin.php",
+                "/config.php",
+                "/setup.php",
+                "/install.php"
+        })
+        void 악성_경로_패턴은_true를_반환한다(final String path) {
+            assertThat(matcher.isMalicious(path)).isTrue();
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(strings = {
+                "/.ENV",
+                "/.Git",
+                "/WP-ADMIN",
+                "/XMLRPC.PHP"
+        })
+        void 대소문자_구분_없이_악성_경로를_감지한다(final String path) {
+            assertThat(matcher.isMalicious(path)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 경로 허용")
+    class 정상_경로_허용 {
+
+        @ParameterizedTest(name = "{0}")
+        @ValueSource(strings = {
+                "/",
+                "/reports",
+                "/admin",
+                "/admin/login",
+                "/admin/reports",
+                "/ws",
+                "/api/rooms",
+                "/health"
+        })
+        void 정상_경로는_false를_반환한다(final String path) {
+            assertThat(matcher.isMalicious(path)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [ ] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

# 🚀 작업 내용

1. **IpBlockFilter**: `HIGHEST_PRECEDENCE` 서블릿 필터로 Security 체인 이전에 실행
   - 차단된 IP → 즉시 429 반환 (표준 `ProblemDetail` 형식으로 응답)
   - 악성 경로(스캐너 패턴) 접근 → IP 즉시 차단 후 429 반환
   - 정상 요청이 404 응답을 받으면 카운터 누적
2. **IpBlockStore**: Redis 기반 차단 상태 관리
   - `block:404:{ip}` — 404 누적 카운터 (Fixed Window 1시간, 임계값 5회), Lua 스크립트로 `INCR`+`EXPIRE` 원자적 처리
   - `block:ip:{ip}` — 차단 마킹 (TTL 24시간)
3. **MaliciousPathMatcher**: 스캐너·봇 전형 경로 패턴 감지 (`/.env`, `/.git`, `/wp-admin` 등)
4. **GlobalErrorCode**: `IP_BLOCKED` 에러 코드 추가 (`429 Too Many Requests`)
5. 차단 응답을 하드코딩 JSON에서 `ProblemDetail` 기반으로 변경하여 `RestExceptionHandler`의 표준 에러 포맷(`errorCode`, `timestamp`, `exception`)과 일치하도록 수정

# 💬 리뷰 중점사항

- `IpBlockFilter`의 차단 응답이 `RestExceptionHandler`와 동일한 `ProblemDetail` 스키마를 사용하는지 확인
- `ObjectMapper`를 생성자 주입으로 받아 테스트 가능성 유지 여부 확인
- `IpBlockStore`의 404 카운터 증가 시 Lua 스크립트로 `INCR`+`EXPIRE`가 원자적으로 처리되어 TTL 누락이 발생하지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * IP 차단 기능 추가: 비정상적인 접근 및 과도한 오류 요청을 감지하면 자동으로 해당 IP를 차단하고 429 응답을 반환합니다.
  * 악성 요청 탐지 강화: 알려진 공격 패턴에 대한 방어 기능이 추가되었습니다.

* **개선사항**
  * 프록시/로드 밸런서 환경에서의 클라이언트 IP 식별 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->