### PR TITLE
[feat] 패치노트 기능 구현

### DIFF
--- a/backend/src/main/java/coffeeshout/patchnote/application/AdminRow.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/AdminRow.java
@@ -1,0 +1,14 @@
+package coffeeshout.patchnote.application;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import java.time.LocalDateTime;
+
+public record AdminRow(
+        Long id,
+        PatchNoteCategory category,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
@@ -1,0 +1,83 @@
+package coffeeshout.patchnote.application;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.exception.PatchNoteErrorCode;
+import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
+import coffeeshout.patchnote.infra.persistence.PatchNoteJpaRepository;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PatchNoteAdminService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final PatchNoteJpaRepository patchNoteJpaRepository;
+
+    @Transactional(readOnly = true)
+    public List<AdminRow> findAll() {
+        return patchNoteJpaRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(this::toRow)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminRow findById(Long id) {
+        return patchNoteJpaRepository.findById(id)
+                .map(this::toRow)
+                .orElseThrow(() -> new BusinessException(PatchNoteErrorCode.NOT_FOUND, PatchNoteErrorCode.NOT_FOUND.getMessage()));
+    }
+
+    @Transactional
+    public Long create(PatchNoteCategory category, String title, String content) {
+        final PatchNoteEntity entity = PatchNoteEntity.create(category, title, content);
+        return patchNoteJpaRepository.save(entity).getId();
+    }
+
+    @Transactional
+    public void update(Long id, PatchNoteCategory category, String title, String content) {
+        final PatchNoteEntity entity = patchNoteJpaRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(PatchNoteErrorCode.NOT_FOUND, PatchNoteErrorCode.NOT_FOUND.getMessage()));
+        entity.update(category, title, content);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (patchNoteJpaRepository.findById(id).isEmpty()) {
+            return;
+        }
+        patchNoteJpaRepository.deleteById(id);
+    }
+
+    private AdminRow toRow(PatchNoteEntity entity) {
+        return new AdminRow(
+                entity.getId(),
+                entity.getCategory(),
+                entity.getTitle(),
+                entity.getContent(),
+                toKst(entity.getCreatedAt()),
+                toKst(entity.getUpdatedAt())
+        );
+    }
+
+    private LocalDateTime toKst(Instant instant) {
+        return LocalDateTime.ofInstant(instant, KST);
+    }
+
+    public record AdminRow(
+            Long id,
+            PatchNoteCategory category,
+            String title,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
@@ -5,9 +5,9 @@ import coffeeshout.patchnote.domain.PatchNoteCategory;
 import coffeeshout.patchnote.exception.PatchNoteErrorCode;
 import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
 import coffeeshout.patchnote.infra.persistence.PatchNoteJpaRepository;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,8 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PatchNoteAdminService {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
+    private final Clock clock;
     private final PatchNoteJpaRepository patchNoteJpaRepository;
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
@@ -50,9 +50,6 @@ public class PatchNoteAdminService {
 
     @Transactional
     public void delete(Long id) {
-        if (patchNoteJpaRepository.findById(id).isEmpty()) {
-            return;
-        }
         patchNoteJpaRepository.deleteById(id);
     }
 

--- a/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteAdminService.java
@@ -65,16 +65,6 @@ public class PatchNoteAdminService {
     }
 
     private LocalDateTime toKst(Instant instant) {
-        return LocalDateTime.ofInstant(instant, KST);
-    }
-
-    public record AdminRow(
-            Long id,
-            PatchNoteCategory category,
-            String title,
-            String content,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
-    ) {
+        return LocalDateTime.ofInstant(instant, clock.getZone());
     }
 }

--- a/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteQueryService.java
+++ b/backend/src/main/java/coffeeshout/patchnote/application/PatchNoteQueryService.java
@@ -1,0 +1,26 @@
+package coffeeshout.patchnote.application;
+
+import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
+import coffeeshout.patchnote.infra.persistence.PatchNoteJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PatchNoteQueryService {
+
+    private final PatchNoteJpaRepository patchNoteJpaRepository;
+
+    @Transactional(readOnly = true)
+    public List<PatchNoteEntity> findAll() {
+        return patchNoteJpaRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<PatchNoteEntity> findLatest() {
+        return patchNoteJpaRepository.findFirstByOrderByCreatedAtDesc();
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/domain/PatchNoteCategory.java
+++ b/backend/src/main/java/coffeeshout/patchnote/domain/PatchNoteCategory.java
@@ -1,0 +1,14 @@
+package coffeeshout.patchnote.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PatchNoteCategory {
+    NOTICE("공지"),
+    EVENT("이벤트"),
+    UPDATE("업데이트"),
+    MAINTENANCE("점검"),
+    ;
+
+    public final String label;
+}

--- a/backend/src/main/java/coffeeshout/patchnote/exception/PatchNoteErrorCode.java
+++ b/backend/src/main/java/coffeeshout/patchnote/exception/PatchNoteErrorCode.java
@@ -1,0 +1,24 @@
+package coffeeshout.patchnote.exception;
+
+import coffeeshout.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum PatchNoteErrorCode implements ErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "패치노트를 찾을 수 없습니다."),
+    INVALID_TITLE(HttpStatus.BAD_REQUEST, "제목은 1~100자여야 합니다."),
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST, "본문은 비어 있을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/exception/PatchNoteErrorCode.java
+++ b/backend/src/main/java/coffeeshout/patchnote/exception/PatchNoteErrorCode.java
@@ -12,6 +12,8 @@ public enum PatchNoteErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "패치노트를 찾을 수 없습니다."),
     INVALID_TITLE(HttpStatus.BAD_REQUEST, "제목은 1~100자여야 합니다."),
     INVALID_CONTENT(HttpStatus.BAD_REQUEST, "본문은 비어 있을 수 없습니다."),
+    INVALID_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "본문은 5000자를 초과할 수 없습니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리는 필수입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntity.java
+++ b/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntity.java
@@ -43,6 +43,7 @@ public class PatchNoteEntity {
     private Instant updatedAt;
 
     public static PatchNoteEntity create(PatchNoteCategory category, String title, String content) {
+        validateCategory(category);
         validateTitle(title);
         validateContent(content);
         final PatchNoteEntity entity = new PatchNoteEntity();
@@ -55,12 +56,19 @@ public class PatchNoteEntity {
     }
 
     public void update(PatchNoteCategory category, String title, String content) {
+        validateCategory(category);
         validateTitle(title);
         validateContent(content);
         this.category = category;
         this.title = title;
         this.content = content;
         this.updatedAt = Instant.now();
+    }
+
+    private static void validateCategory(PatchNoteCategory category) {
+        if (category == null) {
+            throw new BusinessException(PatchNoteErrorCode.INVALID_CATEGORY, PatchNoteErrorCode.INVALID_CATEGORY.getMessage());
+        }
     }
 
     private static void validateTitle(String title) {
@@ -72,6 +80,9 @@ public class PatchNoteEntity {
     private static void validateContent(String content) {
         if (content == null || content.isBlank()) {
             throw new BusinessException(PatchNoteErrorCode.INVALID_CONTENT, PatchNoteErrorCode.INVALID_CONTENT.getMessage());
+        }
+        if (content.length() > 5000) {
+            throw new BusinessException(PatchNoteErrorCode.INVALID_CONTENT_LENGTH, PatchNoteErrorCode.INVALID_CONTENT_LENGTH.getMessage());
         }
     }
 }

--- a/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntity.java
+++ b/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntity.java
@@ -1,0 +1,77 @@
+package coffeeshout.patchnote.infra.persistence;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.exception.PatchNoteErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "patch_note")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PatchNoteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PatchNoteCategory category;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    public static PatchNoteEntity create(PatchNoteCategory category, String title, String content) {
+        validateTitle(title);
+        validateContent(content);
+        final PatchNoteEntity entity = new PatchNoteEntity();
+        entity.category = category;
+        entity.title = title;
+        entity.content = content;
+        entity.createdAt = Instant.now();
+        entity.updatedAt = entity.createdAt;
+        return entity;
+    }
+
+    public void update(PatchNoteCategory category, String title, String content) {
+        validateTitle(title);
+        validateContent(content);
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.updatedAt = Instant.now();
+    }
+
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank() || title.length() > 100) {
+            throw new BusinessException(PatchNoteErrorCode.INVALID_TITLE, PatchNoteErrorCode.INVALID_TITLE.getMessage());
+        }
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new BusinessException(PatchNoteErrorCode.INVALID_CONTENT, PatchNoteErrorCode.INVALID_CONTENT.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/patchnote/infra/persistence/PatchNoteJpaRepository.java
@@ -1,0 +1,18 @@
+package coffeeshout.patchnote.infra.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+public interface PatchNoteJpaRepository extends Repository<PatchNoteEntity, Long> {
+
+    PatchNoteEntity save(PatchNoteEntity entity);
+
+    Optional<PatchNoteEntity> findById(Long id);
+
+    void deleteById(Long id);
+
+    List<PatchNoteEntity> findAllByOrderByCreatedAtDesc();
+
+    Optional<PatchNoteEntity> findFirstByOrderByCreatedAtDesc();
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteAdminController.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteAdminController.java
@@ -1,7 +1,7 @@
 package coffeeshout.patchnote.ui;
 
+import coffeeshout.patchnote.application.AdminRow;
 import coffeeshout.patchnote.application.PatchNoteAdminService;
-import coffeeshout.patchnote.application.PatchNoteAdminService.AdminRow;
 import coffeeshout.patchnote.domain.PatchNoteCategory;
 import coffeeshout.patchnote.ui.request.CreatePatchNoteRequest;
 import coffeeshout.patchnote.ui.request.UpdatePatchNoteRequest;

--- a/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteAdminController.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteAdminController.java
@@ -1,0 +1,68 @@
+package coffeeshout.patchnote.ui;
+
+import coffeeshout.patchnote.application.PatchNoteAdminService;
+import coffeeshout.patchnote.application.PatchNoteAdminService.AdminRow;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.ui.request.CreatePatchNoteRequest;
+import coffeeshout.patchnote.ui.request.UpdatePatchNoteRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/patch-notes")
+@RequiredArgsConstructor
+public class PatchNoteAdminController {
+
+    private final PatchNoteAdminService patchNoteAdminService;
+
+    @GetMapping
+    public String list(Model model) {
+        final List<AdminRow> patchNotes = patchNoteAdminService.findAll();
+        model.addAttribute("patchNotes", patchNotes);
+        model.addAttribute("totalCount", patchNotes.size());
+        return "admin/patch-note-list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(Model model) {
+        model.addAttribute("categories", PatchNoteCategory.values());
+        model.addAttribute("formAction", "/admin/patch-notes");
+        model.addAttribute("patchNote", null);
+        return "admin/patch-note-form";
+    }
+
+    @PostMapping
+    public String create(@Valid @ModelAttribute CreatePatchNoteRequest request) {
+        patchNoteAdminService.create(request.category(), request.title(), request.content());
+        return "redirect:/admin/patch-notes";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        final AdminRow patchNote = patchNoteAdminService.findById(id);
+        model.addAttribute("categories", PatchNoteCategory.values());
+        model.addAttribute("formAction", "/admin/patch-notes/" + id);
+        model.addAttribute("patchNote", patchNote);
+        return "admin/patch-note-form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @Valid @ModelAttribute UpdatePatchNoteRequest request) {
+        patchNoteAdminService.update(id, request.category(), request.title(), request.content());
+        return "redirect:/admin/patch-notes";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        patchNoteAdminService.delete(id);
+        return "redirect:/admin/patch-notes";
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteApi.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteApi.java
@@ -2,6 +2,7 @@ package coffeeshout.patchnote.ui;
 
 import coffeeshout.patchnote.ui.response.PatchNoteResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -13,5 +14,7 @@ public interface PatchNoteApi {
     ResponseEntity<List<PatchNoteResponse>> findAll();
 
     @Operation(summary = "최신 패치노트 조회", description = "가장 최근 패치노트 1건을 반환합니다. 없으면 204를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "최신 패치노트 반환")
+    @ApiResponse(responseCode = "204", description = "패치노트 없음")
     ResponseEntity<PatchNoteResponse> findLatest();
 }

--- a/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteApi.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteApi.java
@@ -1,0 +1,17 @@
+package coffeeshout.patchnote.ui;
+
+import coffeeshout.patchnote.ui.response.PatchNoteResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "PatchNote", description = "패치노트 API")
+public interface PatchNoteApi {
+
+    @Operation(summary = "패치노트 전체 조회", description = "모든 패치노트를 최신순으로 반환합니다.")
+    ResponseEntity<List<PatchNoteResponse>> findAll();
+
+    @Operation(summary = "최신 패치노트 조회", description = "가장 최근 패치노트 1건을 반환합니다. 없으면 204를 반환합니다.")
+    ResponseEntity<PatchNoteResponse> findLatest();
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteController.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/PatchNoteController.java
@@ -1,0 +1,34 @@
+package coffeeshout.patchnote.ui;
+
+import coffeeshout.patchnote.application.PatchNoteQueryService;
+import coffeeshout.patchnote.ui.response.PatchNoteResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/patch-notes")
+@RequiredArgsConstructor
+public class PatchNoteController implements PatchNoteApi {
+
+    private final PatchNoteQueryService patchNoteQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<PatchNoteResponse>> findAll() {
+        final List<PatchNoteResponse> responses = patchNoteQueryService.findAll().stream()
+                .map(PatchNoteResponse::from)
+                .toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/latest")
+    public ResponseEntity<PatchNoteResponse> findLatest() {
+        return patchNoteQueryService.findLatest()
+                .map(PatchNoteResponse::from)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/request/CreatePatchNoteRequest.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/request/CreatePatchNoteRequest.java
@@ -1,0 +1,13 @@
+package coffeeshout.patchnote.ui.request;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreatePatchNoteRequest(
+        @NotNull PatchNoteCategory category,
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank @Size(max = 5000) String content
+) {
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/request/UpdatePatchNoteRequest.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/request/UpdatePatchNoteRequest.java
@@ -1,0 +1,13 @@
+package coffeeshout.patchnote.ui.request;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePatchNoteRequest(
+        @NotNull PatchNoteCategory category,
+        @NotBlank @Size(max = 100) String title,
+        @NotBlank @Size(max = 5000) String content
+) {
+}

--- a/backend/src/main/java/coffeeshout/patchnote/ui/response/PatchNoteResponse.java
+++ b/backend/src/main/java/coffeeshout/patchnote/ui/response/PatchNoteResponse.java
@@ -1,0 +1,27 @@
+package coffeeshout.patchnote.ui.response;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
+import java.time.Instant;
+
+public record PatchNoteResponse(
+        Long id,
+        PatchNoteCategory category,
+        String categoryLabel,
+        String title,
+        String content,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static PatchNoteResponse from(PatchNoteEntity entity) {
+        return new PatchNoteResponse(
+                entity.getId(),
+                entity.getCategory(),
+                entity.getCategory().label,
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/resources/db/migration/V19__create_patch_note_table.sql
+++ b/backend/src/main/resources/db/migration/V19__create_patch_note_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE patch_note
+(
+    id         BIGINT       AUTO_INCREMENT PRIMARY KEY,
+    category   VARCHAR(20)  NOT NULL COMMENT 'NOTICE/EVENT/UPDATE/MAINTENANCE',
+    title      VARCHAR(100) NOT NULL,
+    content    TEXT         NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
+    updated_at TIMESTAMP(6) NOT NULL,
+    INDEX idx_patch_note_created_at (created_at DESC)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT = '운영자가 작성하는 패치노트';

--- a/backend/src/main/resources/templates/admin/index.html
+++ b/backend/src/main/resources/templates/admin/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>어드민 대시보드 — 커피빵</title>
+    <title>어드민 대시보드 — ZZOL</title>
     <link rel="stylesheet" th:href="@{/css/admin.css}">
     <style>
         .cards {
@@ -11,6 +11,7 @@
             grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
             gap: 1.5rem;
         }
+
         .card {
             background: var(--surface);
             border-radius: var(--radius);
@@ -23,9 +24,10 @@
             position: relative;
             overflow: hidden;
             transition: box-shadow var(--dur) var(--ease),
-                        transform var(--dur) var(--ease),
-                        border-color var(--dur) var(--ease);
+            transform var(--dur) var(--ease),
+            border-color var(--dur) var(--ease);
         }
+
         .card::before {
             content: '';
             position: absolute;
@@ -35,35 +37,48 @@
             transition: opacity var(--dur) var(--ease);
             pointer-events: none;
         }
+
         .card::after {
             content: '→';
             position: absolute;
-            bottom: 1.5rem; right: 1.75rem;
+            bottom: 1.5rem;
+            right: 1.75rem;
             font-size: 1.1rem;
             color: var(--accent-light);
             opacity: 0;
             transform: translateX(-6px);
             transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease);
         }
+
         .card:hover {
             box-shadow: var(--shadow-lg);
             transform: translateY(-3px);
             border-color: var(--accent-border);
         }
-        .card:hover::before { opacity: 1; }
-        .card:hover::after  { opacity: 1; transform: translateX(0); }
+
+        .card:hover::before {
+            opacity: 1;
+        }
+
+        .card:hover::after {
+            opacity: 1;
+            transform: translateX(0);
+        }
+
         .card-icon {
             font-size: 2.25rem;
             margin-bottom: 1rem;
             display: block;
             line-height: 1;
         }
+
         .card-title {
             font-size: 1rem;
             font-weight: 700;
             margin-bottom: 0.4rem;
             letter-spacing: -0.01em;
         }
+
         .card-desc {
             font-size: 0.83rem;
             color: var(--text-secondary);

--- a/backend/src/main/resources/templates/admin/index.html
+++ b/backend/src/main/resources/templates/admin/index.html
@@ -90,6 +90,11 @@
             <div class="card-title">건의사항 / 신고</div>
             <div class="card-desc">유저 제출 버그 신고 및 건의사항 확인</div>
         </a>
+        <a th:href="@{/admin/patch-notes}" class="card">
+            <div class="card-icon">📢</div>
+            <div class="card-title">패치노트</div>
+            <div class="card-desc">공지·이벤트·업데이트·점검 안내 작성</div>
+        </a>
     </div>
 </main>
 </body>

--- a/backend/src/main/resources/templates/admin/login.html
+++ b/backend/src/main/resources/templates/admin/login.html
@@ -3,9 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>운영자 로그인 — 커피빵</title>
+    <title>운영자 로그인 — ZZOL</title>
     <style>
-        * { box-sizing: border-box; margin: 0; padding: 0; }
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
             background: #f0f2f5;
@@ -14,24 +19,28 @@
             justify-content: center;
             min-height: 100vh;
         }
+
         .card {
             background: #fff;
             border-radius: 10px;
-            box-shadow: 0 2px 12px rgba(0,0,0,.1);
+            box-shadow: 0 2px 12px rgba(0, 0, 0, .1);
             padding: 2.5rem 2rem;
             width: 100%;
             max-width: 360px;
         }
+
         h1 {
             font-size: 1.25rem;
             font-weight: 600;
             margin-bottom: 0.25rem;
         }
+
         .subtitle {
             font-size: 0.85rem;
             color: #888;
             margin-bottom: 1.75rem;
         }
+
         label {
             display: block;
             font-size: 0.85rem;
@@ -39,6 +48,7 @@
             margin-bottom: 0.35rem;
             color: #333;
         }
+
         input[type="text"],
         input[type="password"] {
             width: 100%;
@@ -50,7 +60,11 @@
             transition: border-color .15s;
             margin-bottom: 1rem;
         }
-        input:focus { border-color: #4f46e5; }
+
+        input:focus {
+            border-color: #4f46e5;
+        }
+
         button[type="submit"] {
             width: 100%;
             padding: 0.65rem;
@@ -63,15 +77,29 @@
             cursor: pointer;
             transition: background .15s;
         }
-        button[type="submit"]:hover { background: #4338ca; }
+
+        button[type="submit"]:hover {
+            background: #4338ca;
+        }
+
         .alert {
             padding: 0.6rem 0.75rem;
             border-radius: 6px;
             font-size: 0.85rem;
             margin-bottom: 1rem;
         }
-        .alert-error { background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; }
-        .alert-success { background: #f0fdf4; color: #15803d; border: 1px solid #bbf7d0; }
+
+        .alert-error {
+            background: #fef2f2;
+            color: #b91c1c;
+            border: 1px solid #fecaca;
+        }
+
+        .alert-success {
+            background: #f0fdf4;
+            color: #15803d;
+            border: 1px solid #bbf7d0;
+        }
     </style>
 </head>
 <body>

--- a/backend/src/main/resources/templates/admin/nickname-audit.html
+++ b/backend/src/main/resources/templates/admin/nickname-audit.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>닉네임 검열 대시보드 — 커피빵</title>
+    <title>닉네임 검열 대시보드 — ZZOL</title>
     <link rel="stylesheet" th:href="@{/css/admin.css}">
     <script>
         function confirmRelease(form) {
@@ -27,10 +27,12 @@
     <div class="filter-bar" style="margin-bottom: 1.5rem;">
         <span class="filter-label">섹션</span>
         <a href="#flagged" class="filter-btn">
-            FLAGGED <span class="badge badge-flagged" th:text="${flagged.totalElements}" style="margin-left:0.3rem;">0</span>
+            FLAGGED <span class="badge badge-flagged" th:text="${flagged.totalElements}"
+                          style="margin-left:0.3rem;">0</span>
         </a>
         <a href="#pending" class="filter-btn">
-            PENDING <span class="badge badge-pending" th:text="${pending.totalElements}" style="margin-left:0.3rem;">0</span>
+            PENDING <span class="badge badge-pending" th:text="${pending.totalElements}"
+                          style="margin-left:0.3rem;">0</span>
         </a>
     </div>
 
@@ -47,7 +49,13 @@
         <table>
             <thead>
             <tr>
-                <th>ID</th><th>닉네임</th><th>신뢰도</th><th>AI 판단 사유</th><th>등록</th><th>검열</th><th>처리</th>
+                <th>ID</th>
+                <th>닉네임</th>
+                <th>신뢰도</th>
+                <th>AI 판단 사유</th>
+                <th>등록</th>
+                <th>검열</th>
+                <th>처리</th>
             </tr>
             </thead>
             <tbody>
@@ -63,12 +71,14 @@
                             <div class="conf-bar-fill fill-high"
                                  th:style="|width:${item.confidence.value().movePointRight(2).intValue()}%|"></div>
                         </div>
-                        <span class="conf-text" th:text="${#numbers.formatDecimal(item.confidence.value(), 1, 2)}"></span>
+                        <span class="conf-text"
+                              th:text="${#numbers.formatDecimal(item.confidence.value(), 1, 2)}"></span>
                     </div>
                 </td>
                 <td class="reason" th:text="${item.reason}"></td>
                 <td class="date" th:text="${#temporals.format(item.createdAt, 'MM-dd HH:mm')}"></td>
-                <td class="date" th:text="${item.auditedAt != null ? #temporals.format(item.auditedAt, 'MM-dd HH:mm') : '-'}"></td>
+                <td class="date"
+                    th:text="${item.auditedAt != null ? #temporals.format(item.auditedAt, 'MM-dd HH:mm') : '-'}"></td>
                 <td>
                     <form th:action="@{/admin/playername-audit/{id}/allow(id=${item.id})}" method="post"
                           th:data-nickname="${item.playerName}" onsubmit="return confirmRelease(this)">
@@ -82,7 +92,8 @@
         </table>
         <div class="pagination" th:if="${flagged.totalPages > 1}">
             <a class="page-btn" th:if="${!flagged.first}"
-               th:href="@{/admin/playername-audit(flaggedPage=${flagged.number - 1}, pendingPage=${pendingPage})} + '#flagged'">← 이전</a>
+               th:href="@{/admin/playername-audit(flaggedPage=${flagged.number - 1}, pendingPage=${pendingPage})} + '#flagged'">←
+                이전</a>
             <a class="page-btn" th:if="${flaggedPageStart > 0}"
                th:href="@{/admin/playername-audit(flaggedPage=0, pendingPage=${pendingPage})} + '#flagged'">1</a>
             <span class="page-ellipsis" th:if="${flaggedPageStart > 1}">…</span>
@@ -97,7 +108,8 @@
                th:href="@{/admin/playername-audit(flaggedPage=${flagged.totalPages - 1}, pendingPage=${pendingPage})} + '#flagged'"
                th:text="${flagged.totalPages}"></a>
             <a class="page-btn" th:if="${!flagged.last}"
-               th:href="@{/admin/playername-audit(flaggedPage=${flagged.number + 1}, pendingPage=${pendingPage})} + '#flagged'">다음 →</a>
+               th:href="@{/admin/playername-audit(flaggedPage=${flagged.number + 1}, pendingPage=${pendingPage})} + '#flagged'">다음
+                →</a>
         </div>
     </div>
 
@@ -114,7 +126,13 @@
         <table>
             <thead>
             <tr>
-                <th>ID</th><th>닉네임</th><th>신뢰도</th><th>AI 판단 사유</th><th>등록</th><th>검열</th><th>처리</th>
+                <th>ID</th>
+                <th>닉네임</th>
+                <th>신뢰도</th>
+                <th>AI 판단 사유</th>
+                <th>등록</th>
+                <th>검열</th>
+                <th>처리</th>
             </tr>
             </thead>
             <tbody>
@@ -127,12 +145,14 @@
                             <div class="conf-bar-fill fill-mid"
                                  th:style="|width:${item.confidence.value().movePointRight(2).intValue()}%|"></div>
                         </div>
-                        <span class="conf-text" th:text="${#numbers.formatDecimal(item.confidence.value(), 1, 2)}"></span>
+                        <span class="conf-text"
+                              th:text="${#numbers.formatDecimal(item.confidence.value(), 1, 2)}"></span>
                     </div>
                 </td>
                 <td class="reason" th:text="${item.reason}"></td>
                 <td class="date" th:text="${#temporals.format(item.createdAt, 'MM-dd HH:mm')}"></td>
-                <td class="date" th:text="${item.auditedAt != null ? #temporals.format(item.auditedAt, 'MM-dd HH:mm') : '-'}"></td>
+                <td class="date"
+                    th:text="${item.auditedAt != null ? #temporals.format(item.auditedAt, 'MM-dd HH:mm') : '-'}"></td>
                 <td>
                     <div class="actions">
                         <form th:action="@{/admin/playername-audit/{id}/allow(id=${item.id})}" method="post">
@@ -152,7 +172,8 @@
         </table>
         <div class="pagination" th:if="${pending.totalPages > 1}">
             <a class="page-btn" th:if="${!pending.first}"
-               th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=${pending.number - 1})} + '#pending'">← 이전</a>
+               th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=${pending.number - 1})} + '#pending'">←
+                이전</a>
             <a class="page-btn" th:if="${pendingPageStart > 0}"
                th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=0)} + '#pending'">1</a>
             <span class="page-ellipsis" th:if="${pendingPageStart > 1}">…</span>
@@ -167,7 +188,8 @@
                th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=${pending.totalPages - 1})} + '#pending'"
                th:text="${pending.totalPages}"></a>
             <a class="page-btn" th:if="${!pending.last}"
-               th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=${pending.number + 1})} + '#pending'">다음 →</a>
+               th:href="@{/admin/playername-audit(flaggedPage=${flaggedPage}, pendingPage=${pending.number + 1})} + '#pending'">다음
+                →</a>
         </div>
     </div>
 

--- a/backend/src/main/resources/templates/admin/patch-note-form.html
+++ b/backend/src/main/resources/templates/admin/patch-note-form.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${patchNote != null} ? '패치노트 수정 — 커피빵' : '패치노트 작성 — 커피빵'">패치노트 — 커피빵</title>
+    <title th:text="${patchNote != null} ? '패치노트 수정 — ZZOL' : '패치노트 작성 — ZZOL'">패치노트 — ZZOL</title>
     <link rel="stylesheet" th:href="@{/css/admin.css}">
     <style>
         .form-card {
@@ -14,9 +14,11 @@
             padding: 2rem;
             max-width: 720px;
         }
+
         .form-group {
             margin-bottom: 1.25rem;
         }
+
         .form-label {
             display: block;
             font-size: 0.8rem;
@@ -26,6 +28,7 @@
             text-transform: uppercase;
             letter-spacing: 0.05em;
         }
+
         .form-control {
             width: 100%;
             padding: 0.5rem 0.75rem;
@@ -38,20 +41,24 @@
             box-sizing: border-box;
             transition: border-color var(--dur) var(--ease);
         }
+
         .form-control:focus {
             outline: none;
             border-color: var(--accent-border);
         }
+
         textarea.form-control {
             resize: vertical;
             min-height: 240px;
             line-height: 1.6;
         }
+
         .form-actions {
             display: flex;
             gap: 0.75rem;
             margin-top: 1.75rem;
         }
+
         .btn-submit {
             background: var(--accent);
             color: #fff;
@@ -64,7 +71,12 @@
             cursor: pointer;
             transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
         }
-        .btn-submit:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+
+        .btn-submit:hover {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
         .btn-cancel {
             background: var(--surface);
             color: var(--text-secondary);
@@ -119,7 +131,8 @@
 
             <div class="form-actions">
                 <button type="submit" class="btn-submit"
-                        th:text="${patchNote != null} ? '수정하기' : '작성하기'">작성하기</button>
+                        th:text="${patchNote != null} ? '수정하기' : '작성하기'">작성하기
+                </button>
                 <a th:href="@{/admin/patch-notes}" class="btn-cancel">취소</a>
             </div>
         </form>

--- a/backend/src/main/resources/templates/admin/patch-note-form.html
+++ b/backend/src/main/resources/templates/admin/patch-note-form.html
@@ -125,7 +125,7 @@
             <div class="form-group">
                 <label class="form-label" for="content">본문</label>
                 <textarea id="content" name="content" class="form-control"
-                          placeholder="본문을 입력하세요"
+                          placeholder="본문을 입력하세요" maxlength="5000"
                           th:text="${patchNote?.content}"></textarea>
             </div>
 

--- a/backend/src/main/resources/templates/admin/patch-note-form.html
+++ b/backend/src/main/resources/templates/admin/patch-note-form.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${patchNote != null} ? '패치노트 수정 — 커피빵' : '패치노트 작성 — 커피빵'">패치노트 — 커피빵</title>
+    <link rel="stylesheet" th:href="@{/css/admin.css}">
+    <style>
+        .form-card {
+            background: var(--surface);
+            border-radius: var(--radius);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-sm);
+            padding: 2rem;
+            max-width: 720px;
+        }
+        .form-group {
+            margin-bottom: 1.25rem;
+        }
+        .form-label {
+            display: block;
+            font-size: 0.8rem;
+            font-weight: 700;
+            color: var(--text-secondary);
+            margin-bottom: 0.4rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .form-control {
+            width: 100%;
+            padding: 0.5rem 0.75rem;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-xs);
+            font-family: inherit;
+            font-size: 0.88rem;
+            color: var(--text-primary);
+            background: var(--bg);
+            box-sizing: border-box;
+            transition: border-color var(--dur) var(--ease);
+        }
+        .form-control:focus {
+            outline: none;
+            border-color: var(--accent-border);
+        }
+        textarea.form-control {
+            resize: vertical;
+            min-height: 240px;
+            line-height: 1.6;
+        }
+        .form-actions {
+            display: flex;
+            gap: 0.75rem;
+            margin-top: 1.75rem;
+        }
+        .btn-submit {
+            background: var(--accent);
+            color: #fff;
+            border: 1px solid var(--accent);
+            padding: 0.45rem 1.25rem;
+            border-radius: var(--radius-xs);
+            font-size: 0.85rem;
+            font-weight: 700;
+            font-family: inherit;
+            cursor: pointer;
+            transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+        }
+        .btn-submit:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+        .btn-cancel {
+            background: var(--surface);
+            color: var(--text-secondary);
+            border: 1px solid var(--border);
+            padding: 0.45rem 1.25rem;
+            border-radius: var(--radius-xs);
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1 th:text="${patchNote != null} ? '패치노트 수정' : '패치노트 작성'">패치노트</h1>
+    <form th:action="@{/admin/logout}" method="post">
+        <button type="submit" class="logout-btn">로그아웃</button>
+    </form>
+</header>
+
+<main>
+    <a th:href="@{/admin/patch-notes}" class="nav-back">← 패치노트 목록으로</a>
+
+    <div class="form-card">
+        <form th:action="${formAction}" method="post">
+            <div class="form-group">
+                <label class="form-label" for="category">카테고리</label>
+                <select id="category" name="category" class="form-control">
+                    <th:block th:each="cat : ${categories}">
+                        <option th:value="${cat.name()}"
+                                th:text="${cat.name() + '(' + cat.label + ')'}"
+                                th:selected="${patchNote != null and patchNote.category == cat}"></option>
+                    </th:block>
+                </select>
+            </div>
+
+            <div class="form-group">
+                <label class="form-label" for="title">제목</label>
+                <input id="title" name="title" type="text" class="form-control"
+                       maxlength="100" placeholder="제목을 입력하세요 (최대 100자)"
+                       th:value="${patchNote?.title}">
+            </div>
+
+            <div class="form-group">
+                <label class="form-label" for="content">본문</label>
+                <textarea id="content" name="content" class="form-control"
+                          placeholder="본문을 입력하세요"
+                          th:text="${patchNote?.content}"></textarea>
+            </div>
+
+            <div class="form-actions">
+                <button type="submit" class="btn-submit"
+                        th:text="${patchNote != null} ? '수정하기' : '작성하기'">작성하기</button>
+                <a th:href="@{/admin/patch-notes}" class="btn-cancel">취소</a>
+            </div>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/patch-note-list.html
+++ b/backend/src/main/resources/templates/admin/patch-note-list.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>패치노트 대시보드 — 커피빵</title>
+    <title>패치노트 대시보드 — ZZOL</title>
     <link rel="stylesheet" th:href="@{/css/admin.css}">
     <style>
         .list-header-actions {
@@ -11,6 +11,7 @@
             align-items: center;
             gap: 1rem;
         }
+
         .btn-primary {
             background: var(--accent);
             color: #fff;
@@ -25,17 +26,24 @@
             cursor: pointer;
             transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
         }
-        .btn-primary:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+
+        .btn-primary:hover {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
         .btn-edit {
             background: var(--surface);
             color: var(--accent);
             border: 1px solid var(--accent-border);
         }
+
         .btn-delete {
             background: var(--red-bg);
             color: var(--red-text);
-            border-color: rgba(239,68,68,.2);
+            border-color: rgba(239, 68, 68, .2);
         }
+
         .content-preview {
             max-width: 300px;
             overflow: hidden;

--- a/backend/src/main/resources/templates/admin/patch-note-list.html
+++ b/backend/src/main/resources/templates/admin/patch-note-list.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>패치노트 대시보드 — 커피빵</title>
+    <link rel="stylesheet" th:href="@{/css/admin.css}">
+    <style>
+        .list-header-actions {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+        .btn-primary {
+            background: var(--accent);
+            color: #fff;
+            border-color: var(--accent);
+            text-decoration: none;
+            display: inline-block;
+            padding: 0.35rem 0.9rem;
+            border-radius: var(--radius-xs);
+            font-size: 0.78rem;
+            font-weight: 700;
+            font-family: inherit;
+            cursor: pointer;
+            transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+        }
+        .btn-primary:hover { transform: translateY(-1px); box-shadow: var(--shadow-md); }
+        .btn-edit {
+            background: var(--surface);
+            color: var(--accent);
+            border: 1px solid var(--accent-border);
+        }
+        .btn-delete {
+            background: var(--red-bg);
+            color: var(--red-text);
+            border-color: rgba(239,68,68,.2);
+        }
+        .content-preview {
+            max-width: 300px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: var(--text-secondary);
+            font-size: 0.82rem;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>패치노트 대시보드</h1>
+    <form th:action="@{/admin/logout}" method="post">
+        <button type="submit" class="logout-btn">로그아웃</button>
+    </form>
+</header>
+
+<main>
+    <a th:href="@{/admin}" class="nav-back">← 대시보드로</a>
+
+    <div class="section-header list-header-actions">
+        <span class="section-title">패치노트 목록</span>
+        <span class="badge badge-pending" th:text="${totalCount}">0</span>
+        <span style="font-size:0.8rem;color:#9ca3af;">건</span>
+        <a th:href="@{/admin/patch-notes/new}" class="btn-primary" style="margin-left:auto;">+ 새 글 작성</a>
+    </div>
+
+    <div th:if="${patchNotes.empty}" class="empty">작성된 패치노트가 없습니다.</div>
+
+    <div th:if="${!patchNotes.empty}" class="table-wrap">
+        <table>
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>카테고리</th>
+                <th>제목</th>
+                <th>본문 미리보기</th>
+                <th>작성일시</th>
+                <th>수정일시</th>
+                <th>액션</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="n : ${patchNotes}">
+                <td th:text="${n.id}" style="color:#9ca3af;font-size:0.8rem;"></td>
+                <td><span class="tag" th:text="${n.category.name() + '(' + n.category.label + ')'}"></span></td>
+                <td th:text="${n.title}"></td>
+                <td class="content-preview" th:text="${n.content}"></td>
+                <td class="date" th:text="${#temporals.format(n.createdAt, 'yy-MM-dd HH:mm')}"></td>
+                <td class="date" th:text="${#temporals.format(n.updatedAt, 'yy-MM-dd HH:mm')}"></td>
+                <td>
+                    <div class="actions">
+                        <a th:href="@{/admin/patch-notes/{id}/edit(id=${n.id})}" class="btn btn-edit">수정</a>
+                        <form th:action="@{/admin/patch-notes/{id}/delete(id=${n.id})}" method="post"
+                              onsubmit="return confirm('이 패치노트를 삭제하시겠습니까?')">
+                            <button type="submit" class="btn btn-delete">삭제</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/patch-note-list.html
+++ b/backend/src/main/resources/templates/admin/patch-note-list.html
@@ -85,8 +85,8 @@
                 <td><span class="tag" th:text="${n.category.name() + '(' + n.category.label + ')'}"></span></td>
                 <td th:text="${n.title}"></td>
                 <td class="content-preview" th:text="${n.content}"></td>
-                <td class="date" th:text="${#temporals.format(n.createdAt, 'yy-MM-dd HH:mm')}"></td>
-                <td class="date" th:text="${#temporals.format(n.updatedAt, 'yy-MM-dd HH:mm')}"></td>
+                <td class="date" th:text="${#temporals.format(n.createdAt, 'yyyy-MM-dd HH:mm')}"></td>
+                <td class="date" th:text="${#temporals.format(n.updatedAt, 'yyyy-MM-dd HH:mm')}"></td>
                 <td>
                     <div class="actions">
                         <a th:href="@{/admin/patch-notes/{id}/edit(id=${n.id})}" class="btn btn-edit">수정</a>

--- a/backend/src/main/resources/templates/admin/report.html
+++ b/backend/src/main/resources/templates/admin/report.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>건의사항/신고 대시보드 — 커피빵</title>
+    <title>건의사항/신고 대시보드 — ZZOL</title>
     <link rel="stylesheet" th:href="@{/css/admin.css}">
 </head>
 <body>
@@ -68,15 +68,18 @@
         <span>
             총 <strong th:text="${reports.totalElements}" style="color:var(--text-primary);">0</strong>건
             &nbsp;·&nbsp;
-            <span th:text="${reports.pageable.offset + 1}">1</span>–<span th:text="${reports.pageable.offset + reports.numberOfElements}">20</span>번째 표시
+            <span th:text="${reports.pageable.offset + 1}">1</span>–<span
+                th:text="${reports.pageable.offset + reports.numberOfElements}">20</span>번째 표시
         </span>
         <div class="pagination-compact" th:if="${reports.totalPages > 1}">
             <a class="page-btn" th:if="${!reports.first}"
-               th:href="@{/admin/reports(page=${reports.number - 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">‹ 이전</a>
+               th:href="@{/admin/reports(page=${reports.number - 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">‹
+                이전</a>
             <span class="page-current" th:text="${reports.number + 1}"></span>
             <span class="page-info">/ <span th:text="${reports.totalPages}"></span></span>
             <a class="page-btn" th:if="${!reports.last}"
-               th:href="@{/admin/reports(page=${reports.number + 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">다음 ›</a>
+               th:href="@{/admin/reports(page=${reports.number + 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">다음
+                ›</a>
         </div>
     </div>
 
@@ -130,7 +133,8 @@
 
         <div class="pagination" th:if="${reports.totalPages > 1}">
             <a class="page-btn" th:if="${!reports.first}"
-               th:href="@{/admin/reports(page=${reports.number - 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">← 이전</a>
+               th:href="@{/admin/reports(page=${reports.number - 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">←
+                이전</a>
             <a class="page-btn" th:if="${pageStart > 0}"
                th:href="@{/admin/reports(page=0, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">1</a>
             <span class="page-ellipsis" th:if="${pageStart > 1}">…</span>
@@ -145,7 +149,8 @@
                th:href="@{/admin/reports(page=${reports.totalPages - 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}"
                th:text="${reports.totalPages}"></a>
             <a class="page-btn" th:if="${!reports.last}"
-               th:href="@{/admin/reports(page=${reports.number + 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">다음 →</a>
+               th:href="@{/admin/reports(page=${reports.number + 1}, status=${statusFilter}, category=${categoryFilter}, gameType=${gameTypeFilter})}">다음
+                →</a>
         </div>
     </div>
 </main>

--- a/backend/src/test/java/coffeeshout/fixture/PatchNoteFixture.java
+++ b/backend/src/test/java/coffeeshout/fixture/PatchNoteFixture.java
@@ -1,0 +1,18 @@
+package coffeeshout.fixture;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
+
+public final class PatchNoteFixture {
+
+    private PatchNoteFixture() {
+    }
+
+    public static PatchNoteEntity 공지_패치노트() {
+        return PatchNoteEntity.create(PatchNoteCategory.NOTICE, "1.0.0 공지사항", "서버 점검이 예정되어 있습니다.");
+    }
+
+    public static PatchNoteEntity 업데이트_패치노트() {
+        return PatchNoteEntity.create(PatchNoteCategory.UPDATE, "1.1.0 업데이트", "새로운 미니게임이 추가되었습니다.");
+    }
+}

--- a/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteAdminServiceTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteAdminServiceTest.java
@@ -1,0 +1,140 @@
+package coffeeshout.patchnote.application;
+
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.patchnote.application.PatchNoteAdminService.AdminRow;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.exception.PatchNoteErrorCode;
+import coffeeshout.patchnote.infra.persistence.PatchNoteJpaRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PatchNoteAdminServiceTest extends ServiceTest {
+
+    @Autowired
+    private PatchNoteAdminService patchNoteAdminService;
+
+    @Autowired
+    private PatchNoteJpaRepository patchNoteJpaRepository;
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        void 패치노트를_저장하고_id를_반환한다() {
+            final Long id = patchNoteAdminService.create(PatchNoteCategory.NOTICE, "공지 제목", "공지 본문입니다.");
+
+            assertThat(patchNoteJpaRepository.findById(id)).isPresent();
+        }
+
+        @Test
+        void 저장된_패치노트_필드가_일치한다() {
+            final Long id = patchNoteAdminService.create(PatchNoteCategory.UPDATE, "업데이트 제목", "업데이트 내용");
+
+            final var saved = patchNoteJpaRepository.findById(id).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(saved.getCategory()).isEqualTo(PatchNoteCategory.UPDATE);
+                softly.assertThat(saved.getTitle()).isEqualTo("업데이트 제목");
+                softly.assertThat(saved.getContent()).isEqualTo("업데이트 내용");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAll {
+
+        @Test
+        void 최신순으로_반환한다() {
+            patchNoteAdminService.create(PatchNoteCategory.NOTICE, "첫 번째 공지", "내용1");
+            patchNoteAdminService.create(PatchNoteCategory.EVENT, "두 번째 이벤트", "내용2");
+
+            final List<AdminRow> result = patchNoteAdminService.findAll();
+
+            assertThat(result.getFirst().title()).isEqualTo("두 번째 이벤트");
+        }
+
+        @Test
+        void 패치노트가_없으면_빈_목록을_반환한다() {
+            assertThat(patchNoteAdminService.findAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findById")
+    class FindById {
+
+        @Test
+        void id로_패치노트를_조회한다() {
+            final Long id = patchNoteAdminService.create(PatchNoteCategory.MAINTENANCE, "점검 공지", "점검 예정입니다.");
+
+            final AdminRow row = patchNoteAdminService.findById(id);
+
+            assertSoftly(softly -> {
+                softly.assertThat(row.category()).isEqualTo(PatchNoteCategory.MAINTENANCE);
+                softly.assertThat(row.title()).isEqualTo("점검 공지");
+            });
+        }
+
+        @Test
+        void 존재하지_않는_id이면_예외가_발생한다() {
+            assertCoffeeShoutException(
+                    () -> patchNoteAdminService.findById(999L),
+                    PatchNoteErrorCode.NOT_FOUND
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        void 패치노트를_수정한다() {
+            final Long id = patchNoteAdminService.create(PatchNoteCategory.NOTICE, "원래 제목", "원래 본문");
+
+            patchNoteAdminService.update(id, PatchNoteCategory.EVENT, "수정 제목", "수정 본문");
+
+            final var updated = patchNoteJpaRepository.findById(id).orElseThrow();
+            assertSoftly(softly -> {
+                softly.assertThat(updated.getCategory()).isEqualTo(PatchNoteCategory.EVENT);
+                softly.assertThat(updated.getTitle()).isEqualTo("수정 제목");
+                softly.assertThat(updated.getContent()).isEqualTo("수정 본문");
+            });
+        }
+
+        @Test
+        void 존재하지_않는_id이면_예외가_발생한다() {
+            assertCoffeeShoutException(
+                    () -> patchNoteAdminService.update(999L, PatchNoteCategory.NOTICE, "제목", "본문"),
+                    PatchNoteErrorCode.NOT_FOUND
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        void 패치노트를_삭제한다() {
+            final Long id = patchNoteAdminService.create(PatchNoteCategory.NOTICE, "공지", "내용");
+
+            patchNoteAdminService.delete(id);
+
+            assertThat(patchNoteJpaRepository.findById(id)).isEmpty();
+        }
+
+        @Test
+        void 존재하지_않는_id를_삭제해도_예외가_발생하지_않는다() {
+            patchNoteAdminService.delete(999L);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteAdminServiceTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteAdminServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import coffeeshout.global.ServiceTest;
-import coffeeshout.patchnote.application.PatchNoteAdminService.AdminRow;
 import coffeeshout.patchnote.domain.PatchNoteCategory;
 import coffeeshout.patchnote.exception.PatchNoteErrorCode;
 import coffeeshout.patchnote.infra.persistence.PatchNoteJpaRepository;

--- a/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteQueryServiceTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/application/PatchNoteQueryServiceTest.java
@@ -1,0 +1,64 @@
+package coffeeshout.patchnote.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.ServiceTest;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.infra.persistence.PatchNoteEntity;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PatchNoteQueryServiceTest extends ServiceTest {
+
+    @Autowired
+    private PatchNoteAdminService patchNoteAdminService;
+
+    @Autowired
+    private PatchNoteQueryService patchNoteQueryService;
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAll {
+
+        @Test
+        void 모든_패치노트를_최신순으로_반환한다() {
+            patchNoteAdminService.create(PatchNoteCategory.NOTICE, "첫 번째", "내용1");
+            patchNoteAdminService.create(PatchNoteCategory.EVENT, "두 번째", "내용2");
+
+            final List<PatchNoteEntity> result = patchNoteQueryService.findAll();
+
+            assertThat(result).hasSize(2);
+            assertThat(result.getFirst().getTitle()).isEqualTo("두 번째");
+        }
+
+        @Test
+        void 패치노트가_없으면_빈_목록을_반환한다() {
+            assertThat(patchNoteQueryService.findAll()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findLatest")
+    class FindLatest {
+
+        @Test
+        void 가장_최신_패치노트를_반환한다() {
+            patchNoteAdminService.create(PatchNoteCategory.NOTICE, "오래된 공지", "내용1");
+            patchNoteAdminService.create(PatchNoteCategory.UPDATE, "최신 업데이트", "내용2");
+
+            final Optional<PatchNoteEntity> result = patchNoteQueryService.findLatest();
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getTitle()).isEqualTo("최신 업데이트");
+        }
+
+        @Test
+        void 패치노트가_없으면_빈_Optional을_반환한다() {
+            assertThat(patchNoteQueryService.findLatest()).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntityTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntityTest.java
@@ -1,0 +1,142 @@
+package coffeeshout.patchnote.infra.persistence;
+
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import coffeeshout.patchnote.exception.PatchNoteErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PatchNoteEntityTest {
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        void 필드가_정상적으로_설정된다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "1.0.0 공지", "서버 점검 예정입니다.");
+
+            assertSoftly(softly -> {
+                softly.assertThat(entity.getCategory()).isEqualTo(PatchNoteCategory.NOTICE);
+                softly.assertThat(entity.getTitle()).isEqualTo("1.0.0 공지");
+                softly.assertThat(entity.getContent()).isEqualTo("서버 점검 예정입니다.");
+                softly.assertThat(entity.getCreatedAt()).isNotNull();
+                softly.assertThat(entity.getUpdatedAt()).isEqualTo(entity.getCreatedAt());
+            });
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void 제목이_공백이면_예외가_발생한다(String title) {
+            assertCoffeeShoutException(
+                    () -> PatchNoteEntity.create(PatchNoteCategory.NOTICE, title, "본문입니다."),
+                    PatchNoteErrorCode.INVALID_TITLE
+            );
+        }
+
+        @Test
+        void 제목이_100자를_초과하면_예외가_발생한다() {
+            final String longTitle = "가".repeat(101);
+
+            assertCoffeeShoutException(
+                    () -> PatchNoteEntity.create(PatchNoteCategory.NOTICE, longTitle, "본문입니다."),
+                    PatchNoteErrorCode.INVALID_TITLE
+            );
+        }
+
+        @Test
+        void 제목이_정확히_100자이면_정상_생성된다() {
+            final String title = "가".repeat(100);
+
+            final PatchNoteEntity entity = PatchNoteEntity.create(PatchNoteCategory.NOTICE, title, "본문입니다.");
+
+            assertThat(entity.getTitle()).hasSize(100);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void 본문이_공백이면_예외가_발생한다(String content) {
+            assertCoffeeShoutException(
+                    () -> PatchNoteEntity.create(PatchNoteCategory.NOTICE, "제목", content),
+                    PatchNoteErrorCode.INVALID_CONTENT
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        void 필드가_모두_갱신된다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "원래 제목", "원래 본문");
+
+            entity.update(PatchNoteCategory.EVENT, "수정 제목", "수정 본문");
+
+            assertSoftly(softly -> {
+                softly.assertThat(entity.getCategory()).isEqualTo(PatchNoteCategory.EVENT);
+                softly.assertThat(entity.getTitle()).isEqualTo("수정 제목");
+                softly.assertThat(entity.getContent()).isEqualTo("수정 본문");
+            });
+        }
+
+        @Test
+        void updatedAt이_createdAt보다_이전이_아니다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+
+            entity.update(PatchNoteCategory.UPDATE, "새 제목", "새 본문");
+
+            assertThat(entity.getUpdatedAt()).isAfterOrEqualTo(entity.getCreatedAt());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void 제목이_공백이면_예외가_발생한다(String title) {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+
+            assertCoffeeShoutException(
+                    () -> entity.update(PatchNoteCategory.NOTICE, title, "본문"),
+                    PatchNoteErrorCode.INVALID_TITLE
+            );
+        }
+
+        @Test
+        void 제목이_100자를_초과하면_예외가_발생한다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+            final String longTitle = "가".repeat(101);
+
+            assertCoffeeShoutException(
+                    () -> entity.update(PatchNoteCategory.NOTICE, longTitle, "본문"),
+                    PatchNoteErrorCode.INVALID_TITLE
+            );
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   "})
+        void 본문이_공백이면_예외가_발생한다(String content) {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+
+            assertCoffeeShoutException(
+                    () -> entity.update(PatchNoteCategory.NOTICE, "제목", content),
+                    PatchNoteErrorCode.INVALID_CONTENT
+            );
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntityTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/infra/persistence/PatchNoteEntityTest.java
@@ -62,6 +62,14 @@ class PatchNoteEntityTest {
             assertThat(entity.getTitle()).hasSize(100);
         }
 
+        @Test
+        void 카테고리가_null이면_예외가_발생한다() {
+            assertCoffeeShoutException(
+                    () -> PatchNoteEntity.create(null, "제목", "본문입니다."),
+                    PatchNoteErrorCode.INVALID_CATEGORY
+            );
+        }
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {"   "})
@@ -70,6 +78,25 @@ class PatchNoteEntityTest {
                     () -> PatchNoteEntity.create(PatchNoteCategory.NOTICE, "제목", content),
                     PatchNoteErrorCode.INVALID_CONTENT
             );
+        }
+
+        @Test
+        void 본문이_5000자를_초과하면_예외가_발생한다() {
+            final String longContent = "가".repeat(5001);
+
+            assertCoffeeShoutException(
+                    () -> PatchNoteEntity.create(PatchNoteCategory.NOTICE, "제목", longContent),
+                    PatchNoteErrorCode.INVALID_CONTENT_LENGTH
+            );
+        }
+
+        @Test
+        void 본문이_정확히_5000자이면_정상_생성된다() {
+            final String content = "가".repeat(5000);
+
+            final PatchNoteEntity entity = PatchNoteEntity.create(PatchNoteCategory.NOTICE, "제목", content);
+
+            assertThat(entity.getContent()).hasSize(5000);
         }
     }
 
@@ -126,6 +153,17 @@ class PatchNoteEntityTest {
             );
         }
 
+        @Test
+        void 카테고리가_null이면_예외가_발생한다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+
+            assertCoffeeShoutException(
+                    () -> entity.update(null, "제목", "본문"),
+                    PatchNoteErrorCode.INVALID_CATEGORY
+            );
+        }
+
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = {"   "})
@@ -136,6 +174,18 @@ class PatchNoteEntityTest {
             assertCoffeeShoutException(
                     () -> entity.update(PatchNoteCategory.NOTICE, "제목", content),
                     PatchNoteErrorCode.INVALID_CONTENT
+            );
+        }
+
+        @Test
+        void 본문이_5000자를_초과하면_예외가_발생한다() {
+            final PatchNoteEntity entity = PatchNoteEntity.create(
+                    PatchNoteCategory.NOTICE, "제목", "본문");
+            final String longContent = "가".repeat(5001);
+
+            assertCoffeeShoutException(
+                    () -> entity.update(PatchNoteCategory.NOTICE, "제목", longContent),
+                    PatchNoteErrorCode.INVALID_CONTENT_LENGTH
             );
         }
     }

--- a/backend/src/test/java/coffeeshout/patchnote/ui/PatchNoteControllerTest.java
+++ b/backend/src/test/java/coffeeshout/patchnote/ui/PatchNoteControllerTest.java
@@ -1,0 +1,77 @@
+package coffeeshout.patchnote.ui;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import coffeeshout.fixture.IntegrationTestSupport;
+import coffeeshout.patchnote.application.PatchNoteAdminService;
+import coffeeshout.patchnote.domain.PatchNoteCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@DisplayName("PatchNoteController 통합 테스트")
+class PatchNoteControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    PatchNoteAdminService patchNoteAdminService;
+
+    @Nested
+    @DisplayName("GET /patch-notes")
+    class FindAll {
+
+        @Test
+        void 패치노트_목록을_최신순으로_반환한다() throws Exception {
+            patchNoteAdminService.create(PatchNoteCategory.NOTICE, "오래된 공지", "내용1");
+            patchNoteAdminService.create(PatchNoteCategory.UPDATE, "최신 업데이트", "내용2");
+
+            mockMvc.perform(get("/patch-notes"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()").value(2))
+                    .andExpect(jsonPath("$[0].title").value("최신 업데이트"))
+                    .andExpect(jsonPath("$[0].category").value("UPDATE"))
+                    .andExpect(jsonPath("$[0].categoryLabel").value("업데이트"))
+                    .andExpect(jsonPath("$[0].content").value("내용2"))
+                    .andExpect(jsonPath("$[1].title").value("오래된 공지"));
+        }
+
+        @Test
+        void 패치노트가_없으면_빈_배열을_반환한다() throws Exception {
+            mockMvc.perform(get("/patch-notes"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.length()").value(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /patch-notes/latest")
+    class FindLatest {
+
+        @Test
+        void 최신_패치노트를_반환한다() throws Exception {
+            patchNoteAdminService.create(PatchNoteCategory.NOTICE, "오래된 공지", "내용1");
+            patchNoteAdminService.create(PatchNoteCategory.EVENT, "최신 이벤트", "이벤트 본문");
+
+            mockMvc.perform(get("/patch-notes/latest"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value("최신 이벤트"))
+                    .andExpect(jsonPath("$.category").value("EVENT"))
+                    .andExpect(jsonPath("$.categoryLabel").value("이벤트"))
+                    .andExpect(jsonPath("$.content").value("이벤트 본문"));
+        }
+
+        @Test
+        void 패치노트가_없으면_204를_반환한다() throws Exception {
+            mockMvc.perform(get("/patch-notes/latest"))
+                    .andExpect(status().isNoContent());
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1194

# 🚀 작업 내용

변경 사항

  운영진이 공지·이벤트·업데이트·점검 안내를 작성할 수 있는 패치노트 기능을 추가합니다.

  어드민 대시보드 (/admin/patch-notes)
  - 패치노트 목록 조회, 작성, 수정, 삭제
  - 카테고리: NOTICE / EVENT / UPDATE / MAINTENANCE

  공개 API
  - GET /patch-notes — 전체 목록 (최신순, 본문 포함)
  - GET /patch-notes/latest — 최신 1건. 없으면 204

  주요 구현

  - V19__create_patch_note_table.sql — patch_note 테이블 추가
  - coffeeshout.patchnote 신규 컨텍스트 (domain → application → ui 4계층)
  - 기존 어드민 인증(adminFilterChain) 그대로 적용, Security 변경 없음

# 💬 리뷰 중점사항

중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 패치노트 관리 기능 추가(생성·조회·수정·삭제) 및 관리자 UI(목록/작성/편집) 추가
  * 공개 API 엔드포인트 추가(전체 조회, 최신 패치노트 조회)
  * 관리자 대시보드에 패치노트 카드 추가
* **데이터베이스**
  * 패치노트 테이블 추가 마이그레이션 적용
* **테스트**
  * 관련 서비스·컨트롤러·엔티티 단위/통합 테스트 추가
* **문서/템플릿**
  * 관리자 페이지 타이틀 브랜드명 변경(ZZOL) 및 템플릿 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->