### PR TITLE
[feat] 회원 탈퇴 기능 구현

### DIFF
--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -48,4 +48,6 @@ export const authApi = {
 
   updateNickname: (nickname: string): Promise<User> =>
     apiRequest('/users/me', { method: 'PATCH', body: { nickname } }),
+
+  deleteMe: (): Promise<void> => apiRequest('/users/me', { method: 'DELETE' }),
 };

--- a/frontend/src/features/auth/components/DeleteAccountSheet/DeleteAccountSheet.styled.ts
+++ b/frontend/src/features/auth/components/DeleteAccountSheet/DeleteAccountSheet.styled.ts
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 8px 0 4px;
+`;
+
+export const WarningBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  background: ${({ theme }) => theme.color.point[50]};
+  border: 1px solid ${({ theme }) => theme.color.point[100]};
+  border-radius: 12px;
+`;
+
+export const WarningIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.color.point[100]};
+  color: ${({ theme }) => theme.color.point[500]};
+  flex-shrink: 0;
+`;
+
+export const WarningText = styled.p`
+  font-size: 13px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.color.gray[700]};
+  line-height: 1.5;
+  margin: 0;
+`;
+
+export const InfoList = styled.ul`
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.gray[500]};
+  line-height: 1.7;
+  list-style: none;
+  margin: 0;
+  padding: 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+`;
+
+export const CancelButton = styled.button`
+  flex: 1;
+  padding: 14px 0;
+  border: 1px solid ${({ theme }) => theme.color.gray[200]};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.color.white};
+  color: ${({ theme }) => theme.color.gray[700]};
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  &:active {
+    background-color: ${({ theme }) => theme.color.gray[50]};
+  }
+`;
+
+export const DeleteButton = styled.button`
+  flex: 1;
+  padding: 14px 0;
+  border: none;
+  border-radius: 12px;
+  background: ${({ theme }) => theme.color.point[500]};
+  color: ${({ theme }) => theme.color.white};
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:active {
+    filter: brightness(0.88);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+`;

--- a/frontend/src/features/auth/components/DeleteAccountSheet/DeleteAccountSheet.tsx
+++ b/frontend/src/features/auth/components/DeleteAccountSheet/DeleteAccountSheet.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import useModal from '@/components/@common/Modal/useModal';
+import useToast from '@/components/@common/Toast/useToast';
+import { useAuth } from '../../contexts/AuthContext';
+import * as S from './DeleteAccountSheet.styled';
+
+const DeleteAccountSheet = () => {
+  const { deleteAccount } = useAuth();
+  const { closeModal } = useModal();
+  const { showToast } = useToast();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteAccount();
+      closeModal();
+      showToast({ message: '회원 탈퇴가 완료되었습니다.', type: 'success' });
+    } catch {
+      showToast({ message: '회원 탈퇴에 실패했습니다. 다시 시도해주세요.', type: 'error' });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.WarningBox>
+        <S.WarningIcon>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </S.WarningIcon>
+        <S.WarningText>
+          탈퇴하면 계정 정보와 활동 데이터가 모두 삭제되며, 복구할 수 없습니다.
+        </S.WarningText>
+      </S.WarningBox>
+
+      <S.InfoList>
+        <li>• 닉네임 및 프로필 정보가 삭제됩니다.</li>
+        <li>• 동일 소셜 계정으로 재가입은 가능합니다.</li>
+      </S.InfoList>
+
+      <S.ButtonGroup>
+        <S.CancelButton type="button" onClick={closeModal} disabled={isDeleting}>
+          취소
+        </S.CancelButton>
+        <S.DeleteButton
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          aria-busy={isDeleting}
+        >
+          {isDeleting ? '탈퇴 중...' : '탈퇴하기'}
+        </S.DeleteButton>
+      </S.ButtonGroup>
+    </S.Wrapper>
+  );
+};
+
+export default DeleteAccountSheet;

--- a/frontend/src/features/auth/contexts/AuthContext.ts
+++ b/frontend/src/features/auth/contexts/AuthContext.ts
@@ -9,6 +9,7 @@ type AuthContextType = {
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
   updateNickname: (nickname: string) => Promise<void>;
+  deleteAccount: () => Promise<void>;
 };
 
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/frontend/src/features/auth/contexts/AuthProvider.tsx
+++ b/frontend/src/features/auth/contexts/AuthProvider.tsx
@@ -98,6 +98,13 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     Sentry.setUser({ id: updated.userCode, username: updated.provider });
   }, []);
 
+  const deleteAccount = useCallback(async () => {
+    await authApi.deleteMe();
+    tokenStore.clearTokens();
+    setUser(null);
+    Sentry.setUser(null);
+  }, []);
+
   return (
     <AuthContext.Provider
       value={{
@@ -108,6 +115,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         logout: handleLogout,
         refreshUser,
         updateNickname,
+        deleteAccount,
       }}
     >
       {children}

--- a/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
@@ -120,3 +120,43 @@ export const TooltipList = styled.ul`
   flex-direction: column;
   gap: 4px;
 `;
+
+export const DangerCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${({ theme }) => theme.color.gray[100]};
+  border-radius: 16px;
+  overflow: hidden;
+  background: ${({ theme }) => theme.color.white};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  margin-top: 12px;
+`;
+
+export const DangerRow = styled.button`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 14px 18px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+
+  &:active {
+    background: ${({ theme }) => theme.color.point[50]};
+  }
+`;
+
+export const DangerLabel = styled.span`
+  font-size: 13px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.point[500]};
+`;
+
+export const DangerIcon = styled.span`
+  font-size: 16px;
+  font-weight: 300;
+  color: ${({ theme }) => theme.color.point[200]};
+`;

--- a/frontend/src/features/home/components/MenuTab/views/MyInfoView.tsx
+++ b/frontend/src/features/home/components/MenuTab/views/MyInfoView.tsx
@@ -1,11 +1,24 @@
 import PlayerIcon from '@/components/@composition/PlayerIcon/PlayerIcon';
+import useModal from '@/components/@common/Modal/useModal';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useAuth } from '@/features/auth/contexts/AuthContext';
+import DeleteAccountSheet from '@/features/auth/components/DeleteAccountSheet/DeleteAccountSheet';
 import { useMyStats } from '@/features/home/hooks/useMyStats';
 import * as S from './MyInfoView.styled';
 
 const MyInfoView = () => {
   const { myName } = useIdentifier();
   const { winCount, streak } = useMyStats();
+  const { isAuthenticated } = useAuth();
+  const { openModal } = useModal();
+
+  const handleDeleteAccount = () => {
+    openModal(<DeleteAccountSheet />, {
+      title: '회원 탈퇴',
+      showCloseButton: true,
+      closeOnBackdropClick: true,
+    });
+  };
 
   return (
     <S.Container>
@@ -44,6 +57,15 @@ const MyInfoView = () => {
           </S.TooltipList>
         </S.TooltipCard>
       </S.InfoSection>
+
+      {isAuthenticated && (
+        <S.DangerCard>
+          <S.DangerRow type="button" onClick={handleDeleteAccount}>
+            <S.DangerLabel>회원 탈퇴하기</S.DangerLabel>
+            <S.DangerIcon>›</S.DangerIcon>
+          </S.DangerRow>
+        </S.DangerCard>
+      )}
     </S.Container>
   );
 };


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1224

# 🚀 작업 내용

1. `authApi.deleteMe()` — `DELETE /users/me` API 호출 추가
2. `AuthContext` / `AuthProvider` — `deleteAccount()` 메서드 추가 (토큰 초기화 + Sentry 사용자 클리어)
3. `DeleteAccountSheet` 컴포넌트 신규 구현 — 경고 안내 + 취소/탈퇴 버튼, 로딩 상태(`isDeleting`) 처리
4. `MyInfoView` — 로그인 상태일 때 회원 탈퇴 카드 노출, 모달로 `DeleteAccountSheet` 진입

# 💬 리뷰 중점사항

- `deleteAccount`는 API 성공 후 토큰 초기화 → `setUser(null)` 순서로 처리하며, 실패 시 모달이 유지되어 재시도 가능
- 204 No Content 응답은 `apiRequest` 내부에서 이미 처리되어 있어 별도 분기 불필요
- 색상은 `theme.color.point` 토큰 사용 (`point[50]`, `point[100]`, `point[200]`, `point[500]`), active 상태 어두워짐은 `filter: brightness(0.88)` 적용