### PR TITLE
[feat] 블록쌓기 대시보드 추가

### DIFF
--- a/frontend/docs/todo/done.md
+++ b/frontend/docs/todo/done.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 블록 쌓기 TOP 플레이어 랭킹 탭 연동 (#1161)
+
+- `rankingConfigs.ts`에 `blockstacking-top-players` 카테고리 추가 (`GET /dashboard/blockstacking-top-players`)
+- `dashBoard.ts`에 `BlockStackingTopPlayer` 타입 추가
+- 랭킹 탭 아코디언 UI 및 빈 배열 처리는 기존 `RankingAccordionItem` 인프라 재사용
+
+---
+
 ## 건의사항 POST /reports API 연동
 
 - `SuggestionTab.tsx`에서 `useMutation`으로 연동

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -41,6 +41,7 @@ export const RANKING_CATEGORIES: RankingCategory[] = [
     endpoint: '/dashboard/lowest-probability-winner',
     transformData: (raw) => {
       const data = raw as LowestProbabilityWinner;
+      if (!data?.playerNames?.length) return [];
       const probability = Math.round(data.probability * 10) / 10;
       return data.playerNames.map((name, i) => ({
         rank: i + 1,

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -1,4 +1,9 @@
-import type { TopWinner, GamePlayCount, LowestProbabilityWinner, BlockStackingTopPlayer } from '@/types/dashBoard';
+import type {
+  TopWinner,
+  GamePlayCount,
+  LowestProbabilityWinner,
+  BlockStackingTopPlayer,
+} from '@/types/dashBoard';
 import { MINI_GAME_NAME_MAP, type MiniGameType } from '@/types/miniGame/common';
 
 export type RankingItem = {

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -1,4 +1,4 @@
-import type { TopWinner, GamePlayCount, LowestProbabilityWinner } from '@/types/dashBoard';
+import type { TopWinner, GamePlayCount, LowestProbabilityWinner, BlockStackingTopPlayer } from '@/types/dashBoard';
 import { MINI_GAME_NAME_MAP, type MiniGameType } from '@/types/miniGame/common';
 
 export type RankingItem = {
@@ -44,6 +44,19 @@ export const RANKING_CATEGORIES: RankingCategory[] = [
         unit: '%',
       }));
     },
+  },
+  {
+    key: 'blockstacking-top-players',
+    label: '블록쌓기 최고 기록',
+    icon: '🧱',
+    endpoint: '/dashboard/blockstacking-top-players',
+    transformData: (raw) =>
+      (raw as BlockStackingTopPlayer[]).map((p, i) => ({
+        rank: i + 1,
+        name: p.playerName,
+        count: p.maxFloor,
+        unit: '층',
+      })),
   },
   {
     key: 'game-play-counts',

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -55,7 +55,7 @@ export const RANKING_CATEGORIES: RankingCategory[] = [
     key: 'blockstacking-top-players',
     label: '블록쌓기 최고 기록',
     icon: '🧱',
-    endpoint: '/dashboard/blockstacking-top-players',
+    endpoint: '/dashboard/block-stacking-top-players',
     transformData: (raw) =>
       (raw as BlockStackingTopPlayer[]).map((p, i) => ({
         rank: i + 1,

--- a/frontend/src/types/dashBoard.ts
+++ b/frontend/src/types/dashBoard.ts
@@ -12,3 +12,8 @@ export type GamePlayCount = {
   gameType: string;
   playCount: number;
 };
+
+export type BlockStackingTopPlayer = {
+  playerName: string;
+  maxFloor: number;
+};


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1161

# 🚀 작업 내용

1. 상세 랭킹에서 블록쌓기 랭킹을 확인하도록 수정했습니다.
2. 최저 확률 당첨자에 랭킹이 없을 시 runtime 에러를 수정했습니다.

# 💬 리뷰 중점사항

중점사항
