### PR TITLE
[refactor] 블록 쌓기 모두 실패 시 전환 추가

### DIFF
--- a/backend/docs/adr/0002-block-stacking-game-design.md
+++ b/backend/docs/adr/0002-block-stacking-game-design.md
@@ -1,7 +1,7 @@
 # 0002. BlockStacking 게임 서버 설계
 
 - 날짜: 2026-04-03
-- 상태: 승인
+- 상태: 승인 (2026-04-13 §2, §8 수정 — 전원 실패 조기 종료 추가)
 
 ## 컨텍스트
 
@@ -31,9 +31,17 @@ overlap ≤ 0이거나 floor 값이 비연속적으로 증가하면 **해당 이
 - 서버가 reject 응답을 보낼 시점에 블록 위치가 이미 달라져 재현 불가능하다
 - 파티 게임 특성상 단일 이벤트 거부가 게임 흐름 전체를 방해해선 안 된다
 
-### 2. 게임 종료 기준 — 서버 20초 타이머 단일 기준
+### 2. 게임 종료 기준 — 20초 타이머 기본, 전원 실패 시 조기 종료
 
-전원 제출을 기다리는 `EarlyFinishTrigger` 패턴을 적용하지 않는다. 타이머 만료 시점에 서버가 보유한 각 플레이어의 `currentFloor`를 최종 점수로 확정한다. 별도 `submit` 커맨드도 두지 않는다. 플레이어 블록이 이탈해도 이후 progress를 보내지 않으면 그 층수가 자연스럽게 최종값이 된다.
+타이머 만료 시점에 서버가 보유한 각 플레이어의 `currentFloor`를 최종 점수로 확정한다. 별도 `submit` 커맨드는 두지 않는다. 플레이어 블록이 이탈해도 이후 progress를 보내지 않으면 그 층수가 자연스럽게 최종값이 된다.
+
+단, **모든 플레이어가 실패(블록 이탈)를 명시적으로 신고하면 타이머 잔여 시간과 무관하게 `allFailedDelay`(기본 2초) 후 게임을 종료**한다. 플레이어는 `/app/room/{joinCode}/block-stacking/fail` 엔드포인트로 실패를 신고한다.
+
+조기 종료에 `EarlyFinishTrigger` 패턴을 도입한 이유:
+
+- BlockStacking은 CardGame처럼 `submit` 커맨드가 없으므로 `EarlyFinishTrigger`를 CardGame처럼 "전원 제출 대기"로 사용하지 않는다
+- "전원 실패"는 더 이상 게임이 진행될 수 없는 상태이므로 UX 측면에서 즉시 결과를 보여주는 것이 적합하다
+- 미실패 플레이어 대기 문제가 없다 — 실패한 경우만 신호를 보내기 때문이다
 
 ### 3. 플레이어 진행 상태 — 단일 객체로 관리
 
@@ -97,16 +105,17 @@ PLAYING 상태로 전환할 때 서버 기준 게임 종료 시각을 함께 전
 
 PREPARE / PLAYING / DONE 세 가지 상태 전환 알림을 단일 `BlockStackingStateResponse`로 통일한다. 별도 complete 토픽(`/block-stacking/complete`)을 두지 않는다. 게임 최종 결과는 `room.applyMiniGameResult()`로 Room Score에 반영되므로 DONE 알림에 랭킹 데이터를 포함할 필요가 없다.
 
-### 8. FlowOrchestrator — 단일 체인
+### 8. FlowOrchestrator — 단일 체인 (조기 종료 포함)
 
 ```text
 startFlow()
   → [즉시] PREPARE
-  → [prepare 3초] PLAYING
-  → [playing 20초] FINISH_GAME → MiniGameFinishedEvent 발행
+  → [prepare 3초] PLAYING  ← EarlyFinishTrigger 등록
+  → raceTimeout(playing 20초, allFailedTrigger, allFailedDelay 2초)
+  → [즉시] FINISH_GAME → MiniGameFinishedEvent 발행
 ```
 
