### PR TITLE
[fix] Google·Naver 로그인 버튼 공식 브랜딩 가이드라인 적용

### DIFF
--- a/frontend/src/features/auth/components/ProviderButton/ProviderButton.styled.ts
+++ b/frontend/src/features/auth/components/ProviderButton/ProviderButton.styled.ts
@@ -1,37 +1,56 @@
 import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
 import { OAuthProvider } from '../../types';
 
 const BG: Record<OAuthProvider, string> = {
-  google: '#FFFFFF',
-  kakao: '#FEE500',
-  naver: '#03C75A',
+  google: theme.color.oauth.google.bg,
+  kakao: theme.color.oauth.kakao.bg,
+  naver: theme.color.oauth.naver.bg,
 };
 
 const TEXT: Record<OAuthProvider, string> = {
-  google: '#191919',
-  kakao: '#191919',
-  naver: '#FFFFFF',
+  google: theme.color.oauth.google.text,
+  kakao: theme.color.oauth.kakao.text,
+  naver: theme.color.oauth.naver.text,
 };
 
 const BORDER: Record<OAuthProvider, string> = {
-  google: '#E5E7EB',
+  google: theme.color.oauth.google.border,
   kakao: 'transparent',
   naver: 'transparent',
+};
+
+const FONT_SIZE: Record<OAuthProvider, string> = {
+  google: '14px',
+  kakao: '15px',
+  naver: '16px',
+};
+
+const FONT_WEIGHT: Record<OAuthProvider, number> = {
+  google: 500,
+  kakao: 600,
+  naver: 600,
+};
+
+const GAP: Record<OAuthProvider, string> = {
+  google: '10px',
+  kakao: '10px',
+  naver: '8px',
 };
 
 export const Button = styled.button<{ $provider: OAuthProvider }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: ${({ $provider }) => GAP[$provider]};
   width: 100%;
   padding: 14px 0;
   border: 1px solid ${({ $provider }) => BORDER[$provider]};
   border-radius: 12px;
   background-color: ${({ $provider }) => BG[$provider]};
   color: ${({ $provider }) => TEXT[$provider]};
-  font-size: 15px;
-  font-weight: 600;
+  font-size: ${({ $provider }) => FONT_SIZE[$provider]};
+  font-weight: ${({ $provider }) => FONT_WEIGHT[$provider]};
   cursor: pointer;
   transition: opacity 0.15s ease;
 

--- a/frontend/src/features/auth/components/ProviderButton/providerIcons.tsx
+++ b/frontend/src/features/auth/components/ProviderButton/providerIcons.tsx
@@ -33,8 +33,7 @@ export const KakaoIcon = (props: IconProps) => (
 );
 
 export const NaverIcon = (props: IconProps) => (
-  <svg viewBox="0 0 24 24" width="20" height="20" {...props}>
-    <rect width="24" height="24" rx="2" fill="#03C75A" />
+  <svg viewBox="0 0 24 24" width="25" height="25" {...props}>
     <path d="M13.75 12.3L10.1 6H7v12h3.25V11.7L13.9 18H17V6h-3.25v6.3z" fill="white" />
   </svg>
 );

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -29,6 +29,22 @@ const color = {
   white: '#FFFFFF',
   black: '#000000',
   yellow: '#FFDF20',
+
+  oauth: {
+    google: {
+      bg: '#FFFFFF',
+      text: '#1F1F1F',
+      border: '#747775',
+    },
+    kakao: {
+      bg: '#FEE500',
+      text: '#191919',
+    },
+    naver: {
+      bg: '#03A94D',
+      text: '#FFFFFF',
+    },
+  },
 } as const;
 
 const typography = {


### PR DESCRIPTION
## Summary

- `theme.color.oauth` 토큰 추가 — Google/Kakao/Naver 브랜드 색상을 theme에서 일원 관리
- `ProviderButton.styled.ts` 하드코딩 hex 값을 모두 theme 토큰으로 교체
- Google 공식 가이드라인 반영: 텍스트 `#1F1F1F`, 테두리 `#747775`, 폰트 14px/500
- Naver 공식 가이드라인 반영: 배경 `#03A94D`, 폰트 16px, 아이콘-텍스트 gap 8px
- `NaverIcon` 내부 중복 배경 rect 제거 (버튼 배경색과 중복)

## Test plan

- [ ] Google 로그인 버튼: 흰 배경, 회색 테두리(`#747775`), 텍스트 색상 `#1F1F1F` 확인
- [ ] Naver 로그인 버튼: 배경 `#03A94D`, 흰 N 아이콘, 아이콘-텍스트 간격 8px 확인
- [ ] Kakao 로그인 버튼: 기존 스타일 변경 없음 확인
- [ ] 세 버튼 모두 클릭 시 OAuth 플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)