### PR TITLE
[fix] 앱 종료 시 delayRemovalScheduler 타임아웃 개선

### DIFF
--- a/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
+++ b/backend/src/main/java/coffeeshout/global/config/DelayRemovalSchedulerConfig.java
@@ -28,6 +28,7 @@ public class DelayRemovalSchedulerConfig {
         scheduler.setAwaitTerminationSeconds(30);
 
         scheduler.initialize();
+        scheduler.getScheduledThreadPoolExecutor().setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         return scheduler;
     }
 }


### PR DESCRIPTION
## Summary

- `ThreadPoolTaskScheduler`의 `setExecuteExistingDelayedTasksAfterShutdownPolicy(false)` 설정 추가
- 앱 종료 시 큐에 대기 중인 지연 태스크(방/플레이어 지연 삭제)가 즉시 취소되어 shutdown 지연 제거

## 원인

`setWaitForTasksToCompleteOnShutdown(true)` 설정은 내부적으로 `ScheduledThreadPoolExecutor.shutdown()`을 호출하는데, 이 메서드는 미래에 실행될 delayed task를 취소하지 않고 만료 시각까지 기다린다. 결과적으로 `awaitTerminationSeconds(30)` 제한에 걸려 종료 시 WARN 로그가 발생했다.

## 안전성 검토

- `MemoryRoomRepository`: 인메모리(JVM)이므로 앱 종료 시 어차피 소멸
- Redis recovery stream/id-map 키: Lua 스크립트에서 `streamTtlSeconds` / `dedupTtlSeconds` TTL이 설정되므로 `cleanup()` 미실행 시에도 자동 만료

## Test plan

- [ ] 앱 정상 기동 확인
- [ ] 앱 종료 시 WARN 로그 미발생 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 시스템 종료 시 스케줄러의 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->