-라운드 반복, 조기 종료 트리거 없음.
+라운드 반복 없음. 조기 종료는 전원 실패 시 `allFailedDelay` 후 진행.
 
 ## 고려한 대안
 
@@ -114,7 +123,7 @@ startFlow()
 |---------------------------------------------|-------------------|--------------------------------------|
 | 잘못된 값 수신 시 에러 응답 + 재전송 요청                   | 서버-클라이언트 상태 동기화   | 낙관적 업데이트와 충돌, 재현 불가                  |
 | 잘못된 값 수신 시 WebSocket 연결 끊기                  | 강력한 치팅 차단         | 파티 게임에 과도한 제재, UX 파괴                 |
-| 전원 제출 완료 시 조기 종료 (EarlyFinishTrigger)       | 전원 완료 즉시 결과 확인 가능 | 미제출 플레이어로 인한 대기, 별도 제출 커맨드 필요        |
+| 전원 실패 시 조기 종료 (EarlyFinishTrigger) — **§2에서 채택** | 모두 실패한 이후 불필요한 대기 제거 | 클라이언트가 fail 신호를 명시적으로 전송해야 함 |
 | currentFloors / finalFloors 분리 관리           | 제출 전후 상태 명시적 구분   | 두 Map 동기화 부담, 클래스 외부에서 관리 규칙 추론 필요   |
 | FlowScheduler를 각 게임 패키지에 유지                 | 게임별 완전 독립         | 동일 패턴 중복, 의존성 방향 불명확                 |
 | progress 이벤트를 공유 CommandType 라우터 사용         | 기존 인프라 재사용        | 게임별 독립 진화 어려움, payload 구조 공유 라우터에 노출 |
@@ -149,4 +158,6 @@ startFlow()
 - 랭킹 알림 토픽: `/topic/room/{joinCode}/block-stacking/progress`
 - PLAYING 전환 시 `endTimeEpochMs` (UTC epoch ms) 포함
 - 검증 실패 시 warn 로그 기록 위치: `BlockStackingGame.recordProgress()`
-- 타이밍 설정: `block-stacking.timing.prepare=3s`, `block-stacking.timing.playing=20s`
+- 타이밍 설정: `block-stacking.timing.prepare=3s`, `block-stacking.timing.playing=20s`, `block-stacking.timing.all-failed-delay=2s`
+- 실패 신고 엔드포인트: `/app/room/{joinCode}/block-stacking/fail`
+- 실패 이벤트 흐름: `BlockStackingWebSocketController → BLOCK_STACKING_EVENTS → BlockStackingFailEventConsumer → BlockStackingService.recordFailure() → BlockStackingFlowOrchestrator.triggerEarlyFinishIfAllFailed()`

--- a/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingFlowOrchestrator.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingFlowOrchestrator.java
@@ -7,12 +7,14 @@ import static coffeeshout.blockstacking.domain.BlockStackingGameStep.START_PLAY;
 import coffeeshout.blockstacking.config.BlockStackingTimingProperties;
 import coffeeshout.blockstacking.domain.BlockStackingGame;
 import coffeeshout.blockstacking.domain.BlockStackingGameStep;
