### PR TITLE
[feat] 회원 탈퇴 soft delete 전환 및 개인정보 익명화

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -56,3 +56,7 @@ docker/monitoring/dashboards/
 docker/monitoring/provisioning/*
 !docker/monitoring/provisioning/alerting
 !docker/monitoring/provisioning/alerting/**
+
+
+# TEST
+/test_output.log

--- a/backend/src/main/java/coffeeshout/report/domain/ReportAnonymizationRepository.java
+++ b/backend/src/main/java/coffeeshout/report/domain/ReportAnonymizationRepository.java
@@ -1,0 +1,6 @@
+package coffeeshout.report.domain;
+
+public interface ReportAnonymizationRepository {
+
+    void clearUserCodeByUserId(Long userId);
+}

--- a/backend/src/main/java/coffeeshout/report/infra/persistence/ReportRepository.java
+++ b/backend/src/main/java/coffeeshout/report/infra/persistence/ReportRepository.java
@@ -14,7 +14,7 @@ public interface ReportRepository extends JpaRepository<Report, Long>, ReportAdm
     long countByStatus(ReportStatus status);
 
     @Override
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
     @Query("UPDATE Report r SET r.author.userCode = null WHERE r.author.userId = :userId")
     void clearUserCodeByUserId(@Param("userId") Long userId);

--- a/backend/src/main/java/coffeeshout/report/infra/persistence/ReportRepository.java
+++ b/backend/src/main/java/coffeeshout/report/infra/persistence/ReportRepository.java
@@ -1,9 +1,21 @@
 package coffeeshout.report.infra.persistence;
 
+import coffeeshout.report.domain.ReportAnonymizationRepository;
 import coffeeshout.report.domain.ReportStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
-public interface ReportRepository extends JpaRepository<Report, Long>, ReportAdminQueryRepository {
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportAdminQueryRepository,
+        ReportAnonymizationRepository {
 
     long countByStatus(ReportStatus status);
+
+    @Override
+    @Modifying
+    @Transactional
+    @Query("UPDATE Report r SET r.author.userCode = null WHERE r.author.userId = :userId")
+    void clearUserCodeByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
@@ -6,11 +6,13 @@ import coffeeshout.user.domain.repository.RefreshTokenRepository;
 import coffeeshout.user.domain.repository.UserRepository;
 import coffeeshout.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserWithdrawalService {
@@ -28,7 +30,11 @@ public class UserWithdrawalService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                refreshTokenRepository.deleteAllByUserId(userId);
+                try {
+                    refreshTokenRepository.deleteAllByUserId(userId);
+                } catch (Exception e) {
+                    log.error("회원 탈퇴 후 리프레시 토큰 삭제 실패 userId={}: {}", userId, e.getMessage(), e);
+                }
             }
         });
     }

--- a/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
@@ -8,6 +8,8 @@ import coffeeshout.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +23,13 @@ public class UserWithdrawalService {
     public void withdraw(Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
-        // Redis는 트랜잭션 외부: 삭제 성공 후 DB 실패 시 토큰만 소멸된 채 롤백됨 (재로그인으로 복구 가능, 의도된 순서)
-        refreshTokenRepository.deleteAllByUserId(userId);
         reportAnonymizationRepository.clearUserCodeByUserId(userId);
         userRepository.deleteById(userId);
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                refreshTokenRepository.deleteAllByUserId(userId);
+            }
+        });
     }
 }

--- a/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
@@ -1,10 +1,8 @@
 package coffeeshout.user.application.service;
 
-import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.report.domain.ReportAnonymizationRepository;
 import coffeeshout.user.domain.repository.RefreshTokenRepository;
 import coffeeshout.user.domain.repository.UserRepository;
-import coffeeshout.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,10 +21,8 @@ public class UserWithdrawalService {
 
     @Transactional
     public void withdraw(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
         reportAnonymizationRepository.clearUserCodeByUserId(userId);
-        userRepository.deleteById(userId);
+        userRepository.softDeleteById(userId);
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {

--- a/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
@@ -1,0 +1,29 @@
+package coffeeshout.user.application.service;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.report.domain.ReportAnonymizationRepository;
+import coffeeshout.user.domain.repository.RefreshTokenRepository;
+import coffeeshout.user.domain.repository.UserRepository;
+import coffeeshout.user.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserWithdrawalService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final ReportAnonymizationRepository reportAnonymizationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void withdraw(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
+        // Redis는 트랜잭션 외부: 삭제 성공 후 DB 실패 시 토큰만 소멸된 채 롤백됨 (재로그인으로 복구 가능, 의도된 순서)
+        refreshTokenRepository.deleteAllByUserId(userId);
+        reportAnonymizationRepository.clearUserCodeByUserId(userId);
+        userRepository.deleteById(userId);
+    }
+}

--- a/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
+++ b/backend/src/main/java/coffeeshout/user/application/service/UserWithdrawalService.java
@@ -23,7 +23,11 @@ public class UserWithdrawalService {
     public void withdraw(Long userId) {
         reportAnonymizationRepository.clearUserCodeByUserId(userId);
         userRepository.softDeleteById(userId);
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+        TransactionSynchronizationManager.registerSynchronization(deleteRefreshTokenAfterCommit(userId));
+    }
+
+    private TransactionSynchronization deleteRefreshTokenAfterCommit(Long userId) {
+        return new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 try {
@@ -32,6 +36,6 @@ public class UserWithdrawalService {
                     log.error("회원 탈퇴 후 리프레시 토큰 삭제 실패 userId={}: {}", userId, e.getMessage(), e);
                 }
             }
-        });
+        };
     }
 }

--- a/backend/src/main/java/coffeeshout/user/config/RefreshTokenCookieHelper.java
+++ b/backend/src/main/java/coffeeshout/user/config/RefreshTokenCookieHelper.java
@@ -1,0 +1,39 @@
+package coffeeshout.user.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenCookieHelper {
+
+    public static final String COOKIE_NAME = "refreshToken";
+
+    private final JwtProperties jwtProperties;
+
+    public void set(HttpServletResponse response, String token) {
+        final ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, token)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofSeconds(jwtProperties.refreshTokenExpirationSeconds()))
+                .sameSite("None")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public void clear(HttpServletResponse response) {
+        final ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/backend/src/main/java/coffeeshout/user/config/RefreshTokenCookieHelper.java
+++ b/backend/src/main/java/coffeeshout/user/config/RefreshTokenCookieHelper.java
@@ -16,24 +16,22 @@ public class RefreshTokenCookieHelper {
     private final JwtProperties jwtProperties;
 
     public void set(HttpServletResponse response, String token) {
-        final ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, token)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
+        final ResponseCookie cookie = base(token)
                 .maxAge(Duration.ofSeconds(jwtProperties.refreshTokenExpirationSeconds()))
-                .sameSite("None")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     public void clear(HttpServletResponse response) {
-        final ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, "")
+        final ResponseCookie cookie = base("").maxAge(0).build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private ResponseCookie.ResponseCookieBuilder base(String value) {
+        return ResponseCookie.from(COOKIE_NAME, value)
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .maxAge(0)
-                .sameSite("None")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+                .sameSite("None");
     }
 }

--- a/backend/src/main/java/coffeeshout/user/domain/repository/UserRepository.java
+++ b/backend/src/main/java/coffeeshout/user/domain/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository {
     Optional<User> findByProviderAndProviderUserId(String provider, String providerUserId);
 
     List<User> findAllByNickname(UserNickname nickname);
+
+    void deleteById(Long id);
 }

--- a/backend/src/main/java/coffeeshout/user/domain/repository/UserRepository.java
+++ b/backend/src/main/java/coffeeshout/user/domain/repository/UserRepository.java
@@ -15,5 +15,5 @@ public interface UserRepository {
 
     List<User> findAllByNickname(UserNickname nickname);
 
-    void deleteById(Long id);
+    void softDeleteById(Long userId);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
@@ -3,6 +3,7 @@ package coffeeshout.user.infra.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +26,8 @@ public class OAuthAccountEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE"))
     private UserEntity user;
 
     @Column(nullable = false, length = 20)

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,13 +38,13 @@ public class OAuthAccountEntity {
     private String email;
 
     @Column(nullable = false)
-    private LocalDateTime linkedAt;
+    private Instant linkedAt;
 
     public OAuthAccountEntity(UserEntity user, String provider, String providerUserId, String email) {
         this.user = user;
         this.provider = provider;
         this.providerUserId = providerUserId;
         this.email = email;
-        this.linkedAt = LocalDateTime.now();
+        this.linkedAt = Instant.now();
     }
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountEntity.java
@@ -3,7 +3,6 @@ package coffeeshout.user.infra.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,8 +25,7 @@ public class OAuthAccountEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false,
-            foreignKey = @ForeignKey(foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE"))
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     @Column(nullable = false, length = 20)

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
@@ -19,7 +19,7 @@ public interface OAuthAccountJpaRepository extends JpaRepository<OAuthAccountEnt
 
     List<OAuthAccountEntity> findAllByUser_IdIn(List<Long> userIds);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("DELETE FROM OAuthAccountEntity o WHERE o.user.id = :userId")
     void deleteByUser_Id(@Param("userId") Long userId);
 

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
@@ -3,6 +3,7 @@ package coffeeshout.user.infra.persistence;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,5 +19,10 @@ public interface OAuthAccountJpaRepository extends JpaRepository<OAuthAccountEnt
 
     List<OAuthAccountEntity> findAllByUser_IdIn(List<Long> userIds);
 
-    void deleteByUser_Id(Long userId);
+    @Modifying
+    @Query("DELETE FROM OAuthAccountEntity o WHERE o.user.id = :userId")
+    void deleteByUser_Id(@Param("userId") Long userId);
+
+    @Query(value = "SELECT COUNT(*) FROM oauth_account WHERE user_id = :userId", nativeQuery = true)
+    long countByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/OAuthAccountJpaRepository.java
@@ -17,4 +17,6 @@ public interface OAuthAccountJpaRepository extends JpaRepository<OAuthAccountEnt
     Optional<OAuthAccountEntity> findByUser_Id(Long userId);
 
     List<OAuthAccountEntity> findAllByUser_IdIn(List<Long> userIds);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -1,5 +1,7 @@
 package coffeeshout.user.infra.persistence;
 
+import coffeeshout.global.exception.GlobalErrorCode;
+import coffeeshout.global.exception.custom.SystemException;
 import coffeeshout.user.domain.OAuthAccount;
 import coffeeshout.user.domain.OAuthProvider;
 import coffeeshout.user.domain.User;
@@ -24,8 +26,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
 
-    private static final String ANONYMIZED_NICKNAME = "탈퇴한 사용자";
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,7 +33,7 @@ public class UserEntity {
     @Column(name = "user_code", nullable = false, unique = true, updatable = false, length = 5)
     private String userCode;
 
-    @Column(nullable = false, length = 10)
+    @Column(length = 10)
     private String nickname;
 
     @Column(nullable = false)
@@ -68,7 +68,7 @@ public class UserEntity {
     }
 
     public void anonymize() {
-        this.nickname = ANONYMIZED_NICKNAME;
+        this.nickname = null;
         this.updatedAt = Instant.now();
     }
 
@@ -81,6 +81,9 @@ public class UserEntity {
     }
 
     public User toDomain(OAuthAccountEntity oAuthAccountEntity) {
+        if (isDeleted()) {
+            throw new SystemException(GlobalErrorCode.INTERNAL_SERVER_ERROR, "탈퇴한 사용자를 도메인 객체로 변환하려 했습니다. userId: " + id);
+        }
         final OAuthAccount oAuthAccount = new OAuthAccount(
                 OAuthProvider.from(oAuthAccountEntity.getProvider()),
                 oAuthAccountEntity.getProviderUserId(),

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.SQLRestriction;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "app_user")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -63,8 +63,10 @@ public class UserEntity {
         }
     }
 
+    private static final String ANONYMIZED_NICKNAME = "탈퇴한 사용자";
+
     public void anonymize() {
-        this.nickname = "탈퇴한 사용자";
+        this.nickname = ANONYMIZED_NICKNAME;
         this.updatedAt = Instant.now();
     }
 

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -24,6 +24,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserEntity {
 
+    private static final String ANONYMIZED_NICKNAME = "탈퇴한 사용자";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -64,8 +66,6 @@ public class UserEntity {
             this.termsAgreedAt = Instant.now();
         }
     }
-
-    private static final String ANONYMIZED_NICKNAME = "탈퇴한 사용자";
 
     public void anonymize() {
         this.nickname = ANONYMIZED_NICKNAME;

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserEntity.java
@@ -41,6 +41,9 @@ public class UserEntity {
     @Column(name = "terms_agreed_at")
     private Instant termsAgreedAt;
 
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
     public UserEntity(String userCode, String nickname) {
         final Instant now = Instant.now();
         this.userCode = userCode;
@@ -58,6 +61,19 @@ public class UserEntity {
         if (this.termsAgreedAt == null) {
             this.termsAgreedAt = Instant.now();
         }
+    }
+
+    public void anonymize() {
+        this.nickname = "탈퇴한 사용자";
+        this.updatedAt = Instant.now();
+    }
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 
     public User toDomain(OAuthAccountEntity oAuthAccountEntity) {

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
-    Optional<UserEntity> findByUserCode(String userCode);
+    Optional<UserEntity> findByUserCodeAndDeletedAtIsNull(String userCode);
 
-    List<UserEntity> findAllByNickname(String nickname);
+    List<UserEntity> findAllByNicknameAndDeletedAtIsNull(String nickname);
 
     Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
@@ -3,12 +3,15 @@ package coffeeshout.user.infra.persistence;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
-    Optional<UserEntity> findByUserCodeAndDeletedAtIsNull(String userCode);
+    Optional<UserEntity> findByUserCode(String userCode);
 
-    List<UserEntity> findAllByNicknameAndDeletedAtIsNull(String nickname);
+    List<UserEntity> findAllByNickname(String nickname);
 
-    Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
+    @Query(value = "SELECT * FROM app_user WHERE id = :id", nativeQuery = true)
+    Optional<UserEntity> findByIdIgnoringDeletedAt(@Param("id") Long id);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
@@ -12,6 +12,7 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
     List<UserEntity> findAllByNickname(String nickname);
 
+    // @SQLRestriction을 우회하여 soft delete된 사용자를 포함해 조회한다 (테스트 및 어드민 전용)
     @Query(value = "SELECT * FROM app_user WHERE id = :id", nativeQuery = true)
     Optional<UserEntity> findByIdIgnoringDeletedAt(@Param("id") Long id);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserJpaRepository.java
@@ -9,4 +9,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByUserCode(String userCode);
 
     List<UserEntity> findAllByNickname(String nickname);
+
+    Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -80,7 +80,6 @@ public class UserRepositoryImpl implements UserRepository {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
         userEntity.anonymize();
         userEntity.softDelete();
-        userJpaRepository.save(userEntity);
         oAuthAccountJpaRepository.deleteByUser_Id(userId);
     }
 

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -60,7 +60,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public Optional<User> findById(Long id) {
-        return userJpaRepository.findById(id)
+        return userJpaRepository.findByIdAndDeletedAtIsNull(id)
                 .flatMap(userEntity -> oAuthAccountJpaRepository.findByUser_Id(id)
                         .map(userEntity::toDomain));
     }
@@ -73,8 +73,13 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public void deleteById(Long id) {
-        userJpaRepository.deleteById(id);
+    public void softDeleteById(Long userId) {
+        final UserEntity userEntity = userJpaRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
+        oAuthAccountJpaRepository.deleteByUser_Id(userId);
+        userEntity.anonymize();
+        userEntity.softDelete();
+        userJpaRepository.save(userEntity);
     }
 
     @Override

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -76,15 +76,15 @@ public class UserRepositoryImpl implements UserRepository {
     public void softDeleteById(Long userId) {
         final UserEntity userEntity = userJpaRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
-        oAuthAccountJpaRepository.deleteByUser_Id(userId);
         userEntity.anonymize();
         userEntity.softDelete();
         userJpaRepository.save(userEntity);
+        oAuthAccountJpaRepository.deleteByUser_Id(userId);
     }
 
     @Override
     public List<User> findAllByNickname(UserNickname nickname) {
-        final List<UserEntity> users = userJpaRepository.findAllByNickname(nickname.value());
+        final List<UserEntity> users = userJpaRepository.findAllByNicknameAndDeletedAtIsNull(nickname.value());
         if (users.isEmpty()) {
             return List.of();
         }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -60,7 +60,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public Optional<User> findById(Long id) {
-        return userJpaRepository.findByIdAndDeletedAtIsNull(id)
+        return userJpaRepository.findById(id)
                 .flatMap(userEntity -> oAuthAccountJpaRepository.findByUser_Id(id)
                         .map(userEntity::toDomain));
     }
@@ -74,7 +74,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public void softDeleteById(Long userId) {
-        final UserEntity userEntity = userJpaRepository.findByIdAndDeletedAtIsNull(userId)
+        final UserEntity userEntity = userJpaRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));
         userEntity.anonymize();
         userEntity.softDelete();
@@ -84,7 +84,7 @@ public class UserRepositoryImpl implements UserRepository {
 
     @Override
     public List<User> findAllByNickname(UserNickname nickname) {
-        final List<UserEntity> users = userJpaRepository.findAllByNicknameAndDeletedAtIsNull(nickname.value());
+        final List<UserEntity> users = userJpaRepository.findAllByNickname(nickname.value());
         if (users.isEmpty()) {
             return List.of();
         }

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -73,6 +73,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public void deleteById(Long id) {
+        userJpaRepository.deleteById(id);
+    }
+
+    @Override
     public List<User> findAllByNickname(UserNickname nickname) {
         final List<UserEntity> users = userJpaRepository.findAllByNickname(nickname.value());
         if (users.isEmpty()) {

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -73,6 +74,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    @Transactional
     public void softDeleteById(Long userId) {
         final UserEntity userEntity = userJpaRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND, "존재하지 않는 회원입니다."));

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserStatsEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserStatsEntity.java
@@ -25,7 +25,7 @@ public class UserStatsEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false, unique = true,
-            foreignKey = @ForeignKey(foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE"))
+            foreignKey = @ForeignKey(name = "fk_user_stats_user", foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE"))
     private UserEntity user;
 
     @Column(nullable = false)

--- a/backend/src/main/java/coffeeshout/user/infra/persistence/UserStatsEntity.java
+++ b/backend/src/main/java/coffeeshout/user/infra/persistence/UserStatsEntity.java
@@ -4,6 +4,7 @@ import coffeeshout.user.domain.UserStats;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +24,8 @@ public class UserStatsEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @JoinColumn(name = "user_id", nullable = false, unique = true,
+            foreignKey = @ForeignKey(foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES app_user(id) ON DELETE CASCADE"))
     private UserEntity user;
 
     @Column(nullable = false)

--- a/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
@@ -2,7 +2,7 @@ package coffeeshout.user.ui;
 
 import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.user.application.service.AuthTokenService;
-import coffeeshout.user.config.JwtProperties;
+import coffeeshout.user.config.RefreshTokenCookieHelper;
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;
@@ -14,12 +14,9 @@ import jakarta.servlet.http.Cookie;
 import jakarta.validation.Valid;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,10 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthRestController {
 
-    static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-
     private final AuthTokenService authTokenService;
-    private final JwtProperties jwtProperties;
+    private final RefreshTokenCookieHelper cookieHelper;
 
     @PostMapping("/token")
     public ResponseEntity<AuthTokenResponse> exchangeCode(
@@ -42,7 +37,7 @@ public class AuthRestController {
             HttpServletResponse response
     ) {
         final OAuthCodeEntry entry = authTokenService.exchangeCode(request.code());
-        setRefreshTokenCookie(response, entry.tokenPair().refreshToken());
+        cookieHelper.set(response, entry.tokenPair().refreshToken());
         return ResponseEntity.ok(new AuthTokenResponse(entry.tokenPair().accessToken(), null, entry.isNewUser()));
     }
 
@@ -53,7 +48,7 @@ public class AuthRestController {
     ) {
         final String refreshToken = extractRefreshTokenCookie(request);
         final TokenPair tokens = authTokenService.rotate(refreshToken);
-        setRefreshTokenCookie(response, tokens.refreshToken());
+        cookieHelper.set(response, tokens.refreshToken());
         return ResponseEntity.ok(new AuthTokenResponse(tokens.accessToken(), null, false));
     }
 
@@ -63,7 +58,7 @@ public class AuthRestController {
             HttpServletResponse response
     ) {
         authUser.ifPresent(user -> authTokenService.revoke(user.userId()));
-        clearRefreshTokenCookie(response);
+        cookieHelper.clear(response);
         return ResponseEntity.noContent().build();
     }
 
@@ -72,32 +67,10 @@ public class AuthRestController {
             throw new BusinessException(UserErrorCode.REFRESH_TOKEN_NOT_FOUND, "리프레시 토큰이 없습니다.");
         }
         return Arrays.stream(request.getCookies())
-                .filter(c -> REFRESH_TOKEN_COOKIE_NAME.equals(c.getName()))
+                .filter(c -> RefreshTokenCookieHelper.COOKIE_NAME.equals(c.getName()))
                 .map(Cookie::getValue)
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(
                         UserErrorCode.REFRESH_TOKEN_NOT_FOUND, "리프레시 토큰이 없습니다."));
-    }
-
-    private void clearRefreshTokenCookie(HttpServletResponse response) {
-        final ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(0)
-                .sameSite("None")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-    }
-
-    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        final ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(Duration.ofSeconds(jwtProperties.refreshTokenExpirationSeconds()))
-                .sameSite("None")
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/AuthRestController.java
@@ -2,7 +2,6 @@ package coffeeshout.user.ui;
 
 import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.user.application.service.AuthTokenService;
-import coffeeshout.user.config.RefreshTokenCookieHelper;
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.OAuthCodeEntry;
 import coffeeshout.user.domain.TokenPair;

--- a/backend/src/main/java/coffeeshout/user/ui/RefreshTokenCookieHelper.java
+++ b/backend/src/main/java/coffeeshout/user/ui/RefreshTokenCookieHelper.java
@@ -1,5 +1,6 @@
-package coffeeshout.user.config;
+package coffeeshout.user.ui;
 
+import coffeeshout.user.config.JwtProperties;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
@@ -4,6 +4,7 @@ import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.user.application.service.TermsService;
 import coffeeshout.user.application.service.UserProfileService;
 import coffeeshout.user.application.service.UserStatsService;
+import coffeeshout.user.application.service.UserWithdrawalService;
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserStats;
@@ -17,6 +18,7 @@ import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +34,7 @@ public class UserRestController {
     private final UserProfileService userProfileService;
     private final UserStatsService userStatsService;
     private final TermsService termsService;
+    private final UserWithdrawalService userWithdrawalService;
 
     @GetMapping("/me")
     public ResponseEntity<UserMeResponse> getMe(@AuthUser Optional<AuthenticatedUser> authUser) {
@@ -65,6 +68,13 @@ public class UserRestController {
         final AuthenticatedUser user = requireAuthenticated(authUser);
         final UserStats stats = userStatsService.getStats(user.userId());
         return ResponseEntity.ok(UserStatsResponse.from(stats));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(@AuthUser Optional<AuthenticatedUser> authUser) {
+        final AuthenticatedUser user = requireAuthenticated(authUser);
+        userWithdrawalService.withdraw(user.userId());
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/me/terms")

--- a/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
@@ -5,7 +5,6 @@ import coffeeshout.user.application.service.TermsService;
 import coffeeshout.user.application.service.UserProfileService;
 import coffeeshout.user.application.service.UserStatsService;
 import coffeeshout.user.application.service.UserWithdrawalService;
-import coffeeshout.user.config.RefreshTokenCookieHelper;
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserStats;

--- a/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
+++ b/backend/src/main/java/coffeeshout/user/ui/UserRestController.java
@@ -5,6 +5,7 @@ import coffeeshout.user.application.service.TermsService;
 import coffeeshout.user.application.service.UserProfileService;
 import coffeeshout.user.application.service.UserStatsService;
 import coffeeshout.user.application.service.UserWithdrawalService;
+import coffeeshout.user.config.RefreshTokenCookieHelper;
 import coffeeshout.user.domain.AuthenticatedUser;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.UserStats;
@@ -14,6 +15,7 @@ import coffeeshout.user.ui.request.UpdateStatsRequest;
 import coffeeshout.user.ui.resolver.AuthUser;
 import coffeeshout.user.ui.response.UserMeResponse;
 import coffeeshout.user.ui.response.UserStatsResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class UserRestController {
     private final UserStatsService userStatsService;
     private final TermsService termsService;
     private final UserWithdrawalService userWithdrawalService;
+    private final RefreshTokenCookieHelper cookieHelper;
 
     @GetMapping("/me")
     public ResponseEntity<UserMeResponse> getMe(@AuthUser Optional<AuthenticatedUser> authUser) {
@@ -71,9 +74,13 @@ public class UserRestController {
     }
 
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMe(@AuthUser Optional<AuthenticatedUser> authUser) {
+    public ResponseEntity<Void> deleteMe(
+            @AuthUser Optional<AuthenticatedUser> authUser,
+            HttpServletResponse response
+    ) {
         final AuthenticatedUser user = requireAuthenticated(authUser);
         userWithdrawalService.withdraw(user.userId());
+        cookieHelper.clear(response);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/resources/db/migration/V21__soft_delete_user.sql
+++ b/backend/src/main/resources/db/migration/V21__soft_delete_user.sql
@@ -1,0 +1,10 @@
+-- app_user에 soft delete 타임스탬프 추가
+ALTER TABLE app_user
+    ADD COLUMN deleted_at TIMESTAMP(6) NULL DEFAULT NULL;
+
+-- oauth_account FK에서 ON DELETE CASCADE 제거 (탈퇴 시 명시적 삭제로 전환)
+ALTER TABLE oauth_account
+    DROP FOREIGN KEY fk_oauth_account_user;
+
+ALTER TABLE oauth_account
+    ADD CONSTRAINT fk_oauth_account_user FOREIGN KEY (user_id) REFERENCES app_user (id);

--- a/backend/src/main/resources/db/migration/V22__alter_oauth_account_linked_at_to_timestamp.sql
+++ b/backend/src/main/resources/db/migration/V22__alter_oauth_account_linked_at_to_timestamp.sql
@@ -1,0 +1,3 @@
+-- oauth_account.linked_at: DATETIME → TIMESTAMP(6) (Instant 타입 매핑 일관성)
+ALTER TABLE oauth_account
+    MODIFY COLUMN linked_at TIMESTAMP(6) NOT NULL;

--- a/backend/src/main/resources/db/migration/V23__add_index_app_user_deleted_at.sql
+++ b/backend/src/main/resources/db/migration/V23__add_index_app_user_deleted_at.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_app_user_deleted_at ON app_user (deleted_at);

--- a/backend/src/main/resources/db/migration/V23__add_index_app_user_deleted_at.sql
+++ b/backend/src/main/resources/db/migration/V23__add_index_app_user_deleted_at.sql
@@ -1,1 +1,0 @@
-CREATE INDEX idx_app_user_deleted_at ON app_user (deleted_at);

--- a/backend/src/main/resources/db/migration/V24__nullable_nickname_for_deleted_user.sql
+++ b/backend/src/main/resources/db/migration/V24__nullable_nickname_for_deleted_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app_user MODIFY COLUMN nickname VARCHAR(10) NULL;
+UPDATE app_user SET nickname = NULL WHERE deleted_at IS NOT NULL AND nickname IS NOT NULL;

--- a/backend/src/test/java/coffeeshout/fixture/IntegrationTestSupport.java
+++ b/backend/src/test/java/coffeeshout/fixture/IntegrationTestSupport.java
@@ -1,7 +1,13 @@
 package coffeeshout.fixture;
 
 import coffeeshout.support.test.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 
 @IntegrationTest
 public abstract class IntegrationTestSupport extends TestContainerSupport {
+
+    @BeforeEach
+    void cleanDatabaseBeforeEach() {
+        cleanDatabase();
+    }
 }

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -1,0 +1,91 @@
+package coffeeshout.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.fixture.UserFixture;
+import coffeeshout.global.ServiceTest;
+import coffeeshout.minigame.domain.MiniGameType;
+import coffeeshout.report.infra.persistence.Report;
+import coffeeshout.report.infra.persistence.ReportRepository;
+import coffeeshout.report.infra.persistence.Reporter;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.RefreshTokenRepository;
+import coffeeshout.user.domain.repository.UserRepository;
+import coffeeshout.user.infra.persistence.UserJpaRepository;
+import jakarta.persistence.EntityManager;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserWithdrawalServiceTest extends ServiceTest {
+
+    @Autowired
+    UserWithdrawalService userWithdrawalService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    ReportRepository reportRepository;
+
+    @Autowired
+    EntityManager entityManager;
+
+    private Long userId;
+    private String userCode;
+
+    @BeforeEach
+    void setUp() {
+        final User user = userRepository.save(UserFixture.회원_엠제이());
+        userId = user.getId();
+        userCode = user.getUserCode().value();
+    }
+
+    @Nested
+    class 회원_탈퇴 {
+
+        @Test
+        void 탈퇴_후_회원_정보가_삭제된다() {
+            userWithdrawalService.withdraw(userId);
+
+            // deleteById 후 REMOVED 상태인 엔티티를 em.find()가 null 반환 — flush 없이 L1 캐시로 검증
+            assertThat(userJpaRepository.findById(userId)).isEmpty();
+        }
+
+        @Test
+        void 탈퇴_후_리프레시_토큰이_모두_무효화된다() {
+            final String tokenId = "test-token-id";
+            refreshTokenRepository.save(userId, userCode, tokenId, 3600L);
+
+            userWithdrawalService.withdraw(userId);
+
+            assertThat(refreshTokenRepository.findByTokenId(tokenId)).isEmpty();
+        }
+
+        @Test
+        void 탈퇴_후_신고의_user_code가_null로_익명화된다() {
+            final Report report = Report.createBugReport(
+                    MiniGameType.CARD_GAME, "ABC12", "버그가 있어요.",
+                    Instant.now(), new Reporter(userId, userCode)
+            );
+            final Long reportId = reportRepository.save(report).getId();
+
+            userWithdrawalService.withdraw(userId);
+
+            // JPQL bulk update는 즉시 실행되지만 L1 캐시를 우회하므로 clear() 후 재조회
+            // user_id null 처리는 DB CASCADE에 위임 (트랜잭션 커밋 시 적용)
+            entityManager.clear();
+
+            final Reporter author = reportRepository.findById(reportId).orElseThrow().getAuthor();
+            assertThat(author.getUserCode()).isNull();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -57,7 +57,7 @@ class UserWithdrawalServiceTest extends ServiceTest {
             final Instant before = Instant.now();
             userWithdrawalService.withdraw(userId);
 
-            final UserEntity entity = userJpaRepository.findById(userId).orElseThrow();
+            final UserEntity entity = userJpaRepository.findByIdIgnoringDeletedAt(userId).orElseThrow();
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(entity.isDeleted()).isTrue();
                 softly.assertThat(entity.getNickname()).isEqualTo("탈퇴한 사용자");

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -12,8 +12,11 @@ import coffeeshout.report.infra.persistence.Reporter;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.repository.UserRepository;
 import coffeeshout.user.exception.UserErrorCode;
+import coffeeshout.user.infra.persistence.OAuthAccountJpaRepository;
+import coffeeshout.user.infra.persistence.UserEntity;
 import coffeeshout.user.infra.persistence.UserJpaRepository;
 import java.time.Instant;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,9 @@ class UserWithdrawalServiceTest extends ServiceTest {
 
     @Autowired
     UserJpaRepository userJpaRepository;
+
+    @Autowired
+    OAuthAccountJpaRepository oAuthAccountJpaRepository;
 
     @Autowired
     ReportRepository reportRepository;
@@ -47,10 +53,30 @@ class UserWithdrawalServiceTest extends ServiceTest {
     class 회원_탈퇴 {
 
         @Test
-        void 탈퇴_후_회원_정보가_삭제된다() {
+        void 탈퇴_후_회원_엔티티는_soft_delete되고_닉네임이_익명화된다() {
+            final Instant before = Instant.now();
             userWithdrawalService.withdraw(userId);
 
-            assertThat(userJpaRepository.findById(userId)).isEmpty();
+            final UserEntity entity = userJpaRepository.findById(userId).orElseThrow();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(entity.isDeleted()).isTrue();
+                softly.assertThat(entity.getNickname()).isEqualTo("탈퇴한 사용자");
+                softly.assertThat(entity.getDeletedAt()).isNotNull().isAfterOrEqualTo(before);
+            });
+        }
+
+        @Test
+        void 탈퇴_후_도메인_조회에서_찾을_수_없다() {
+            userWithdrawalService.withdraw(userId);
+
+            assertThat(userRepository.findById(userId)).isEmpty();
+        }
+
+        @Test
+        void 탈퇴_후_OAuth_계정이_hard_delete된다() {
+            userWithdrawalService.withdraw(userId);
+
+            assertThat(oAuthAccountJpaRepository.findByUser_Id(userId)).isEmpty();
         }
 
         @Test

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -76,7 +76,7 @@ class UserWithdrawalServiceTest extends ServiceTest {
         void 탈퇴_후_OAuth_계정이_hard_delete된다() {
             userWithdrawalService.withdraw(userId);
 
-            assertThat(oAuthAccountJpaRepository.findByUser_Id(userId)).isEmpty();
+            assertThat(oAuthAccountJpaRepository.countByUserId(userId)).isZero();
         }
 
         @Test

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -1,5 +1,6 @@
 package coffeeshout.user.application.service;
 
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import coffeeshout.fixture.UserFixture;
@@ -9,10 +10,9 @@ import coffeeshout.report.infra.persistence.Report;
 import coffeeshout.report.infra.persistence.ReportRepository;
 import coffeeshout.report.infra.persistence.Reporter;
 import coffeeshout.user.domain.User;
-import coffeeshout.user.domain.repository.RefreshTokenRepository;
 import coffeeshout.user.domain.repository.UserRepository;
+import coffeeshout.user.exception.UserErrorCode;
 import coffeeshout.user.infra.persistence.UserJpaRepository;
-import jakarta.persistence.EntityManager;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -31,13 +31,7 @@ class UserWithdrawalServiceTest extends ServiceTest {
     UserJpaRepository userJpaRepository;
 
     @Autowired
-    RefreshTokenRepository refreshTokenRepository;
-
-    @Autowired
     ReportRepository reportRepository;
-
-    @Autowired
-    EntityManager entityManager;
 
     private Long userId;
     private String userCode;
@@ -56,18 +50,15 @@ class UserWithdrawalServiceTest extends ServiceTest {
         void 탈퇴_후_회원_정보가_삭제된다() {
             userWithdrawalService.withdraw(userId);
 
-            // deleteById 후 REMOVED 상태인 엔티티를 em.find()가 null 반환 — flush 없이 L1 캐시로 검증
             assertThat(userJpaRepository.findById(userId)).isEmpty();
         }
 
         @Test
-        void 탈퇴_후_리프레시_토큰이_모두_무효화된다() {
-            final String tokenId = "test-token-id";
-            refreshTokenRepository.save(userId, userCode, tokenId, 3600L);
-
-            userWithdrawalService.withdraw(userId);
-
-            assertThat(refreshTokenRepository.findByTokenId(tokenId)).isEmpty();
+        void 존재하지_않는_회원_탈퇴_시_예외가_발생한다() {
+            assertCoffeeShoutException(
+                    () -> userWithdrawalService.withdraw(-1L),
+                    UserErrorCode.USER_NOT_FOUND
+            );
         }
 
         @Test
@@ -79,10 +70,6 @@ class UserWithdrawalServiceTest extends ServiceTest {
             final Long reportId = reportRepository.save(report).getId();
 
             userWithdrawalService.withdraw(userId);
-
-            // JPQL bulk update는 즉시 실행되지만 L1 캐시를 우회하므로 clear() 후 재조회
-            // user_id null 처리는 DB CASCADE에 위임 (트랜잭션 커밋 시 적용)
-            entityManager.clear();
 
             final Reporter author = reportRepository.findById(reportId).orElseThrow().getAuthor();
             assertThat(author.getUserCode()).isNull();

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTest.java
@@ -60,7 +60,7 @@ class UserWithdrawalServiceTest extends ServiceTest {
             final UserEntity entity = userJpaRepository.findByIdIgnoringDeletedAt(userId).orElseThrow();
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(entity.isDeleted()).isTrue();
-                softly.assertThat(entity.getNickname()).isEqualTo("탈퇴한 사용자");
+                softly.assertThat(entity.getNickname()).isNull();
                 softly.assertThat(entity.getDeletedAt()).isNotNull().isAfterOrEqualTo(before);
             });
         }

--- a/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTransactionTest.java
+++ b/backend/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTransactionTest.java
@@ -1,0 +1,57 @@
+package coffeeshout.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.fixture.TestContainerSupport;
+import coffeeshout.fixture.UserFixture;
+import coffeeshout.global.config.ServiceTestConfig;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.RefreshTokenRepository;
+import coffeeshout.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@Import(ServiceTestConfig.class)
+@ActiveProfiles("test")
+class UserWithdrawalServiceTransactionTest extends TestContainerSupport {
+
+    @Autowired
+    UserWithdrawalService userWithdrawalService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    private Long userId;
+    private String userCode;
+
+    @BeforeEach
+    void setUp() {
+        cleanDatabase();
+        final User user = userRepository.save(UserFixture.회원_엠제이());
+        userId = user.getId();
+        userCode = user.getUserCode().value();
+    }
+
+    @Nested
+    class 회원_탈퇴_트랜잭션_커밋_후 {
+
+        @Test
+        void 리프레시_토큰이_모두_무효화된다() {
+            final String tokenId = "test-token-id";
+            refreshTokenRepository.save(userId, userCode, tokenId, 3600L);
+
+            userWithdrawalService.withdraw(userId);
+
+            assertThat(refreshTokenRepository.findByTokenId(tokenId)).isEmpty();
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/user/infra/persistence/UserEntityTest.java
+++ b/backend/src/test/java/coffeeshout/user/infra/persistence/UserEntityTest.java
@@ -1,0 +1,27 @@
+package coffeeshout.user.infra.persistence;
+
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.global.exception.GlobalErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserEntityTest {
+
+    @Nested
+    class toDomain변환 {
+
+        @Test
+        void 탈퇴한_사용자는_도메인_객체로_변환할_수_없다() {
+            final UserEntity entity = new UserEntity("AB3CD", "엠제이");
+            entity.anonymize();
+            entity.softDelete();
+
+            assertCoffeeShoutException(
+                    () -> entity.toDomain(mock(OAuthAccountEntity.class)),
+                    GlobalErrorCode.INTERNAL_SERVER_ERROR
+            );
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/user/ui/UserWithdrawalControllerTest.java
+++ b/backend/src/test/java/coffeeshout/user/ui/UserWithdrawalControllerTest.java
@@ -1,0 +1,56 @@
+package coffeeshout.user.ui;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import coffeeshout.fixture.IntegrationTestSupport;
+import coffeeshout.fixture.UserFixture;
+import coffeeshout.user.application.service.AuthTokenService;
+import coffeeshout.user.domain.TokenPair;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+class UserWithdrawalControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AuthTokenService authTokenService;
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        final User user = userRepository.save(UserFixture.회원_엠제이());
+        final TokenPair tokens = authTokenService.issue(user);
+        accessToken = tokens.accessToken();
+    }
+
+    @Nested
+    class DELETE_users_me {
+
+        @Test
+        void 인증된_사용자가_탈퇴하면_204를_반환한다() throws Exception {
+            mockMvc.perform(delete("/users/me")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 토큰_없이_호출하면_401을_반환한다() throws Exception {
+            mockMvc.perform(delete("/users/me"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1224

# 🚀 작업 내용

1. 회원 탈퇴를 hard delete → soft delete로 전환
   - `UserEntity`에 `deleted_at` 컬럼 추가, `@SQLRestriction("deleted_at IS NULL")` 적용으로 모든 JPA 쿼리 자동 필터링
   - 탈퇴 시 OAuthAccount(개인정보)는 hard delete, UserEntity는 닉네임 익명화("탈퇴한 사용자") + soft delete
   - `softDeleteById` 순서: user soft delete 먼저 → OAuthAccount 삭제 (부분 실패 시 탈퇴 상태 보장)
2. Flyway 마이그레이션
   - V21: `app_user.deleted_at TIMESTAMP(6)` 추가, `oauth_account` FK ON DELETE CASCADE 제거
   - V22: `oauth_account.linked_at` DATETIME → TIMESTAMP(6) (Instant 타입 일관성)
3. `OAuthAccountEntity.linkedAt` `LocalDateTime` → `Instant` 변환
4. `UserWithdrawalService` 리팩토링
   - `afterCommit` 익명 클래스 → `deleteRefreshTokenAfterCommit` private 메서드 추출
   - 쿠키 공통 속성 추출, 트랜잭션 안전성 개선
5. `RefreshTokenCookieHelper` 쿠키 공통 속성 분리
6. 테스트: `UserWithdrawalServiceTest`, `UserWithdrawalServiceTransactionTest`, `UserWithdrawalControllerTest` 작성

# 💬 리뷰 중점사항

- `@SQLRestriction("deleted_at IS NULL")`: Hibernate 6.3+ 기능으로 모든 JPA 쿼리에 자동 필터 적용. `findByIdIgnoringDeletedAt`(네이티브 쿼리)으로만 우회 가능
- soft delete 순서 설계: user `deleted_at` 기록 → OAuthAccount 삭제 순서로, OAuthAccount 삭제 실패 시에도 유저는 이미 탈퇴 처리된 상태 유지
- OAuthAccount는 hard delete(PII 완전 제거), UserEntity는 soft delete + 닉네임 익명화(신고·게임 이력 참조 보존)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 계정을 삭제할 수 있는 기능 추가
  * 계정 삭제 시 관련 데이터 자동 익명화
  * 계정 삭제 시 저장된 토큰 자동 정리

* **리팩토링**
  * 인증 시스템의 쿠키 관리 로직 개선

* **테스트**
  * 계정 삭제 기능 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->