### PR TITLE
[fix] 사다리게임 drawing 종료 직전 클릭 씹힘 방지 grace period 추가

### DIFF
--- a/backend/.claude/skills/create-pr/SKILL.md
+++ b/backend/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: create-pr
+description: PR 템플릿을 읽어 GitHub Pull Request를 생성한다.
+argument-hint: "[PR 제목 (선택)] [--base=브랜치명 (기본: be/dev)]"
+allowed-tools: Read, Bash, Glob
+---
+
+# create-pr
+
+## 사전 작업
+
+1. `.github/pull_request_template.md`를 Read로 읽어 템플릿 구조를 파악한다.
+2. `git log be/dev..HEAD --oneline`으로 이번 브랜치의 커밋 목록을 확인한다.
+3. `git diff be/dev...HEAD --stat`으로 변경된 파일 목록을 확인한다.
+
+## PR 제목 규칙
+
+- 형식: `[type] 한국어 설명`
+- type 종류: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
+- `$ARGUMENTS`에 제목이 주어지면 그대로 사용, 없으면 커밋 내용을 분석해 자동 생성
+
+## 템플릿 작성 규칙
+
+`.github/pull_request_template.md`의 섹션을 그대로 유지하고 아래 기준으로 채운다.
+
+| 섹션         | 작성 기준                                         |
+|------------|-----------------------------------------------|
+| ✅ 체크리스트    | `--base` 브랜치 확인 후 `[x]`로 체크                   |
+| 🔥 연관 이슈   | `$ARGUMENTS`에 이슈 번호가 있으면 `close #N`, 없으면 `없음` |
+| 🚀 작업 내용   | 변경된 파일·커밋을 분석해 번호 목록으로 작성                     |
+| 💬 리뷰 중점사항 | 리뷰어가 특히 확인해야 할 설계 결정, 트레이드오프, 주의 사항           |
+
+## 실행
+
+```bash
+gh pr create \
+  --title "[type] 제목" \
+  --base be/dev \
+  --body "$(cat <<'EOF'
+<템플릿 채운 내용>
+EOF
+)"
+```
+
+완료 후 PR URL을 사용자에게 출력한다.

--- a/backend/.claude/skills/create-pr/SKILL.md
+++ b/backend/.claude/skills/create-pr/SKILL.md
@@ -19,6 +19,23 @@ allowed-tools: Read, Bash, Glob
 - type 종류: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
 - `$ARGUMENTS`에 제목이 주어지면 그대로 사용, 없으면 커밋 내용을 분석해 자동 생성
 
+## 라벨 & Assignee
+
+**라벨** — type에 따라 자동 선택 (중복 가능):
+
+| type | 라벨 |
+|------|------|
+| feat | `✨feat`, `BE` 또는 `FE` |
+| fix | `🐞bug`, `BE` 또는 `FE` |
+| refactor | `🛠️refactor`, `BE` 또는 `FE` |
+| chore | `⚙️chore` |
+| docs | `📝docs` |
+| test | `🧪 test` |
+
+우선순위 라벨(`p-*`)은 `$ARGUMENTS`에 명시된 경우에만 추가한다.
+
+**Assignee** — `gh api user --jq '.login'`으로 현재 git 사용자 GitHub 로그인을 조회해 자동 지정한다.
+
 ## 템플릿 작성 규칙
 
 `.github/pull_request_template.md`의 섹션을 그대로 유지하고 아래 기준으로 채운다.
