### PR TITLE
[feat] 약관 동의 기능 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/user/application/service/AuthTokenService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/AuthTokenService.java
@@ -3,6 +3,7 @@ package coffeeshout.user.application.service;
 import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.user.config.JwtProperties;
 import coffeeshout.user.domain.AuthenticatedUser;
+import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.repository.OAuthCodeRepository;
@@ -24,14 +25,14 @@ public class AuthTokenService {
     private final OAuthCodeRepository oAuthCodeRepository;
     private final JwtProperties jwtProperties;
 
-    public String issueCode(User user) {
-        final TokenPair tokens = issue(user);
+    public String issueCode(LoginResult loginResult) {
+        final TokenPair tokens = issue(loginResult.user());
         final String code = UUID.randomUUID().toString();
-        oAuthCodeRepository.save(code, tokens, OAUTH_CODE_TTL_SECONDS);
+        oAuthCodeRepository.save(code, tokens, loginResult.isNewUser(), OAUTH_CODE_TTL_SECONDS);
         return code;
     }
 
-    public TokenPair exchangeCode(String code) {
+    public OAuthCodeEntry exchangeCode(String code) {
         return oAuthCodeRepository.findAndDelete(code)
                 .orElseThrow(() -> new BusinessException(
                         UserErrorCode.OAUTH_CODE_NOT_FOUND, "유효하지 않거나 만료된 인증 코드입니다."));

--- a/backend/src/main/java/coffeeshout/user/application/service/LoginResult.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/LoginResult.java
@@ -1,0 +1,6 @@
+package coffeeshout.user.application.service;
+
+import coffeeshout.user.domain.User;
+
+public record LoginResult(User user, boolean isNewUser) {
+}

--- a/backend/src/main/java/coffeeshout/user/application/service/TermsService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/TermsService.java
@@ -1,0 +1,23 @@
+package coffeeshout.user.application.service;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.user.exception.UserErrorCode;
+import coffeeshout.user.infra.persistence.UserEntity;
+import coffeeshout.user.infra.persistence.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermsService {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Transactional
+    public void agreeTerms(Long userId) {
+        final UserEntity userEntity = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        userEntity.agreeTerms();
+    }
+}

--- a/backend/src/main/java/coffeeshout/user/application/service/UserRegistrationService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserRegistrationService.java
@@ -28,18 +28,19 @@ public class UserRegistrationService {
     private final NameValidator nameValidator;
     private final NicknameDefaultGenerator nicknameDefaultGenerator;
 
-    public User registerOrLogin(OAuthProvider provider, String providerUserId, String email, String suggestedNickname) {
+    public LoginResult registerOrLogin(OAuthProvider provider, String providerUserId, String email, String suggestedNickname) {
         final Optional<User> existing = userRepository.findByProviderAndProviderUserId(
                 provider.getRegistrationId(), providerUserId);
         if (existing.isPresent()) {
             log.debug("기존 회원 로그인: provider={}, providerUserId={}", provider, providerUserId);
-            return existing.get();
+            return new LoginResult(existing.get(), false);
         }
 
         final UserNickname nickname = resolveNickname(suggestedNickname);
         final OAuthAccount oAuthAccount = new OAuthAccount(provider, providerUserId, email);
+        final User newUser = saveNewUserWithRetry(nickname, oAuthAccount, provider);
 
-        return saveNewUserWithRetry(nickname, oAuthAccount, provider);
+        return new LoginResult(newUser, true);
     }
 
     private User saveNewUserWithRetry(UserNickname nickname, OAuthAccount oAuthAccount, OAuthProvider provider) {

--- a/backend/src/main/java/coffeeshout/user/domain/OAuthCodeEntry.java
+++ b/backend/src/main/java/coffeeshout/user/domain/OAuthCodeEntry.java
@@ -1,0 +1,4 @@
+package coffeeshout.user.domain;
+
+public record OAuthCodeEntry(TokenPair tokenPair, boolean isNewUser) {
+}

--- a/backend/src/main/java/coffeeshout/user/domain/repository/OAuthCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/user/domain/repository/OAuthCodeRepository.java
@@ -1,11 +1,12 @@
 package coffeeshout.user.domain.repository;
 
+import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
 import java.util.Optional;
 
 public interface OAuthCodeRepository {
 
-    void save(String code, TokenPair tokens, long ttlSeconds);
+    void save(String code, TokenPair tokens, boolean isNewUser, long ttlSeconds);
 
-    Optional<TokenPair> findAndDelete(String code);
+    Optional<OAuthCodeEntry> findAndDelete(String code);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -38,6 +38,9 @@ public class UserEntity {
     @Column(nullable = false)
     private Instant updatedAt;
 
+    @Column(name = "terms_agreed_at")
+    private Instant termsAgreedAt;
+
     public UserEntity(String userCode, String nickname) {
         final Instant now = Instant.now();
         this.userCode = userCode;
@@ -49,6 +52,10 @@ public class UserEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
         this.updatedAt = Instant.now();
+    }
+
+    public void agreeTerms() {
+        this.termsAgreedAt = Instant.now();
     }
 
     public User toDomain(OAuthAccountEntity oAuthAccountEntity) {

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -55,7 +55,9 @@ public class UserEntity {
     }
 
     public void agreeTerms() {
-        this.termsAgreedAt = Instant.now();
+        if (this.termsAgreedAt == null) {
+            this.termsAgreedAt = Instant.now();
+        }
     }
 
     public User toDomain(OAuthAccountEntity oAuthAccountEntity) {

--- a/backend/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/redis/RedisOAuthCodeRepository.java
@@ -1,5 +1,6 @@
 package coffeeshout.user.infra.redis;
 
+import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
 import coffeeshout.user.domain.repository.OAuthCodeRepository;
 import java.util.Optional;
@@ -18,24 +19,24 @@ public class RedisOAuthCodeRepository implements OAuthCodeRepository {
     private final StringRedisTemplate stringRedisTemplate;
 
     @Override
-    public void save(String code, TokenPair tokens, long ttlSeconds) {
-        final String value = tokens.accessToken() + DELIMITER + tokens.refreshToken();
+    public void save(String code, TokenPair tokens, boolean isNewUser, long ttlSeconds) {
+        final String value = tokens.accessToken() + DELIMITER + tokens.refreshToken() + DELIMITER + isNewUser;
         stringRedisTemplate.opsForValue().set(KEY_PREFIX + code, value, ttlSeconds, TimeUnit.SECONDS);
     }
 
     @Override
-    public Optional<TokenPair> findAndDelete(String code) {
+    public Optional<OAuthCodeEntry> findAndDelete(String code) {
         final String key = KEY_PREFIX + code;
         final String value = stringRedisTemplate.opsForValue().getAndDelete(key);
         if (value == null) {
             return Optional.empty();
         }
-        final int delimIdx = value.indexOf(DELIMITER);
-        if (delimIdx < 0) {
+        final String[] parts = value.split("\\|\\|", 3);
+        if (parts.length != 3) {
             return Optional.empty();
         }
-        final String accessToken = value.substring(0, delimIdx);
-        final String refreshToken = value.substring(delimIdx + DELIMITER.length());
-        return Optional.of(new TokenPair(accessToken, refreshToken));
+        final TokenPair tokenPair = new TokenPair(parts[0], parts[1]);
+        final boolean isNewUser = Boolean.parseBoolean(parts[2]);
+        return Optional.of(new OAuthCodeEntry(tokenPair, isNewUser));
     }
 }

--- a/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
@@ -4,6 +4,7 @@ import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.user.application.service.AuthTokenService;
 import coffeeshout.user.config.JwtProperties;
 import coffeeshout.user.domain.AuthenticatedUser;
+import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
 import coffeeshout.user.exception.UserErrorCode;
 import coffeeshout.user.ui.request.ExchangeCodeRequest;
@@ -40,9 +41,9 @@ public class AuthRestController {
             @Valid @RequestBody ExchangeCodeRequest request,
             HttpServletResponse response
     ) {
-        final TokenPair tokens = authTokenService.exchangeCode(request.code());
-        setRefreshTokenCookie(response, tokens.refreshToken());
-        return ResponseEntity.ok(new AuthTokenResponse(tokens.accessToken(), null));
+        final OAuthCodeEntry entry = authTokenService.exchangeCode(request.code());
+        setRefreshTokenCookie(response, entry.tokenPair().refreshToken());
+        return ResponseEntity.ok(new AuthTokenResponse(entry.tokenPair().accessToken(), null, entry.isNewUser()));
     }
 
     @PostMapping("/refresh")
@@ -53,7 +54,7 @@ public class AuthRestController {
         final String refreshToken = extractRefreshTokenCookie(request);
         final TokenPair tokens = authTokenService.rotate(refreshToken);
         setRefreshTokenCookie(response, tokens.refreshToken());
-        return ResponseEntity.ok(new AuthTokenResponse(tokens.accessToken(), null));
+        return ResponseEntity.ok(new AuthTokenResponse(tokens.accessToken(), null, false));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/coffeeshout/user/ui/OAuthSuccessHandler.java
+++ b/backend/src/main/java/coffeeshout/user/ui/OAuthSuccessHandler.java
@@ -1,9 +1,9 @@
 package coffeeshout.user.ui;
 
 import coffeeshout.user.application.service.AuthTokenService;
+import coffeeshout.user.application.service.LoginResult;
 import coffeeshout.user.application.service.UserRegistrationService;
 import coffeeshout.user.domain.OAuthProvider;
-import coffeeshout.user.domain.User;
 import coffeeshout.user.infra.oauth.CustomOAuth2UserService.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,14 +33,14 @@ public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
         final CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         final OAuthProvider provider = OAuthProvider.from(oAuth2User.registrationId());
 
-        final User user = userRegistrationService.registerOrLogin(
+        final LoginResult loginResult = userRegistrationService.registerOrLogin(
                 provider,
                 oAuth2User.providerUserId(),
                 oAuth2User.email(),
                 oAuth2User.nickname()
         );
 
-        final String code = authTokenService.issueCode(user);
+        final String code = authTokenService.issueCode(loginResult);
         response.sendRedirect(frontendRedirectUri + "?code=" + code);
     }
 }

--- a/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
@@ -1,6 +1,7 @@
 package coffeeshout.user.ui;
 
 import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.user.application.service.TermsService;
 import coffeeshout.user.application.service.UserProfileService;
 import coffeeshout.user.application.service.UserStatsService;
 import coffeeshout.user.domain.AuthenticatedUser;
@@ -30,6 +31,7 @@ public class UserRestController {
 
     private final UserProfileService userProfileService;
     private final UserStatsService userStatsService;
+    private final TermsService termsService;
 
     @GetMapping("/me")
     public ResponseEntity<UserMeResponse> getMe(@AuthUser Optional<AuthenticatedUser> authUser) {
@@ -63,6 +65,13 @@ public class UserRestController {
         final AuthenticatedUser user = requireAuthenticated(authUser);
         final UserStats stats = userStatsService.getStats(user.userId());
         return ResponseEntity.ok(UserStatsResponse.from(stats));
+    }
+
+    @PostMapping("/me/terms")
+    public ResponseEntity<Void> agreeTerms(@AuthUser Optional<AuthenticatedUser> authUser) {
+        final AuthenticatedUser user = requireAuthenticated(authUser);
+        termsService.agreeTerms(user.userId());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/me/stats")

--- a/backend/src/main/java/coffeeshout/user/ui/response/AuthTokenResponse.java
+++ b/backend/src/main/java/coffeeshout/user/ui/response/AuthTokenResponse.java
@@ -2,6 +2,7 @@ package coffeeshout.user.ui.response;
 
 public record AuthTokenResponse(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        boolean isNewUser
 ) {
 }

--- a/backend/src/main/resources/db/migration/V19__add_terms_agreed_at_to_user.sql
+++ b/backend/src/main/resources/db/migration/V19__add_terms_agreed_at_to_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE app_user ADD COLUMN terms_agreed_at DATETIME(6) NULL;

--- a/backend/src/test/java/coffeeshout/user/application/service/TermsServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/TermsServiceTest.java
@@ -8,7 +8,6 @@ import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.repository.UserRepository;
 import coffeeshout.user.infra.persistence.UserEntity;
 import coffeeshout.user.infra.persistence.UserJpaRepository;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ class TermsServiceTest extends ServiceTest {
         }
 
         @Test
-        void 약관_동의를_여러_번_호출해도_최신_시각으로_갱신된다() {
+        void 약관_동의를_여러_번_호출해도_최초_동의_시각이_유지된다() {
             termsService.agreeTerms(userId);
             final UserEntity afterFirst = userJpaRepository.findById(userId).orElseThrow();
             final var firstAgreedAt = afterFirst.getTermsAgreedAt();
@@ -53,10 +52,7 @@ class TermsServiceTest extends ServiceTest {
             termsService.agreeTerms(userId);
             final UserEntity afterSecond = userJpaRepository.findById(userId).orElseThrow();
 
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(afterSecond.getTermsAgreedAt()).isNotNull();
-                softly.assertThat(afterSecond.getTermsAgreedAt()).isAfterOrEqualTo(firstAgreedAt);
-            });
+            assertThat(afterSecond.getTermsAgreedAt()).isEqualTo(firstAgreedAt);
         }
     }
 }

--- a/backend/src/test/java/coffeeshout/user/application/service/TermsServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/TermsServiceTest.java
@@ -1,0 +1,62 @@
+package coffeeshout.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.fixture.UserFixture;
+import coffeeshout.global.ServiceTest;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.UserRepository;
+import coffeeshout.user.infra.persistence.UserEntity;
+import coffeeshout.user.infra.persistence.UserJpaRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TermsServiceTest extends ServiceTest {
+
+    @Autowired
+    TermsService termsService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        final User user = userRepository.save(UserFixture.회원_엠제이());
+        userId = user.getId();
+    }
+
+    @Nested
+    class 약관_동의 {
+
+        @Test
+        void 약관_동의_후_termsAgreedAt이_기록된다() {
+            termsService.agreeTerms(userId);
+
+            final UserEntity userEntity = userJpaRepository.findById(userId).orElseThrow();
+            assertThat(userEntity.getTermsAgreedAt()).isNotNull();
+        }
+
+        @Test
+        void 약관_동의를_여러_번_호출해도_최신_시각으로_갱신된다() {
+            termsService.agreeTerms(userId);
+            final UserEntity afterFirst = userJpaRepository.findById(userId).orElseThrow();
+            final var firstAgreedAt = afterFirst.getTermsAgreedAt();
+
+            termsService.agreeTerms(userId);
+            final UserEntity afterSecond = userJpaRepository.findById(userId).orElseThrow();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(afterSecond.getTermsAgreedAt()).isNotNull();
+                softly.assertThat(afterSecond.getTermsAgreedAt()).isAfterOrEqualTo(firstAgreedAt);
+            });
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/user/application/service/UserRegistrationServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserRegistrationServiceTest.java
@@ -3,7 +3,6 @@ package coffeeshout.user.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import coffeeshout.global.ServiceTest;
-import coffeeshout.user.domain.OAuthAccount;
 import coffeeshout.user.domain.OAuthProvider;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserNickname;
@@ -30,8 +29,9 @@ class UserRegistrationServiceTest extends ServiceTest {
 
         @Test
         void 새_User가_생성되고_UserCode가_부여된다() {
-            final User user = userRegistrationService.registerOrLogin(
+            final LoginResult result = userRegistrationService.registerOrLogin(
                     GOOGLE, PROVIDER_USER_ID, EMAIL, "용감한호랑이");
+            final User user = result.user();
 
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(user.getId()).isNotNull();
@@ -41,9 +41,17 @@ class UserRegistrationServiceTest extends ServiceTest {
         }
 
         @Test
+        void 신규_가입이면_isNewUser가_true다() {
+            final LoginResult result = userRegistrationService.registerOrLogin(
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "용감한호랑이");
+
+            assertThat(result.isNewUser()).isTrue();
+        }
+
+        @Test
         void 닉네임이_null이면_자동_닉네임으로_가입된다() {
             final User user = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, null);
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, null).user();
 
             assertThat(user.getNickname().value())
                     .isNotBlank()
@@ -53,7 +61,7 @@ class UserRegistrationServiceTest extends ServiceTest {
         @Test
         void 닉네임이_빈_문자열이면_자동_닉네임으로_가입된다() {
             final User user = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "").user();
 
             assertThat(user.getNickname().value())
                     .isNotBlank()
@@ -63,7 +71,7 @@ class UserRegistrationServiceTest extends ServiceTest {
         @Test
         void 비속어_닉네임이면_자동_닉네임으로_대체된다() {
             final User user = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "씨발");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "씨발").user();
 
             assertThat(user.getNickname().value()).isNotEqualTo("씨발");
         }
@@ -71,7 +79,7 @@ class UserRegistrationServiceTest extends ServiceTest {
         @Test
         void 닉네임이_최대_길이를_초과하면_잘라서_사용한다() {
             final User user = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "용감한호랑이열한글자초과");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "용감한호랑이열한글자초과").user();
 
             assertThat(user.getNickname().value().length())
                     .isLessThanOrEqualTo(UserNickname.MAX_LENGTH);
@@ -84,10 +92,10 @@ class UserRegistrationServiceTest extends ServiceTest {
         @Test
         void 동일_provider와_providerUserId이면_기존_User를_반환한다() {
             final User first = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "처음닉네임");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "처음닉네임").user();
 
             final User second = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "다른닉네임");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "다른닉네임").user();
 
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(second.getId()).isEqualTo(first.getId());
@@ -96,11 +104,21 @@ class UserRegistrationServiceTest extends ServiceTest {
         }
 
         @Test
+        void 기존_회원_로그인이면_isNewUser가_false다() {
+            userRegistrationService.registerOrLogin(GOOGLE, PROVIDER_USER_ID, EMAIL, "처음닉네임");
+
+            final LoginResult result = userRegistrationService.registerOrLogin(
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "다른닉네임");
+
+            assertThat(result.isNewUser()).isFalse();
+        }
+
+        @Test
         void 다른_provider이면_별도_User로_가입된다() {
             final User googleUser = userRegistrationService.registerOrLogin(
-                    GOOGLE, PROVIDER_USER_ID, EMAIL, "구글유저");
+                    GOOGLE, PROVIDER_USER_ID, EMAIL, "구글유저").user();
             final User kakaoUser = userRegistrationService.registerOrLogin(
-                    OAuthProvider.KAKAO, PROVIDER_USER_ID, EMAIL, "카카오유저");
+                    OAuthProvider.KAKAO, PROVIDER_USER_ID, EMAIL, "카카오유저").user();
 
             assertThat(kakaoUser.getId()).isNotEqualTo(googleUser.getId());
         }

--- a/backend/src/test/java/coffeeshout/user/application/service/UserStatsServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserStatsServiceTest.java
@@ -25,7 +25,7 @@ class UserStatsServiceTest extends ServiceTest {
     @BeforeEach
     void setUp() {
         final User user = userRegistrationService.registerOrLogin(
-                OAuthProvider.GOOGLE, "google-uid-stats", "stats@example.com", "통계유저");
+                OAuthProvider.GOOGLE, "google-uid-stats", "stats@example.com", "통계유저").user();
         userId = user.getId();
     }
 

--- a/backend/src/test/java/coffeeshout/user/ui/TermsControllerTest.java
+++ b/backend/src/test/java/coffeeshout/user/ui/TermsControllerTest.java
@@ -1,0 +1,56 @@
+package coffeeshout.user.ui;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import coffeeshout.fixture.IntegrationTestSupport;
+import coffeeshout.fixture.UserFixture;
+import coffeeshout.user.application.service.AuthTokenService;
+import coffeeshout.user.domain.TokenPair;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+class TermsControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AuthTokenService authTokenService;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        final User user = userRepository.save(UserFixture.회원_엠제이());
+        final TokenPair tokens = authTokenService.issue(user);
+        accessToken = tokens.accessToken();
+    }
+
+    @Nested
+    class POST_users_me_terms {
+
+        @Test
+        void 인증된_사용자가_약관에_동의하면_204를_반환한다() throws Exception {
+            mockMvc.perform(post("/users/me/terms")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 토큰_없이_호출하면_401을_반환한다() throws Exception {
+            mockMvc.perform(post("/users/me/terms"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1214

# 🚀 작업 내용

변경 사항
  - OAuth 로그인 시 신규/기존 회원 구분 (isNewUser) 응답 추가
  - POST /users/me/terms — 개인정보 수집·이용 동의 시각 기록
  - app_user.terms_agreed_at 컬럼 추가 (V19 마이그레이션)

  관련 변경
  - 게임 종료 시 UserStats 자동 업데이트 (기존 수동 API 호출 의존 제거)
  - 대시보드 최저 확률 당첨자 집계를 로그인 사용자로 한정

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 사용자 약관 동의 기능 추가: 사용자가 서비스 약관에 동의할 수 있으며, 동의 시간이 자동으로 기록됩니다.
* OAuth 인증 개선: OAuth 로그인 시 신규 사용자와 기존 사용자를 정확하게 구분하여 맞춤형 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->