+import coffeeshout.global.flow.EarlyFinishTrigger;
 import coffeeshout.global.flow.FlowScheduler;
 import coffeeshout.minigame.domain.MiniGameType;
 import coffeeshout.minigame.event.dto.MiniGameFinishedEvent;
 import coffeeshout.room.domain.Room;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -28,13 +30,32 @@ public class BlockStackingFlowOrchestrator {
     private final BlockStackingNotifier notifier;
     private final ApplicationEventPublisher eventPublisher;
 
+    private final ConcurrentHashMap<String, EarlyFinishTrigger> earlyFinishTriggers = new ConcurrentHashMap<>();
+
     public void startFlow(BlockStackingGame game, Room room) {
         final String joinCode = room.getJoinCode().getValue();
+        final EarlyFinishTrigger trigger = blockStackingFlowScheduler.createEarlyFinishTrigger();
 
         blockStackingFlowScheduler.schedule(step(game, room, PREPARE), Duration.ZERO)
-                .andThen(startPlay(game, room), timing.prepare())
-                .andThen(finishGame(game, room), timing.playing())
-                .onError(ex -> log.error("BlockStacking flow 실패: joinCode={}", joinCode, ex));
+                .andThen(startPlay(game, room, trigger), timing.prepare())
+                .raceTimeout(timing.playing(), trigger, timing.allFailedDelay())
+                .andThen(finishGame(game, room), Duration.ZERO)
+                .onError(ex -> {
+                    earlyFinishTriggers.remove(joinCode);
+                    log.error("BlockStacking flow 실패: joinCode={}", joinCode, ex);
+                });
+    }
+
+    public void triggerEarlyFinishIfAllFailed(String joinCode, BlockStackingGame game) {
+        if (!game.isAllPlayersFailed()) {
+            return;
+        }
+        final EarlyFinishTrigger trigger = earlyFinishTriggers.get(joinCode);
+        if (trigger == null || trigger.isCompleted()) {
+            return;
+        }
+        log.info("전원 실패 — 조기 종료 트리거: joinCode={}", joinCode);
+        trigger.complete();
     }
 
     private Runnable step(BlockStackingGame game, Room room, BlockStackingGameStep gameStep) {
@@ -49,21 +70,24 @@ public class BlockStackingFlowOrchestrator {
         };
     }
 
-    private Runnable startPlay(BlockStackingGame game, Room room) {
+    private Runnable startPlay(BlockStackingGame game, Room room, EarlyFinishTrigger trigger) {
         return () -> {
+            final String joinCode = room.getJoinCode().getValue();
+            earlyFinishTriggers.put(joinCode, trigger);
             START_PLAY.execute(game, room);
             final Instant playingEndTime = Instant.now().plus(timing.playing());
             try {
                 notifier.notifyPlayingStarted(room, playingEndTime);
             } catch (Exception e) {
-                log.warn("BlockStacking PLAYING 알림 실패: joinCode={}", room.getJoinCode().getValue(), e);
+                log.warn("BlockStacking PLAYING 알림 실패: joinCode={}", joinCode, e);
             }
         };
     }
 
     private Runnable finishGame(BlockStackingGame game, Room room) {
+        final String joinCode = room.getJoinCode().getValue();
         return () -> {
-            final String joinCode = room.getJoinCode().getValue();
+            earlyFinishTriggers.remove(joinCode);
             FINISH_GAME.execute(game, room);
             try {
                 notifier.notifyStateChanged(game, room);

--- a/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
@@ -46,6 +46,17 @@ public class BlockStackingService implements MiniGameService {
         }
     }
 
+    public void recordFailure(String joinCode, String playerName) {
+        log.debug("블록 쌓기 실패 처리 시작: joinCode={}, playerName={}", joinCode, playerName);
+
+        final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
+        final BlockStackingGame game = getGame(room);
+        final Player player = game.findPlayerByName(new PlayerName(playerName));
+
+        game.recordFailure(player);
+        flowOrchestrator.triggerEarlyFinishIfAllFailed(joinCode, game);
+    }
+
     @Override
     public MiniGameType getMiniGameType() {
         return MiniGameType.BLOCK_STACKING;

--- a/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
@@ -37,8 +37,8 @@ public class BlockStackingService implements MiniGameService {
                 joinCode, playerName, floor);
 
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
-        final BlockStackingGame game = (BlockStackingGame) room.findMiniGame(MiniGameType.BLOCK_STACKING);
-        final Player player = game.findPlayerByName(new PlayerName(playerName));
+        final BlockStackingGame game = getGame(room);
+        final Player player = findPlayer(game, playerName);
 
         final boolean updated = game.recordProgress(player, floor, movingBlockX, stackTopX, stackTopWidth);
         if (updated) {
@@ -51,7 +51,7 @@ public class BlockStackingService implements MiniGameService {
 
         final Room room = roomQueryService.getByJoinCode(new JoinCode(joinCode));
         final BlockStackingGame game = getGame(room);
-        final Player player = game.findPlayerByName(new PlayerName(playerName));
+        final Player player = findPlayer(game, playerName);
 
         final boolean recorded = game.recordFailure(player);
         if (recorded) {
@@ -66,5 +66,9 @@ public class BlockStackingService implements MiniGameService {
 
     private BlockStackingGame getGame(Room room) {
         return (BlockStackingGame) room.findMiniGame(MiniGameType.BLOCK_STACKING);
+    }
+
+    private Player findPlayer(BlockStackingGame game, String playerName) {
+        return game.findPlayerByName(new PlayerName(playerName));
     }
 }

--- a/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/application/BlockStackingService.java
@@ -53,8 +53,10 @@ public class BlockStackingService implements MiniGameService {
         final BlockStackingGame game = getGame(room);
         final Player player = game.findPlayerByName(new PlayerName(playerName));
 
-        game.recordFailure(player);
-        flowOrchestrator.triggerEarlyFinishIfAllFailed(joinCode, game);
+        final boolean recorded = game.recordFailure(player);
+        if (recorded) {
+            flowOrchestrator.triggerEarlyFinishIfAllFailed(joinCode, game);
+        }
     }
 
     @Override

--- a/backend/src/main/java/coffeeshout/blockstacking/config/BlockStackingTimingProperties.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/config/BlockStackingTimingProperties.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "block-stacking.timing")
 public record BlockStackingTimingProperties(
         @NotNull @DurationMin(nanos = 1) Duration prepare,
-        @NotNull @DurationMin(nanos = 1) Duration playing
+        @NotNull @DurationMin(nanos = 1) Duration playing,
+        @NotNull @DurationMin(nanos = 1) Duration allFailedDelay
 ) {
 }

--- a/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingGame.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingGame.java
@@ -8,7 +8,6 @@ import coffeeshout.room.domain.Playable;
 import coffeeshout.room.domain.player.Player;
 import coffeeshout.room.domain.player.PlayerName;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,20 +20,16 @@ import lombok.extern.slf4j.Slf4j;
 public class BlockStackingGame implements Playable {
 
     private volatile BlockStackingGameState state;
-    private Map<Player, BlockStackingPlayerProgress> playerProgresses;
+    private final ConcurrentHashMap<Player, BlockStackingPlayerProgress> playerProgresses = new ConcurrentHashMap<>();
 
     public BlockStackingGame() {
         this.state = BlockStackingGameState.READY;
-        this.playerProgresses = new ConcurrentHashMap<>();
     }
 
     @Override
     public void setUp(List<Player> players) {
-        this.playerProgresses = players.stream()
-                .collect(Collectors.toConcurrentMap(
-                        p -> p,
-                        p -> BlockStackingPlayerProgress.initial(p.getName())
-                ));
+        playerProgresses.clear();
+        players.forEach(p -> playerProgresses.put(p, BlockStackingPlayerProgress.initial(p.getName())));
     }
 
     public void prepare() {
@@ -76,6 +71,13 @@ public class BlockStackingGame implements Playable {
             );
         }
 
+        if (progress.failed()) {
+            log.warn("[{}] 이미 실패한 플레이어의 진행 이벤트 수신 — 무시: player={}",
+                    BlockStackingGameErrorCode.INVALID_PROGRESS.getCode(),
+                    player.getName().value());
+            return false;
+        }
+
         if (!isValidFloorSequence(floor, progress.currentFloor())) {
             log.warn("[{}] 비연속적 층수 수신 — 무시: player={}, expected={}, received={}",
                     BlockStackingGameErrorCode.INVALID_PROGRESS.getCode(),
@@ -93,6 +95,41 @@ public class BlockStackingGame implements Playable {
 
         playerProgresses.put(player, progress.advanceTo(floor));
         return true;
+    }
+
+    /**
+     * 플레이어의 실패를 기록한다.
+     *
+     * @return 실패 상태로 전환됐으면 true, 이미 실패한 상태였으면 false
+     * @throws BusinessException 게임이 PLAYING 상태가 아닐 때, 또는 등록되지 않은 플레이어일 때
+     */
+    public synchronized boolean recordFailure(Player player) {
+        if (state != BlockStackingGameState.PLAYING) {
+            throw new BusinessException(
+                    BlockStackingGameErrorCode.NOT_PLAYING_STATE,
+                    "현재 게임이 진행중인 상태가 아닙니다. state=" + state
+            );
+        }
+
+        final BlockStackingPlayerProgress progress = playerProgresses.get(player);
+        if (progress == null) {
+            throw new BusinessException(
+                    BlockStackingGameErrorCode.PLAYER_NOT_FOUND,
+                    "등록되지 않은 플레이어입니다: " + player.getName().value()
+            );
+        }
+
+        if (progress.failed()) {
+            return false;
+        }
+        playerProgresses.put(player, progress.fail());
+        log.info("플레이어 실패 기록: player={}, floor={}", player.getName().value(), progress.currentFloor());
+        return true;
+    }
+
+    public boolean isAllPlayersFailed() {
+        return !playerProgresses.isEmpty()
+                && playerProgresses.values().stream().allMatch(BlockStackingPlayerProgress::failed);
     }
 
     public List<BlockStackingPlayerRankInfo> getRanking() {

--- a/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
@@ -19,7 +19,7 @@ public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloo
             throw new IllegalArgumentException(
                     "floor는 currentFloor(" + currentFloor + ") 이상이어야 합니다: " + floor);
         }
-        return new BlockStackingPlayerProgress(playerName, floor, false);
+        return new BlockStackingPlayerProgress(playerName, floor, failed);
     }
 
     public BlockStackingPlayerProgress fail() {

--- a/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
@@ -2,7 +2,7 @@ package coffeeshout.blockstacking.domain;
 
 import coffeeshout.room.domain.player.PlayerName;
 
-public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloor) {
+public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloor, boolean failed) {
 
     public BlockStackingPlayerProgress {
         if (currentFloor < 0) {
@@ -11,7 +11,7 @@ public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloo
     }
 
     public static BlockStackingPlayerProgress initial(PlayerName playerName) {
-        return new BlockStackingPlayerProgress(playerName, 0);
+        return new BlockStackingPlayerProgress(playerName, 0, false);
     }
 
     public BlockStackingPlayerProgress advanceTo(int floor) {
@@ -19,6 +19,10 @@ public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloo
             throw new IllegalArgumentException(
                     "floor는 currentFloor(" + currentFloor + ") 이상이어야 합니다: " + floor);
         }
-        return new BlockStackingPlayerProgress(playerName, floor);
+        return new BlockStackingPlayerProgress(playerName, floor, false);
+    }
+
+    public BlockStackingPlayerProgress fail() {
+        return new BlockStackingPlayerProgress(playerName, currentFloor, true);
     }
 }

--- a/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgress.java
@@ -19,7 +19,7 @@ public record BlockStackingPlayerProgress(PlayerName playerName, int currentFloo
             throw new IllegalArgumentException(
                     "floor는 currentFloor(" + currentFloor + ") 이상이어야 합니다: " + floor);
         }
-        return new BlockStackingPlayerProgress(playerName, floor, failed);
+        return new BlockStackingPlayerProgress(playerName, floor, this.failed);
     }
 
     public BlockStackingPlayerProgress fail() {

--- a/backend/src/main/java/coffeeshout/blockstacking/domain/event/BlockStackingFailEvent.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/domain/event/BlockStackingFailEvent.java
@@ -1,0 +1,27 @@
+package coffeeshout.blockstacking.domain.event;
+
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.trace.TraceInfo;
+import coffeeshout.global.trace.TraceInfoExtractor;
+import coffeeshout.global.trace.Traceable;
+import java.time.Instant;
+import java.util.UUID;
+
+public record BlockStackingFailEvent(
+        String eventId,
+        String joinCode,
+        String playerName,
+        Instant timestamp,
+        TraceInfo traceInfo
+) implements BaseEvent, Traceable {
+
+    public static BlockStackingFailEvent of(String joinCode, String playerName) {
+        return new BlockStackingFailEvent(
+                UUID.randomUUID().toString(),
+                joinCode,
+                playerName,
+                Instant.now(),
+                TraceInfoExtractor.extract()
+        );
+    }
+}

--- a/backend/src/main/java/coffeeshout/blockstacking/infra/messaging/consumer/BlockStackingFailEventConsumer.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/infra/messaging/consumer/BlockStackingFailEventConsumer.java
@@ -1,0 +1,33 @@
+package coffeeshout.blockstacking.infra.messaging.consumer;
+
+import coffeeshout.blockstacking.application.BlockStackingService;
+import coffeeshout.blockstacking.domain.event.BlockStackingFailEvent;
+import coffeeshout.global.exception.custom.BusinessException;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BlockStackingFailEventConsumer implements Consumer<BlockStackingFailEvent> {
+
+    private final BlockStackingService blockStackingService;
+
+    @Override
+    public void accept(BlockStackingFailEvent event) {
+        try {
+            blockStackingService.recordFailure(event.joinCode(), event.playerName());
+        } catch (BusinessException e) {
+            log.warn(
+                    "블록 쌓기 실패 이벤트 처리 중 비즈니스 예외 발생: joinCode={}, playerName={}",
+                    event.joinCode(), event.playerName(), e);
+        } catch (Exception e) {
+            log.error(
+                    "블록 쌓기 실패 이벤트 처리 중 오류 발생: joinCode={}, playerName={}",
+                    event.joinCode(), event.playerName(), e);
+            throw e;
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/blockstacking/ui/BlockStackingWebSocketController.java
+++ b/backend/src/main/java/coffeeshout/blockstacking/ui/BlockStackingWebSocketController.java
@@ -1,6 +1,7 @@
 package coffeeshout.blockstacking.ui;
 
 import coffeeshout.blockstacking.domain.event.BlockStackingCommandEvent;
+import coffeeshout.blockstacking.domain.event.BlockStackingFailEvent;
 import coffeeshout.blockstacking.ui.request.BlockStackingProgressRequest;
 import coffeeshout.global.redis.stream.StreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
@@ -49,5 +50,25 @@ public class BlockStackingWebSocketController {
 
         log.debug("블록 쌓기 진행 이벤트 발행: joinCode={}, playerName={}, floor={}, eventId = {}",
                 joinCode, authenticatedPlayerName, request.floor(), event.eventId());
+    }
+
+    @MessageMapping("/room/{joinCode}/block-stacking/fail")
+    @Operation(
+            summary = "블록 쌓기 실패 이벤트 전송",
+            description = """
+                    플레이어가 블록을 쌓지 못하고 실패했을 때 서버로 전송하는 웹소켓 요청입니다.
+                    모든 플레이어가 실패하면 남은 플레이 시간과 무관하게 2초 뒤 결과 화면으로 전환됩니다.
+                    """
+    )
+    public void recordFail(
+            @DestinationVariable String joinCode,
+            Principal principal
+    ) {
+        final String authenticatedPlayerName = PlayerKey.parse(principal.getName()).playerName();
+        final BlockStackingFailEvent event = BlockStackingFailEvent.of(joinCode, authenticatedPlayerName);
+        streamPublisher.publish(StreamKey.BLOCK_STACKING_EVENTS, event);
+
+        log.debug("블록 쌓기 실패 이벤트 발행: joinCode={}, playerName={}, eventId={}",
+                joinCode, authenticatedPlayerName, event.eventId());
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -90,6 +90,7 @@ block-stacking:
   timing:
     prepare: 3000ms
     playing: 20000ms
+    all-failed-delay: 2000ms
   scheduler:
     pool-size: 2
 

--- a/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingGameTest.java
+++ b/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingGameTest.java
@@ -173,6 +173,19 @@ class BlockStackingGameTest {
         }
 
         @Test
+        void 이미_실패한_플레이어의_진행_이벤트_수신_시_false를_반환하고_floor가_갱신되지_않는다() {
+            game.recordProgress(꾹이, 1, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
+            game.recordFailure(꾹이);
+
+            final boolean recorded = game.recordProgress(꾹이, 2, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(recorded).isFalse();
+                softly.assertThat(game.getScores().get(꾹이).getValue()).isEqualTo(1L);
+            });
+        }
+
+        @Test
         void 각_플레이어는_독립적으로_floor를_쌓는다() {
             game.recordProgress(꾹이, 1, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
             game.recordProgress(꾹이, 2, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
@@ -236,6 +249,100 @@ class BlockStackingGameTest {
                     () -> game.findPlayerByName(new PlayerName("없는플레이어")),
                     BlockStackingGameErrorCode.PLAYER_NOT_FOUND
             );
+        }
+    }
+
+    @Nested
+    class 실패_기록_테스트 {
+
+        @BeforeEach
+        void 게임_시작() {
+            game.prepare();
+            game.startPlay();
+        }
+
+        @Test
+        void 플레이어_실패_기록_시_해당_플레이어의_failed가_true가_된다() {
+            final boolean recorded = game.recordFailure(꾹이);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(recorded).isTrue();
+                softly.assertThat(game.getPlayerProgresses().get(꾹이).failed()).isTrue();
+            });
+        }
+
+        @Test
+        void 실패_기록_시_쌓은_층수는_유지된다() {
+            game.recordProgress(꾹이, 1, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
+            game.recordProgress(꾹이, 2, MOVING_BLOCK_X, STACK_TOP_X, STACK_TOP_WIDTH);
+
+            game.recordFailure(꾹이);
+
+            assertThat(game.getScores().get(꾹이).getValue()).isEqualTo(2L);
+        }
+
+        @Test
+        void 이미_실패한_플레이어에게_중복_실패_기록_시_false를_반환하고_상태가_유지된다() {
+            game.recordFailure(꾹이);
+            final boolean second = game.recordFailure(꾹이);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(second).isFalse();
+                softly.assertThat(game.getPlayerProgresses().get(꾹이).failed()).isTrue();
+            });
+        }
+
+        @Test
+        void PLAYING_상태가_아닐_때_recordFailure_호출_시_예외를_던진다() {
+            game.finish();
+
+            assertCoffeeShoutException(
+                    () -> game.recordFailure(꾹이),
+                    BlockStackingGameErrorCode.NOT_PLAYING_STATE
+            );
+        }
+
+        @Test
+        void 등록되지_않은_플레이어의_실패_기록_시_예외를_던진다() {
+            final Player 미등록플레이어 = PlayerFixture.호스트유령();
+
+            assertCoffeeShoutException(
+                    () -> game.recordFailure(미등록플레이어),
+                    BlockStackingGameErrorCode.PLAYER_NOT_FOUND
+            );
+        }
+    }
+
+    @Nested
+    class 전원_실패_여부_테스트 {
+
+        @BeforeEach
+        void 게임_시작() {
+            game.prepare();
+            game.startPlay();
+        }
+
+        @Test
+        void 아무도_실패하지_않은_경우_false를_반환한다() {
+            assertThat(game.isAllPlayersFailed()).isFalse();
+        }
+
+        @Test
+        void 일부만_실패한_경우_false를_반환한다() {
+            game.recordFailure(꾹이);
+            game.recordFailure(루키);
+
+            assertThat(game.isAllPlayersFailed()).isFalse();
+        }
+
+        @Test
+        void 모든_플레이어가_실패하면_true를_반환한다() {
+            game.recordFailure(꾹이);
+            game.recordFailure(루키);
+            game.recordFailure(엠제이);
+            game.recordFailure(한스);
+
+            assertThat(game.isAllPlayersFailed()).isTrue();
         }
     }
 

--- a/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgressTest.java
+++ b/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgressTest.java
@@ -66,12 +66,12 @@ class BlockStackingPlayerProgressTest {
         }
 
         @Test
-        void advanceTo_호출_후_failed는_false이다() {
+        void 실패_상태에서_advanceTo_호출_후_failed_상태가_유지된다() {
             final BlockStackingPlayerProgress progress = BlockStackingPlayerProgress.initial(플레이어명)
                     .fail()
                     .advanceTo(1);
 
-            assertThat(progress.failed()).isFalse();
+            assertThat(progress.failed()).isTrue();
         }
     }
 

--- a/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgressTest.java
+++ b/backend/src/test/java/coffeeshout/blockstacking/domain/BlockStackingPlayerProgressTest.java
@@ -21,7 +21,57 @@ class BlockStackingPlayerProgressTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(progress.playerName()).isEqualTo(플레이어명);
                 softly.assertThat(progress.currentFloor()).isZero();
+                softly.assertThat(progress.failed()).isFalse();
             });
+        }
+    }
+
+    @Nested
+    class 실패_처리_테스트 {
+
+        @Test
+        void fail_호출_시_새_인스턴스를_반환한다() {
+            final BlockStackingPlayerProgress original = BlockStackingPlayerProgress.initial(플레이어명);
+
+            final BlockStackingPlayerProgress failed = original.fail();
+
+            assertThat(failed).isNotSameAs(original);
+        }
+
+        @Test
+        void fail_호출_후_failed가_true이다() {
+            final BlockStackingPlayerProgress progress = BlockStackingPlayerProgress.initial(플레이어명).fail();
+
+            assertThat(progress.failed()).isTrue();
+        }
+
+        @Test
+        void fail_호출_후_playerName과_currentFloor는_유지된다() {
+            final BlockStackingPlayerProgress original = BlockStackingPlayerProgress.initial(플레이어명).advanceTo(3);
+
+            final BlockStackingPlayerProgress failed = original.fail();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(failed.playerName()).isEqualTo(플레이어명);
+                softly.assertThat(failed.currentFloor()).isEqualTo(3);
+            });
+        }
+
+        @Test
+        void fail_호출_후_원본_인스턴스의_failed는_변경되지_않는다() {
+            final BlockStackingPlayerProgress original = BlockStackingPlayerProgress.initial(플레이어명);
+            original.fail();
+
+            assertThat(original.failed()).isFalse();
+        }
+
+        @Test
+        void advanceTo_호출_후_failed는_false이다() {
+            final BlockStackingPlayerProgress progress = BlockStackingPlayerProgress.initial(플레이어명)
+                    .fail()
+                    .advanceTo(1);
+
+            assertThat(progress.failed()).isFalse();
         }
     }
 

--- a/backend/src/test/java/coffeeshout/bombrelay/application/BombRelayGameProgressHandlerTest.java
+++ b/backend/src/test/java/coffeeshout/bombrelay/application/BombRelayGameProgressHandlerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import coffeeshout.bombrelay.domain.BombRelayGame;
-import coffeeshout.bombrelay.domain.BombRelayGameState;
 import coffeeshout.bombrelay.domain.KoreanCharUtils;
 import coffeeshout.bombrelay.domain.event.BombRelayProgressEvent;
 import coffeeshout.bombrelay.domain.event.WordResultEvent;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1171

# 🚀 작업 내용

1. 블록 쌓기 게임 시 사용자 모두 실패 할 경우 해당 타임아웃과 관계없이 스코어 보드 화면으로 전환합니다. 

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모든 플레이어가 실패를 보고하면 설정된 지연(기본 2초) 내에 게임이 조기 종료됩니다.
  * 플레이어 실패를 서버에 보고하는 메시지 핸들러와 실패 이벤트 전파가 추가되었습니다.
  * 조기 종료를 제어하는 구성 옵션이 추가되었습니다.

* **개선 사항**
  * 이미 실패한 플레이어의 진행은 더 이상 갱신되지 않습니다.
  * 전체 실패 판정 로직으로 모든 플레이어 실패 시 즉시 반영됩니다.

* **문서**
  * 블록 스태킹 게임 설계 ADR에 조기 종료 흐름과 관련 세부사항이 반영되어 업데이트되었습니다.

* **테스트**
  * 실패 처리 및 전체 실패 판정에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->