@@ -33,9 +50,14 @@ allowed-tools: Read, Bash, Glob
 ## 실행
 
 ```bash
+# assignee 조회
+gh api user --jq '.login'
+
 gh pr create \
   --title "[type] 제목" \
   --base be/dev \
+  --label "라벨1,라벨2" \
+  --assignee "$(gh api user --jq '.login')" \
   --body "$(cat <<'EOF'
 <템플릿 채운 내용>
 EOF

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -30,6 +30,16 @@ grep "^startRound	" tags                 # 메서드 정의
 결과 형식: `심볼명\t파일경로\t패턴\t필드(line:N)` → 해당 파일을 line:N 기준으로 Read한다.
 `tags`가 없거나 오래됐으면 `./gradlew generateCtags` 또는 `./gradlew compileJava`로 재생성한다.
 
+## PR 작성 규칙
+
+PR 생성 시 `/create-pr`를 사용한다. 직접 `gh pr create`를 호출할 때도 아래 규칙을 따른다.
+
+- **제목 형식**: `[type] 한국어 설명` (예: `[fix] 사다리게임 grace period 추가`)
+  - type: `feat` / `fix` / `refactor` / `chore` / `docs` / `test`
+- **본문**: `.github/pull_request_template.md` 섹션을 반드시 유지하고 채운다
+- **base 브랜치**: 기본 `be/dev`. 프론트엔드 작업은 `fe/dev`
+- **브랜치 네이밍**: `be/{type}/{이슈번호}-{설명}` (이슈 없으면 설명만)
+
 ## 작업 규칙
 
 - 프로덕션 코드(`src/main/java/`) 작성 또는 수정 완료 시 `/write-tests`를 실행한다

--- a/backend/src/main/java/coffeeshout/laddergame/application/LadderFlowOrchestrator.java
+++ b/backend/src/main/java/coffeeshout/laddergame/application/LadderFlowOrchestrator.java
@@ -29,7 +29,7 @@ public class LadderFlowOrchestrator {
         ladderFlowScheduler.schedule(description(room), Duration.ZERO)
                 .andThen(prepare(game, room), timing.description())
                 .andThen(drawing(game, room), timing.prepare())
-                .andThen(result(game, room), timing.drawing())
+                .andThen(result(game, room), timing.drawing().plus(timing.drawingGracePeriod()))
                 .andThen(done(game, room), timing.result())
                 .onError(ex -> log.error("사다리게임 flow 실패: joinCode={}", joinCode, ex));
     }

--- a/backend/src/main/java/coffeeshout/laddergame/config/LadderTimingProperties.java
+++ b/backend/src/main/java/coffeeshout/laddergame/config/LadderTimingProperties.java
@@ -12,6 +12,7 @@ public record LadderTimingProperties(
         @NotNull @DurationMin(nanos = 1) Duration description,
         @NotNull @DurationMin(nanos = 1) Duration prepare,
         @NotNull @DurationMin(nanos = 1) Duration drawing,
+        @NotNull @DurationMin(nanos = 1) Duration drawingGracePeriod,
         @NotNull @DurationMin(nanos = 1) Duration result
 ) {
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -99,6 +99,7 @@ ladder:
     description: 4000ms
     prepare: 2000ms
     drawing: 8000ms
+    drawing-grace-period: 300ms
     result: 5000ms
   scheduler:
     pool-size: 2

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -84,6 +84,7 @@ ladder:
     description: 500ms
     prepare: 500ms
     drawing: 1000ms
+    drawing-grace-period: 300ms
     result: 500ms
 
 card-game:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. `LadderTimingProperties`에 `drawingGracePeriod` 필드 추가
2. `LadderFlowOrchestrator`에서 `result()` 전환 딜레이를 `drawing + drawingGracePeriod`로 변경
3. `application.yml` / `application-test.yml`에 `drawing-grace-period: 300ms` 추가

프론트에 전달하는 `drawingEndTime`은 기존 `timing.drawing()` 기준 그대로 유지하여 UI 타이머와 서버 수락 마감 시각이 불일치하지 않는다.

# 💬 리뷰 중점사항

- `drawingGracePeriod` 기본값 300ms가 적절한지 (네트워크 RTT + 처리 지연 기준)
- grace period 동안 DRAWING 상태가 유지되므로 result 전환 직전 클릭은 정상 처리됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기타 개선 사항**
  * 드로잉 단계와 결과 단계 사이 대기 시간을 300ms 연장해 게임 흐름 안정성을 향상했습니다.
  * 운영 및 테스트 설정에 새 타이밍 구성 옵션이 추가되어 동일한 동작을 반영합니다.

* **문서**
  * PR 작성 및 워크플로우 관련 가이드가 추가되어 일관된 PR 생성 절차를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->