### PR TITLE
fix: DashboardService Clock 타임존 불일치로 인한 월말 테스트 실패 수정

### DIFF
--- a/backend/src/test/java/coffeeshout/global/config/ServiceTestConfig.java
+++ b/backend/src/test/java/coffeeshout/global/config/ServiceTestConfig.java
@@ -1,6 +1,7 @@
 package coffeeshout.global.config;
 
 import coffeeshout.global.flow.FlowScheduler;
+import java.time.Clock;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -67,5 +68,11 @@ public class ServiceTestConfig {
     @Primary
     public ApplicationEventPublisher mockEventPublisher() {
         return Mockito.mock(ApplicationEventPublisher.class);
+    }
+
+    @Bean
+    @Primary
+    public Clock testClock() {
+        return Clock.systemDefaultZone();
     }
 }


### PR DESCRIPTION
## Summary

- `DashboardService`는 `ClockConfig`의 KST `Clock`으로 이번달 범위를 계산하지만, `RouletteResultEntity.createdAt`은 `LocalDateTime.now()`(JVM 기본 TZ)를 사용
- CI 환경(UTC JVM)에서 월말 9시간 동안(`00:00~08:59 KST`) 엔티티는 이전 달 날짜로 저장되어 쿼리 범위를 벗어남 → `getLowestProbabilityWinner()` 테스트 NPE

## Changes

- `ServiceTestConfig`에 `@Primary Clock.systemDefaultZone()` 빈 등록
- 테스트에서 서비스(Clock)와 엔티티(`LocalDateTime.now()`) 모두 JVM 기본 TZ를 참조해 일관성 확보

## Test plan

- [ ] `DashboardServiceTest$GetLowestProbabilityWinnerTest` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)