### PR TITLE
[feat] 약관 동의 기능 추가

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,15 +1,18 @@
 import { apiRequest } from '@/apis/rest/apiRequest';
-import { User, Tokens } from '../types';
+import { User, Tokens, OAuthCallbackResponse } from '../types';
 
 const API_URL = process.env.API_URL;
 
 // auth 전용 fetch — apiRequest 인터셉터를 우회해 무한 401 루프 방지
 const authFetch = async <T>(
   endpoint: string,
-  options: { method?: string; body?: string } = {}
+  options: { method?: string; body?: string; token?: string } = {}
 ): Promise<T> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (options.token) headers['Authorization'] = `Bearer ${options.token}`;
+
   const response = await fetch(`${API_URL}${endpoint}`, {
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     credentials: 'include',
     method: options.method,
     body: options.body,
@@ -29,11 +32,14 @@ export const authApi = {
   me: (): Promise<User> => apiRequest('/users/me'),
 
   // code를 accessToken으로 교환 — refreshToken은 HttpOnly 쿠키로 자동 설정됨
-  token: (code: string): Promise<Tokens> =>
+  token: (code: string): Promise<OAuthCallbackResponse> =>
     authFetch('/auth/token', {
       method: 'POST',
       body: JSON.stringify({ code }),
     }),
+
+  agreeTerms: (tempToken: string): Promise<Tokens> =>
+    authFetch('/users/me/terms', { method: 'POST', token: tempToken }),
 
   // refreshToken은 쿠키로 자동 전송 — body 불필요
   refresh: (): Promise<Tokens> => authFetch('/auth/refresh', { method: 'POST' }),

--- a/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import useToast from '@/components/@common/Toast/useToast';
+import { storageManager, STORAGE_KEYS } from '@/utils/StorageManager';
 import { useAuth } from '../contexts/AuthContext';
 import { tokenStore } from '../tokens';
 import { authApi } from '../api/authApi';
@@ -34,10 +35,15 @@ const OAuthCallbackPage = () => {
       }
 
       try {
-        const tokens = await authApi.token(code);
-        tokenStore.setTokens(tokens);
-        await refreshUser();
-        navigate('/', { replace: true });
+        const result = await authApi.token(code);
+        if (result.isNewUser) {
+          storageManager.setItem(STORAGE_KEYS.TEMP_TOKEN, result.tempToken, 'sessionStorage');
+          navigate('/auth/terms', { replace: true });
+        } else {
+          tokenStore.setTokens({ accessToken: result.accessToken });
+          await refreshUser();
+          navigate('/', { replace: true });
+        }
       } catch {
         showToast({ message: '로그인 처리 중 오류가 발생했습니다.', type: 'error' });
         navigate('/', { replace: true });

--- a/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
@@ -37,6 +37,7 @@ const OAuthCallbackPage = () => {
       try {
         const result = await authApi.token(code);
         if (result.isNewUser) {
+          tokenStore.clearTokens();
           storageManager.setItem(STORAGE_KEYS.TEMP_TOKEN, result.accessToken, 'sessionStorage');
           navigate('/auth/terms', { replace: true });
         } else {

--- a/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
+++ b/frontend/src/features/auth/pages/OAuthCallbackPage.tsx
@@ -37,7 +37,7 @@ const OAuthCallbackPage = () => {
       try {
         const result = await authApi.token(code);
         if (result.isNewUser) {
-          storageManager.setItem(STORAGE_KEYS.TEMP_TOKEN, result.tempToken, 'sessionStorage');
+          storageManager.setItem(STORAGE_KEYS.TEMP_TOKEN, result.accessToken, 'sessionStorage');
           navigate('/auth/terms', { replace: true });
         } else {
           tokenStore.setTokens({ accessToken: result.accessToken });

--- a/frontend/src/features/auth/pages/TermsAgreementPage.styled.ts
+++ b/frontend/src/features/auth/pages/TermsAgreementPage.styled.ts
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 20px 40px;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 40px;
+`;
+
+export const Title = styled.h1`
+  font-size: 22px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.color.gray[900]};
+  line-height: 1.4;
+`;
+
+export const Subtitle = styled.p`
+  font-size: 14px;
+  color: ${({ theme }) => theme.color.gray[500]};
+  line-height: 1.5;
+`;
+
+export const TermsList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+`;
+
+export const TermsItem = styled.li`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  background: ${({ theme }) => theme.color.white};
+  border: 1px solid ${({ theme }) => theme.color.gray[100]};
+  border-radius: 12px;
+`;
+
+export const Checkbox = styled.input`
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  flex-shrink: 0;
+  accent-color: ${({ theme }) => theme.color.point[500]};
+  cursor: pointer;
+`;
+
+export const TermsLabel = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+`;
+
+export const TermsTitle = styled.span`
+  font-size: 14px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.gray[900]};
+`;
+
+export const TermsDesc = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.gray[500]};
+  line-height: 1.5;
+`;
+
+export const ButtonWrapper = styled.div`
+  margin-top: 24px;
+`;

--- a/frontend/src/features/auth/pages/TermsAgreementPage.tsx
+++ b/frontend/src/features/auth/pages/TermsAgreementPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/@common/Button/Button';
+import Layout from '@/layouts/Layout';
+import { storageManager, STORAGE_KEYS } from '@/utils/StorageManager';
+import useToast from '@/components/@common/Toast/useToast';
+import { useAuth } from '../contexts/AuthContext';
+import { tokenStore } from '../tokens';
+import { authApi } from '../api/authApi';
+import * as S from './TermsAgreementPage.styled';
+
+const TermsAgreementPage = () => {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { refreshUser } = useAuth();
+  const [termsChecked, setTermsChecked] = useState(false);
+  const [privacyChecked, setPrivacyChecked] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const allChecked = termsChecked && privacyChecked;
+
+  const handleAgree = async () => {
+    const tempToken = storageManager.getItem(STORAGE_KEYS.TEMP_TOKEN, 'sessionStorage');
+    if (!tempToken) {
+      showToast({ message: '인증 정보가 만료되었습니다. 다시 로그인해 주세요.', type: 'error' });
+      navigate('/', { replace: true });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const tokens = await authApi.agreeTerms(tempToken);
+      storageManager.removeItem(STORAGE_KEYS.TEMP_TOKEN, 'sessionStorage');
+      tokenStore.setTokens(tokens);
+      await refreshUser();
+      navigate('/', { replace: true });
+    } catch {
+      showToast({ message: '약관 동의 처리 중 오류가 발생했습니다.', type: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Layout>
+      <Layout.Content>
+        <S.Container>
+          <S.Header>
+            <S.Title>서비스 이용을 위해{'\n'}약관에 동의해 주세요</S.Title>
+            <S.Subtitle>필수 항목에 모두 동의해야 서비스를 이용할 수 있어요.</S.Subtitle>
+          </S.Header>
+
+          <S.TermsList>
+            <S.TermsItem>
+              <S.Checkbox
+                type="checkbox"
+                id="terms"
+                checked={termsChecked}
+                onChange={(e) => setTermsChecked(e.target.checked)}
+              />
+              <S.TermsLabel htmlFor="terms">
+                <S.TermsTitle>[필수] 서비스 이용약관 동의</S.TermsTitle>
+              </S.TermsLabel>
+            </S.TermsItem>
+
+            <S.TermsItem>
+              <S.Checkbox
+                type="checkbox"
+                id="privacy"
+                checked={privacyChecked}
+                onChange={(e) => setPrivacyChecked(e.target.checked)}
+              />
+              <S.TermsLabel htmlFor="privacy">
+                <S.TermsTitle>[필수] 개인정보 수집·이용 동의</S.TermsTitle>
+                <S.TermsDesc>
+                  수집항목: 이메일·닉네임 / 목적: 회원 식별 / 보유기간: 탈퇴 시까지
+                </S.TermsDesc>
+              </S.TermsLabel>
+            </S.TermsItem>
+          </S.TermsList>
+
+          <S.ButtonWrapper>
+            <Button
+              variant={allChecked ? 'primary' : 'disabled'}
+              isLoading={isLoading}
+              onClick={handleAgree}
+            >
+              동의하고 시작하기
+            </Button>
+          </S.ButtonWrapper>
+        </S.Container>
+      </Layout.Content>
+    </Layout>
+  );
+};
+
+export default TermsAgreementPage;

--- a/frontend/src/features/auth/services/BackendRedirectAuthService.ts
+++ b/frontend/src/features/auth/services/BackendRedirectAuthService.ts
@@ -23,8 +23,10 @@ export class BackendRedirectAuthService implements AuthService {
       throw new Error('OAuth callback에 code가 없습니다');
     }
 
-    const tokens = await authApi.token(code);
-    this.tokenStore.setTokens(tokens);
+    const result = await authApi.token(code);
+    if (!result.isNewUser) {
+      this.tokenStore.setTokens({ accessToken: result.accessToken });
+    }
   }
 
   async refresh(): Promise<void> {

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -9,3 +9,7 @@ export type User = {
 export type Tokens = {
   accessToken: string;
 };
+
+export type OAuthCallbackResponse =
+  | { isNewUser: false; accessToken: string; refreshToken: string }
+  | { isNewUser: true; tempToken: string; accessToken: null; refreshToken: null };

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -12,4 +12,4 @@ export type Tokens = {
 
 export type OAuthCallbackResponse =
   | { isNewUser: false; accessToken: string; refreshToken: string }
-  | { isNewUser: true; tempToken: string; accessToken: null; refreshToken: null };
+  | { isNewUser: true; accessToken: string; refreshToken: null };

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -47,6 +47,10 @@ const QRJoinPage = lazy(
 const OAuthCallbackPage = lazy(
   () => import(/*webpackChunkName: "oauthCallbackPage"*/ './features/auth/pages/OAuthCallbackPage')
 );
+const TermsAgreementPage = lazy(
+  () =>
+    import(/*webpackChunkName: "termsAgreementPage"*/ './features/auth/pages/TermsAgreementPage')
+);
 const PrivacyPage = lazy(
   () => import(/*webpackChunkName: "privacyPage"*/ './features/privacy/pages/PrivacyPage')
 );
@@ -93,6 +97,10 @@ const router = createBrowserRouter([
       {
         path: 'auth/callback',
         element: <OAuthCallbackPage />,
+      },
+      {
+        path: 'auth/terms',
+        element: <TermsAgreementPage />,
       },
       {
         path: 'privacy',

--- a/frontend/src/utils/StorageManager.ts
+++ b/frontend/src/utils/StorageManager.ts
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
   NON_WIN_STREAK: 'zzol-non-win-streak',
   ACCESS_TOKEN: 'zzol-access-token',
   REFRESH_TOKEN: 'zzol-refresh-token',
+  TEMP_TOKEN: 'zzol-temp-token',
 } as const;
 
 type StorageType = 'localStorage' | 'sessionStorage';


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1215

# 🚀 작업 내용
<img width="427" height="897" alt="image" src="https://github.com/user-attachments/assets/7d1b9173-8fbf-4ef2-82ea-09ee9b7ed64e" />

- TermsAgreementPage 컴포넌트 추가 및 스타일 정의
- OAuthCallbackPage에서 새로운 사용자 구분, 약관 동의 로직 연결
- authApi에 agreeTerms API 추가
- TEMP_TOKEN 저장/로드 기능 StorageManager에 추가
- 약관 동의 페이지 라우트 설정 및 Layout 구조 활용

# 💬 리뷰 중점사항

중점사항
