### PR TITLE
[refactor] GeminiPlayerNameAuditor Fail-Safe 전환 및 구조 개선

### DIFF
--- a/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
+++ b/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
@@ -1,0 +1,20 @@
+package coffeeshout.room.domain.audit;
+
+import coffeeshout.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlayerNameAuditErrorCode implements ErrorCode {
+
+    AI_CALL_FAILED("AUDIT_001", "닉네임 검열 AI 호출에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_EMPTY_RESPONSE("AUDIT_002", "닉네임 검열 AI가 빈 응답을 반환했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    PROMPT_BUILD_FAILED("AUDIT_004", "닉네임 검열 프롬프트 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
+++ b/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
@@ -11,7 +11,8 @@ public enum PlayerNameAuditErrorCode implements ErrorCode {
 
     AI_CALL_FAILED("AUDIT_001", "닉네임 검열 AI 호출에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_EMPTY_RESPONSE("AUDIT_002", "닉네임 검열 AI가 빈 응답을 반환했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    PROMPT_BUILD_FAILED("AUDIT_004", "닉네임 검열 프롬프트 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
+++ b/backend/src/main/java/coffeeshout/room/domain/audit/PlayerNameAuditErrorCode.java
@@ -11,8 +11,7 @@ public enum PlayerNameAuditErrorCode implements ErrorCode {
 
     AI_CALL_FAILED("AUDIT_001", "닉네임 검열 AI 호출에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_EMPTY_RESPONSE("AUDIT_002", "닉네임 검열 AI가 빈 응답을 반환했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    PROMPT_BUILD_FAILED("AUDIT_004", "닉네임 검열 프롬프트 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/coffeeshout/room/infra/GeminiPlayerNameAuditor.java
+++ b/backend/src/main/java/coffeeshout/room/infra/GeminiPlayerNameAuditor.java
@@ -106,6 +106,8 @@ public class GeminiPlayerNameAuditor implements PlayerNameAuditor {
                                     .responseSchema(RESPONSE_SCHEMA)
                                     .build()
                     ));
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new InfrastructureException(PlayerNameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 실패", e);
         }

--- a/backend/src/main/java/coffeeshout/room/infra/GeminiPlayerNameAuditor.java
+++ b/backend/src/main/java/coffeeshout/room/infra/GeminiPlayerNameAuditor.java
@@ -1,27 +1,31 @@
 package coffeeshout.room.infra;
 
+import coffeeshout.global.exception.custom.InfrastructureException;
 import coffeeshout.room.config.PlayerNameAuditProperties;
+import coffeeshout.room.domain.audit.AiConfidence;
+import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
 import coffeeshout.room.domain.audit.PlayerNameAuditResult;
+import coffeeshout.room.domain.audit.PlayerNameAuditStatus;
 import coffeeshout.room.domain.audit.PlayerNameAuditor;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackJpaRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
-import java.util.Map;
 import com.google.genai.Client;
+import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import com.google.genai.types.Schema;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
@@ -31,44 +35,55 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @Profile("!local & !test")
-@RequiredArgsConstructor
 public class GeminiPlayerNameAuditor implements PlayerNameAuditor {
 
-    private static final String BASE_SYSTEM_PROMPT = """
-            너는 한국어 닉네임 검열 전문가다.
-            아래 닉네임 목록을 검토하고 각 항목에 대해 JSON 배열로만 응답하라. 반드시 다른 텍스트는 포함하지 마라.
-            
-            비속어 판단 기준:
-            - 직접적 욕설뿐 아니라 자모 분리, 특수문자 삽입, 유사 발음 대체로 우회한 경우 포함
-            - 문화적 맥락을 고려한다 (예: "미쳤다"는 일반 감탄사로 사용되므로 flagged=false)
-            - 판단이 애매한 경우 confidence를 낮게 설정한다
-            
-            응답 형식:
-            [
-              { "playerName": "씨b알",     "flagged": true,  "confidence": 0.97, "reason": "비속어 우회 (특수문자 삽입)" },
-              { "playerName": "용감한호랑이", "flagged": false, "confidence": 0.99, "reason": "일반 닉네임" }
-            ]
-            """;
+    private static final Content SYSTEM_INSTRUCTION = Content.fromParts(
+            Part.fromText(PlayerNameAuditPromptTemplate.SYSTEM_INSTRUCTION)
+    );
+
+    private static final Schema RESPONSE_SCHEMA = Schema.builder()
+            .type("ARRAY")
+            .items(Schema.builder()
+                    .type("OBJECT")
+                    .properties(Map.of(
+                            "playerName", Schema.builder().type("STRING").build(),
+                            "flagged", Schema.builder().type("BOOLEAN").build(),
+                            "confidence", Schema.builder().type("NUMBER").build(),
+                            "reason", Schema.builder().type("STRING").build()
+                    ))
+                    .required(List.of("playerName", "flagged", "confidence", "reason"))
+                    .build())
+            .build();
 
     private final Client geminiClient;
     private final ObjectMapper objectMapper;
     private final PlayerNameAuditProperties properties;
     private final PlayerNameFeedbackJpaRepository feedbackRepository;
-    private final MeterRegistry meterRegistry;
+    private final PlayerNameAuditPromptTemplate promptTemplate;
+    private final Timer apiCallTimer;
+    private final Counter parseFailureCounter;
+    private final Counter itemParseFailureCounter;
 
-    private Timer apiCallTimer;
-    private Counter parseFailureCounter;
-    private Counter itemParseFailureCounter;
-
-    @PostConstruct
-    void initMetrics() {
-        apiCallTimer = Timer.builder("playerName.audit.gemini.call.duration")
+    public GeminiPlayerNameAuditor(
+            Client geminiClient,
+            ObjectMapper objectMapper,
+            PlayerNameAuditProperties properties,
+            PlayerNameFeedbackJpaRepository feedbackRepository,
+            PlayerNameAuditPromptTemplate promptTemplate,
+            MeterRegistry meterRegistry
+    ) {
+        this.geminiClient = geminiClient;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.feedbackRepository = feedbackRepository;
+        this.promptTemplate = promptTemplate;
+        this.apiCallTimer = Timer.builder("playerName.audit.gemini.call.duration")
                 .description("Gemini API 호출 소요 시간")
                 .register(meterRegistry);
-        parseFailureCounter = Counter.builder("playerName.audit.gemini.parse.failures")
+        this.parseFailureCounter = Counter.builder("playerName.audit.gemini.parse.failures")
                 .description("Gemini 응답 JSON 파싱 실패 횟수")
                 .register(meterRegistry);
-        itemParseFailureCounter = Counter.builder("playerName.audit.gemini.item.parse.failures")
+        this.itemParseFailureCounter = Counter.builder("playerName.audit.gemini.item.parse.failures")
                 .description("Gemini 응답 항목 단위 파싱 실패 횟수")
                 .register(meterRegistry);
     }
@@ -77,78 +92,59 @@ public class GeminiPlayerNameAuditor implements PlayerNameAuditor {
     @Retry(name = "geminiAudit")
     @RateLimiter(name = "geminiAudit")
     public List<PlayerNameAuditResult> audit(List<String> nicknames) {
-        final String prompt = buildPrompt(nicknames);
+        final String userMessage = buildUserMessage(nicknames);
 
+        final GenerateContentResponse response;
         try {
-            final GenerateContentResponse response = apiCallTimer.recordCallable(() ->
+            response = apiCallTimer.recordCallable(() ->
                     geminiClient.models.generateContent(
                             properties.model(),
-                            prompt,
+                            userMessage,
                             GenerateContentConfig.builder()
+                                    .systemInstruction(SYSTEM_INSTRUCTION)
                                     .responseMimeType("application/json")
+                                    .responseSchema(RESPONSE_SCHEMA)
                                     .build()
                     ));
-
-            if (response == null) {
-                return List.of();
-            }
-
-            return parseResults(response.text(), nicknames);
         } catch (Exception e) {
-            throw new RuntimeException("Gemini API 호출 실패", e);
+            throw new InfrastructureException(PlayerNameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 실패", e);
         }
+
+        if (response == null || response.text() == null) {
+            throw new InfrastructureException(PlayerNameAuditErrorCode.AI_EMPTY_RESPONSE, "닉네임 검열 AI가 빈 응답을 반환했습니다.");
+        }
+
+        return parseResults(response.text(), nicknames);
     }
 
-    private String buildPrompt(List<String> nicknames) {
-        final StringBuilder prompt = new StringBuilder(BASE_SYSTEM_PROMPT);
+    private String buildUserMessage(List<String> nicknames) {
+        final List<PlayerNameFeedbackEntity> examples = loadFeedbackExamples();
+        return promptTemplate.buildUserMessage(nicknames, examples);
+    }
 
+    private List<PlayerNameFeedbackEntity> loadFeedbackExamples() {
         final List<PlayerNameFeedbackEntity> feedbacks = feedbackRepository.findRecentFeedbacks(
                 PageRequest.of(0, properties.feedbackInjectionThreshold(), Sort.by("createdAt").descending())
         );
-
-        if (feedbacks.size() >= properties.feedbackInjectionThreshold()) {
-            final List<Map<String, Object>> examples = feedbacks.stream()
-                    .map(feedback -> {
-                        boolean operatorFlagged =
-                                feedback.getOperatorDecision() == PlayerNameFeedbackEntity.OperatorDecision.BLOCKED;
-                        double exampleConfidence = operatorFlagged ? 0.99 : 0.01;
-                        return Map.<String, Object>of(
-                                "playerName", feedback.getPlayerName(),
-                                "flagged", operatorFlagged,
-                                "confidence", exampleConfidence,
-                                "reason", "운영자 피드백"
-                        );
-                    })
-                    .toList();
-            try {
-                prompt.append("\n운영자 피드백 기반 추가 예시:\n")
-                        .append(objectMapper.writeValueAsString(examples)).append("\n");
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException("피드백 예시 직렬화 실패", e);
-            }
+        if (feedbacks.size() < properties.feedbackInjectionThreshold()) {
+            return List.of();
         }
-
-        try {
-            prompt.append("\n검열할 닉네임 목록:\n").append(objectMapper.writeValueAsString(nicknames));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("닉네임 목록 직렬화 실패", e);
-        }
-        return prompt.toString();
+        return feedbacks;
     }
 
     private List<PlayerNameAuditResult> parseResults(String responseText, List<String> requestedNicknames) {
-        List<JsonNode> nodes;
+        final List<JsonNode> nodes;
         try {
             nodes = objectMapper.readValue(responseText, new TypeReference<>() {});
         } catch (Exception e) {
             parseFailureCounter.increment();
-            log.warn("Gemini 응답 JSON 파싱 실패, 해당 배치 skip ({}건). responseText={}",
+            log.warn("[PlayerNameAudit] Gemini 응답 JSON 파싱 실패 ({}건). responseText={}",
                     requestedNicknames.size(), responseText, e);
-            return List.of();
+            throw new InfrastructureException(PlayerNameAuditErrorCode.AI_RESPONSE_PARSE_FAILED, "닉네임 검열 AI 응답 파싱 실패", e);
         }
 
         final List<PlayerNameAuditResult> results = new ArrayList<>();
-        for (JsonNode node : nodes) {
+        for (final JsonNode node : nodes) {
             try {
                 final GeminiAuditItem item = objectMapper.treeToValue(node, GeminiAuditItem.class);
                 results.add(PlayerNameAuditResult.of(
@@ -157,12 +153,15 @@ public class GeminiPlayerNameAuditor implements PlayerNameAuditor {
                 ));
             } catch (Exception e) {
                 itemParseFailureCounter.increment();
-                log.warn("Gemini 응답 항목 파싱 실패, 해당 항목 skip. node={}", node, e);
+                log.warn("[PlayerNameAudit] Gemini 응답 항목 파싱 실패, PENDING 처리. node={}", node, e);
+                final String playerName = node.path("playerName").asText("unknown");
+                results.add(new PlayerNameAuditResult(
+                        playerName, PlayerNameAuditStatus.PENDING, AiConfidence.UNKNOWN, "응답 파싱 실패"
+                ));
             }
         }
         return results;
     }
 
-    private record GeminiAuditItem(String playerName, boolean flagged, double confidence, String reason) {
-    }
+    private record GeminiAuditItem(String playerName, boolean flagged, double confidence, String reason) {}
 }

--- a/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
@@ -30,8 +30,7 @@ public class PlayerNameAuditPromptTemplate {
             ]
             """;
 
-    private static final double EXAMPLE_FLAGGED_CONFIDENCE = 0.99;
-    private static final double EXAMPLE_CLEAN_CONFIDENCE = 0.01;
+    private static final double EXAMPLE_CONFIDENCE = 0.99;
 
     private final ObjectMapper objectMapper;
 
@@ -52,7 +51,7 @@ public class PlayerNameAuditPromptTemplate {
                     return Map.<String, Object>of(
                             "playerName", fb.getPlayerName(),
                             "flagged", flagged,
-                            "confidence", flagged ? EXAMPLE_FLAGGED_CONFIDENCE : EXAMPLE_CLEAN_CONFIDENCE,
+                            "confidence", EXAMPLE_CONFIDENCE,
                             "reason", "운영자 피드백"
                     );
                 })

--- a/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
@@ -1,5 +1,7 @@
 package coffeeshout.room.infra;
 
+import coffeeshout.global.exception.custom.InfrastructureException;
+import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -59,7 +61,7 @@ public class PlayerNameAuditPromptTemplate {
                     .append(objectMapper.writeValueAsString(exampleMaps))
                     .append("\n\n");
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("피드백 예시 직렬화 실패", e);
+            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "피드백 예시 직렬화 실패", e);
         }
     }
 
@@ -68,7 +70,7 @@ public class PlayerNameAuditPromptTemplate {
             message.append("검열할 닉네임 목록:\n")
                     .append(objectMapper.writeValueAsString(nicknames));
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("닉네임 목록 직렬화 실패", e);
+            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "닉네임 목록 직렬화 실패", e);
         }
     }
 }

--- a/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
@@ -1,0 +1,77 @@
+package coffeeshout.room.infra;
+
+import coffeeshout.global.exception.custom.InfrastructureException;
+import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
+import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerNameAuditPromptTemplate {
+
+    static final String SYSTEM_INSTRUCTION = """
+            너는 한국어 닉네임 검열 전문가다.
+            아래 닉네임 목록을 검토하고 각 항목에 대해 JSON 배열로만 응답하라. 반드시 다른 텍스트는 포함하지 마라.
+
+            비속어 판단 기준:
+            - 직접적 욕설뿐 아니라 자모 분리, 특수문자 삽입, 유사 발음 대체로 우회한 경우 포함
+            - 문화적 맥락을 고려한다 (예: "미쳤다"는 일반 감탄사로 사용되므로 flagged=false)
+            - 판단이 애매한 경우 confidence를 낮게 설정한다
+
+            응답 형식:
+            [
+              { "playerName": "씨b알",      "flagged": true,  "confidence": 0.97, "reason": "비속어 우회 (특수문자 삽입)" },
+              { "playerName": "용감한호랑이", "flagged": false, "confidence": 0.99, "reason": "일반 닉네임" }
+            ]
+            """;
+
+    private static final double EXAMPLE_FLAGGED_CONFIDENCE = 0.99;
+    private static final double EXAMPLE_CLEAN_CONFIDENCE = 0.01;
+
+    private final ObjectMapper objectMapper;
+
+    public String buildUserMessage(List<String> nicknames, List<PlayerNameFeedbackEntity> feedbackExamples) {
+        final StringBuilder message = new StringBuilder();
+        appendFeedbackExamples(message, feedbackExamples);
+        appendNicknameList(message, nicknames);
+        return message.toString();
+    }
+
+    private void appendFeedbackExamples(StringBuilder message, List<PlayerNameFeedbackEntity> examples) {
+        if (examples.isEmpty()) {
+            return;
+        }
+        final List<Map<String, Object>> exampleMaps = examples.stream()
+                .map(fb -> {
+                    final boolean flagged = fb.getOperatorDecision() == PlayerNameFeedbackEntity.OperatorDecision.BLOCKED;
+                    return Map.<String, Object>of(
+                            "playerName", fb.getPlayerName(),
+                            "flagged", flagged,
+                            "confidence", flagged ? EXAMPLE_FLAGGED_CONFIDENCE : EXAMPLE_CLEAN_CONFIDENCE,
+                            "reason", "운영자 피드백"
+                    );
+                })
+                .toList();
+        try {
+            message.append("운영자 피드백 기반 추가 예시:\n")
+                    .append(objectMapper.writeValueAsString(exampleMaps))
+                    .append("\n\n");
+        } catch (JsonProcessingException e) {
+            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "피드백 예시 직렬화 실패", e);
+        }
+    }
+
+    private void appendNicknameList(StringBuilder message, List<String> nicknames) {
+        try {
+            message.append("검열할 닉네임 목록:\n")
+                    .append(objectMapper.writeValueAsString(nicknames));
+        } catch (JsonProcessingException e) {
+            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "닉네임 목록 직렬화 실패", e);
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplate.java
@@ -1,7 +1,5 @@
 package coffeeshout.room.infra;
 
-import coffeeshout.global.exception.custom.InfrastructureException;
-import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,7 +59,7 @@ public class PlayerNameAuditPromptTemplate {
                     .append(objectMapper.writeValueAsString(exampleMaps))
                     .append("\n\n");
         } catch (JsonProcessingException e) {
-            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "피드백 예시 직렬화 실패", e);
+            throw new IllegalStateException("피드백 예시 직렬화 실패", e);
         }
     }
 
@@ -70,7 +68,7 @@ public class PlayerNameAuditPromptTemplate {
             message.append("검열할 닉네임 목록:\n")
                     .append(objectMapper.writeValueAsString(nicknames));
         } catch (JsonProcessingException e) {
-            throw new InfrastructureException(PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED, "닉네임 목록 직렬화 실패", e);
+            throw new IllegalStateException("닉네임 목록 직렬화 실패", e);
         }
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -306,6 +306,7 @@ resilience4j:
           - java.lang.RuntimeException   # SDK가 rate limit/서버 오류 시 RuntimeException으로 래핑
         ignore-exceptions:
           - io.github.resilience4j.ratelimiter.RequestNotPermitted  # RateLimiter 초과는 재시도하지 않음
+          - coffeeshout.global.exception.custom.InfrastructureException  # 결정론적 실패(프롬프트 빌드, 빈 응답, 파싱 실패)는 재시도하지 않음
   ratelimiter:
     instances:
       geminiAudit:

--- a/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorConnectivityTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorConnectivityTest.java
@@ -34,13 +34,13 @@ class GeminiPlayerNameAuditorConnectivityTest {
 
     @BeforeEach
     void setUp() {
-        String apiKey = System.getenv("GEMINI_API_KEY");
+        final String apiKey = System.getenv("GEMINI_API_KEY");
         assumeThat(apiKey)
                 .as("GEMINI_API_KEY 환경변수가 설정되지 않아 테스트를 건너뜁니다.")
                 .isNotNull()
                 .isNotBlank();
 
-        PlayerNameAuditProperties properties = new PlayerNameAuditProperties(
+        final PlayerNameAuditProperties properties = new PlayerNameAuditProperties(
                 apiKey,
                 "gemini-2.5-flash",
                 0.85,
@@ -48,24 +48,26 @@ class GeminiPlayerNameAuditorConnectivityTest {
                 20
         );
 
-        PlayerNameFeedbackJpaRepository feedbackRepository = mock(PlayerNameFeedbackJpaRepository.class);
+        final PlayerNameFeedbackJpaRepository feedbackRepository = mock(PlayerNameFeedbackJpaRepository.class);
         when(feedbackRepository.findRecentFeedbacks(any(Pageable.class))).thenReturn(List.of());
 
+        final ObjectMapper objectMapper = new ObjectMapper();
         auditor = new GeminiPlayerNameAuditor(
                 Client.builder().apiKey(apiKey).build(),
-                new ObjectMapper(),
+                objectMapper,
                 properties,
                 feedbackRepository,
+                new PlayerNameAuditPromptTemplate(objectMapper),
                 new SimpleMeterRegistry()
         );
     }
 
     @Test
     void 명확한_비속어는_FLAGGED로_판정한다() {
-        List<PlayerNameAuditResult> results = auditor.audit(List.of("씨발놈", "용감한호랑이"));
+        final List<PlayerNameAuditResult> results = auditor.audit(List.of("씨발놈", "용감한호랑이"));
 
-        PlayerNameAuditResult profanity = findByNickname(results, "씨발놈");
-        PlayerNameAuditResult normal = findByNickname(results, "용감한호랑이");
+        final PlayerNameAuditResult profanity = findByNickname(results, "씨발놈");
+        final PlayerNameAuditResult normal = findByNickname(results, "용감한호랑이");
 
         assertThat(profanity.status()).isEqualTo(PlayerNameAuditStatus.FLAGGED);
         assertThat(normal.status()).isEqualTo(PlayerNameAuditStatus.CLEAN);
@@ -73,17 +75,17 @@ class GeminiPlayerNameAuditorConnectivityTest {
 
     @Test
     void 특수문자_우회_비속어는_탐지한다() {
-        List<PlayerNameAuditResult> results = auditor.audit(List.of("씨b알", "빠른여우"));
+        final List<PlayerNameAuditResult> results = auditor.audit(List.of("씨b알", "빠른여우"));
 
-        PlayerNameAuditResult bypassed = findByNickname(results, "씨b알");
+        final PlayerNameAuditResult bypassed = findByNickname(results, "씨b알");
         assertThat(bypassed.status()).isIn(PlayerNameAuditStatus.FLAGGED, PlayerNameAuditStatus.PENDING);
     }
 
     @Test
     void 모든_닉네임에_대해_결과가_반환된다() {
-        List<String> playerNames = List.of("용감한호랑이", "빠른여우", "작은곰");
+        final List<String> playerNames = List.of("용감한호랑이", "빠른여우", "작은곰");
 
-        List<PlayerNameAuditResult> results = auditor.audit(playerNames);
+        final List<PlayerNameAuditResult> results = auditor.audit(playerNames);
 
         assertThat(results).hasSize(playerNames.size())
                 .allSatisfy(result -> {

--- a/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorParseTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorParseTest.java
@@ -124,7 +124,13 @@ class GeminiPlayerNameAuditorParseTest {
 
             final List<PlayerNameAuditResult> results = parse(responseText, List.of("닉1", "닉2"));
 
-            assertThat(results).allSatisfy(r -> assertThat(r.status()).isEqualTo(PlayerNameAuditStatus.PENDING));
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(results).hasSize(2);
+                softly.assertThat(results).extracting(PlayerNameAuditResult::playerName)
+                        .containsExactlyInAnyOrder("닉1", "닉2");
+                softly.assertThat(results).allSatisfy(r ->
+                        softly.assertThat(r.status()).isEqualTo(PlayerNameAuditStatus.PENDING));
+            });
         }
     }
 

--- a/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorParseTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/GeminiPlayerNameAuditorParseTest.java
@@ -1,8 +1,11 @@
 package coffeeshout.room.infra;
 
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import coffeeshout.room.config.PlayerNameAuditProperties;
+import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
 import coffeeshout.room.domain.audit.PlayerNameAuditResult;
 import coffeeshout.room.domain.audit.PlayerNameAuditStatus;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackJpaRepository;
@@ -13,27 +16,26 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@ExtendWith(MockitoExtension.class)
 class GeminiPlayerNameAuditorParseTest {
 
     private static final PlayerNameAuditProperties PROPERTIES =
             new PlayerNameAuditProperties(null, "gemini-2.5-flash", 0.85, 10, 5);
 
-    @Mock
-    PlayerNameFeedbackJpaRepository feedbackRepository;
-
-    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GeminiPlayerNameAuditor auditor;
 
     @BeforeEach
     void setUp() {
-        auditor = new GeminiPlayerNameAuditor(null, new ObjectMapper(), PROPERTIES, feedbackRepository, meterRegistry);
-        auditor.initMetrics();
+        final ObjectMapper objectMapper = new ObjectMapper();
+        auditor = new GeminiPlayerNameAuditor(
+                null,
+                objectMapper,
+                PROPERTIES,
+                mock(PlayerNameFeedbackJpaRepository.class),
+                new PlayerNameAuditPromptTemplate(objectMapper),
+                new SimpleMeterRegistry()
+        );
     }
 
     private List<PlayerNameAuditResult> parse(String responseText, List<String> playerNames) {
@@ -44,17 +46,30 @@ class GeminiPlayerNameAuditorParseTest {
     class JSON_전체_파싱_실패 {
 
         @Test
-        void 빈_리스트를_반환한다() {
-            List<PlayerNameAuditResult> results = parse("invalid json", List.of("닉네임"));
-
-            assertThat(results).isEmpty();
+        void InfrastructureException을_던진다() {
+            assertCoffeeShoutException(
+                    () -> parse("invalid json", List.of("닉네임")),
+                    PlayerNameAuditErrorCode.AI_RESPONSE_PARSE_FAILED
+            );
         }
 
         @Test
         void 배치_파싱_실패_카운터가_증가한다() {
-            parse("not json at all", List.of("닉네임"));
+            final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+            final ObjectMapper objectMapper = new ObjectMapper();
+            final GeminiPlayerNameAuditor localAuditor = new GeminiPlayerNameAuditor(
+                    null, objectMapper, PROPERTIES,
+                    mock(PlayerNameFeedbackJpaRepository.class),
+                    new PlayerNameAuditPromptTemplate(objectMapper),
+                    registry
+            );
 
-            assertThat(meterRegistry.counter("playerName.audit.gemini.parse.failures").count()).isEqualTo(1);
+            try {
+                ReflectionTestUtils.invokeMethod(localAuditor, "parseResults", "not json at all", List.of("닉네임"));
+            } catch (Exception ignored) {
+            }
+
+            assertThat(registry.counter("playerName.audit.gemini.parse.failures").count()).isEqualTo(1);
         }
     }
 
@@ -62,45 +77,54 @@ class GeminiPlayerNameAuditorParseTest {
     class 항목_파싱_실패 {
 
         @Test
-        void 실패_항목을_제외한_나머지를_반환한다() {
-            String responseText = """
+        void 파싱_실패_항목은_PENDING으로_처리한다() {
+            final String responseText = """
                     [
                       {"playerName": "용감한호랑이", "flagged": false, "confidence": 0.99, "reason": "정상"},
                       {"playerName": "씨발", "flagged": true, "confidence": "숫자아님", "reason": "욕설"}
                     ]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("용감한호랑이", "씨발"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("용감한호랑이", "씨발"));
 
             SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(results).hasSize(1);
-                softly.assertThat(results.getFirst().playerName()).isEqualTo("용감한호랑이");
+                softly.assertThat(results).hasSize(2);
+                softly.assertThat(results.get(0).status()).isEqualTo(PlayerNameAuditStatus.CLEAN);
+                softly.assertThat(results.get(1).status()).isEqualTo(PlayerNameAuditStatus.PENDING);
             });
         }
 
         @Test
         void 항목_파싱_실패_카운터가_증가한다() {
-            String responseText = """
+            final String responseText = """
                     [{"playerName": "씨발", "flagged": true, "confidence": "숫자아님", "reason": "욕설"}]
                     """;
 
-            parse(responseText, List.of("씨발"));
+            final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+            final ObjectMapper objectMapper = new ObjectMapper();
+            final GeminiPlayerNameAuditor localAuditor = new GeminiPlayerNameAuditor(
+                    null, objectMapper, PROPERTIES,
+                    mock(PlayerNameFeedbackJpaRepository.class),
+                    new PlayerNameAuditPromptTemplate(objectMapper),
+                    registry
+            );
+            ReflectionTestUtils.invokeMethod(localAuditor, "parseResults", responseText, List.of("씨발"));
 
-            assertThat(meterRegistry.counter("playerName.audit.gemini.item.parse.failures").count()).isEqualTo(1);
+            assertThat(registry.counter("playerName.audit.gemini.item.parse.failures").count()).isEqualTo(1);
         }
 
         @Test
-        void 전체_항목_실패_시_빈_리스트를_반환한다() {
-            String responseText = """
+        void 전체_항목_파싱_실패_시_모두_PENDING으로_처리한다() {
+            final String responseText = """
                     [
                       {"playerName": "닉1", "flagged": true, "confidence": "bad", "reason": "욕설"},
                       {"playerName": "닉2", "flagged": false, "confidence": "bad", "reason": "정상"}
                     ]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("닉1", "닉2"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("닉1", "닉2"));
 
-            assertThat(results).isEmpty();
+            assertThat(results).allSatisfy(r -> assertThat(r.status()).isEqualTo(PlayerNameAuditStatus.PENDING));
         }
     }
 
@@ -109,47 +133,47 @@ class GeminiPlayerNameAuditorParseTest {
 
         @Test
         void flagged_true이고_confidence가_threshold_이상이면_FLAGGED() {
-            String responseText = """
+            final String responseText = """
                     [{"playerName": "씨발", "flagged": true, "confidence": 0.9, "reason": "욕설"}]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발"));
 
-            assertThat(results.get(0).status()).isEqualTo(PlayerNameAuditStatus.FLAGGED);
+            assertThat(results.getFirst().status()).isEqualTo(PlayerNameAuditStatus.FLAGGED);
         }
 
         @Test
         void flagged_true이고_confidence가_threshold_미만이면_PENDING() {
-            String responseText = """
+            final String responseText = """
                     [{"playerName": "씨발", "flagged": true, "confidence": 0.5, "reason": "애매함"}]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발"));
 
-            assertThat(results.get(0).status()).isEqualTo(PlayerNameAuditStatus.PENDING);
+            assertThat(results.getFirst().status()).isEqualTo(PlayerNameAuditStatus.PENDING);
         }
 
         @Test
         void flagged_false이면_CLEAN() {
-            String responseText = """
+            final String responseText = """
                     [{"playerName": "용감한호랑이", "flagged": false, "confidence": 0.99, "reason": "정상"}]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("용감한호랑이"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("용감한호랑이"));
 
-            assertThat(results.get(0).status()).isEqualTo(PlayerNameAuditStatus.CLEAN);
+            assertThat(results.getFirst().status()).isEqualTo(PlayerNameAuditStatus.CLEAN);
         }
 
         @Test
         void 여러_항목을_모두_파싱한다() {
-            String responseText = """
+            final String responseText = """
                     [
                       {"playerName": "씨발", "flagged": true, "confidence": 0.97, "reason": "욕설"},
                       {"playerName": "용감한호랑이", "flagged": false, "confidence": 0.99, "reason": "정상"}
                     ]
                     """;
 
-            List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발", "용감한호랑이"));
+            final List<PlayerNameAuditResult> results = parse(responseText, List.of("씨발", "용감한호랑이"));
 
             assertThat(results).hasSize(2);
         }

--- a/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
@@ -1,11 +1,12 @@
 package coffeeshout.room.infra;
 
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import coffeeshout.room.domain.audit.PlayerNameAuditErrorCode;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity.OperatorDecision;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,7 +30,7 @@ class PlayerNameAuditPromptTemplateTest {
     class 직렬화_실패 {
 
         @Test
-        void 피드백_예시_직렬화_실패_시_IllegalStateException을_던진다() throws Exception {
+        void 피드백_예시_직렬화_실패_시_PROMPT_BUILD_FAILED를_던진다() throws Exception {
             final ObjectMapper mockMapper = mock(ObjectMapper.class);
             when(mockMapper.writeValueAsString(any())).thenThrow(new JsonMappingException(null, "직렬화 실패"));
             final PlayerNameAuditPromptTemplate failTemplate = new PlayerNameAuditPromptTemplate(mockMapper);
@@ -37,20 +38,22 @@ class PlayerNameAuditPromptTemplateTest {
                     "씨발", true, null, OperatorDecision.BLOCKED, "욕설"
             );
 
-            assertThatThrownBy(() -> failTemplate.buildUserMessage(List.of("씨발"), List.of(feedback)))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("피드백 예시 직렬화 실패");
+            assertCoffeeShoutException(
+                    () -> failTemplate.buildUserMessage(List.of("씨발"), List.of(feedback)),
+                    PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED
+            );
         }
 
         @Test
-        void 닉네임_목록_직렬화_실패_시_IllegalStateException을_던진다() throws Exception {
+        void 닉네임_목록_직렬화_실패_시_PROMPT_BUILD_FAILED를_던진다() throws Exception {
             final ObjectMapper mockMapper = mock(ObjectMapper.class);
             when(mockMapper.writeValueAsString(any())).thenThrow(new JsonMappingException(null, "직렬화 실패"));
             final PlayerNameAuditPromptTemplate failTemplate = new PlayerNameAuditPromptTemplate(mockMapper);
 
-            assertThatThrownBy(() -> failTemplate.buildUserMessage(List.of("닉네임"), List.of()))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("닉네임 목록 직렬화 실패");
+            assertCoffeeShoutException(
+                    () -> failTemplate.buildUserMessage(List.of("닉네임"), List.of()),
+                    PlayerNameAuditErrorCode.PROMPT_BUILD_FAILED
+            );
         }
     }
 

--- a/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
@@ -1,0 +1,143 @@
+package coffeeshout.room.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
+import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity.OperatorDecision;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PlayerNameAuditPromptTemplateTest {
+
+    PlayerNameAuditPromptTemplate template;
+
+    @BeforeEach
+    void setUp() {
+        template = new PlayerNameAuditPromptTemplate(new ObjectMapper());
+    }
+
+    @Nested
+    class 닉네임_목록_포함 {
+
+        @Test
+        void 닉네임이_프롬프트에_포함된다() {
+            final String prompt = template.buildUserMessage(List.of("용감한호랑이", "씨발"), List.of());
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(prompt).contains("용감한호랑이");
+                softly.assertThat(prompt).contains("씨발");
+            });
+        }
+
+        @Test
+        void 빈_닉네임_목록도_처리된다() {
+            final String prompt = template.buildUserMessage(List.of(), List.of());
+
+            assertThat(prompt).contains("검열할 닉네임 목록");
+        }
+    }
+
+    @Nested
+    class 피드백_예시_미주입 {
+
+        @Test
+        void 피드백_예시가_없으면_예시_섹션이_포함되지_않는다() {
+            final String prompt = template.buildUserMessage(List.of("닉네임"), List.of());
+
+            assertThat(prompt).doesNotContain("운영자 피드백 기반 추가 예시");
+        }
+    }
+
+    @Nested
+    class 피드백_예시_주입 {
+
+        @Test
+        void BLOCKED_결정은_flagged_true로_포함된다() {
+            final PlayerNameFeedbackEntity blocked = new PlayerNameFeedbackEntity(
+                    "씨발", true, null, OperatorDecision.BLOCKED, "욕설"
+            );
+
+            final String prompt = template.buildUserMessage(List.of("씨발"), List.of(blocked));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(prompt).contains("운영자 피드백 기반 추가 예시");
+                softly.assertThat(prompt).contains("씨발");
+                softly.assertThat(prompt).contains("true");
+            });
+        }
+
+        @Test
+        void ALLOWED_결정은_flagged_false로_포함된다() {
+            final PlayerNameFeedbackEntity allowed = new PlayerNameFeedbackEntity(
+                    "미쳤다", false, null, OperatorDecision.ALLOWED, "일반 감탄사"
+            );
+
+            final String prompt = template.buildUserMessage(List.of("미쳤다"), List.of(allowed));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(prompt).contains("운영자 피드백 기반 추가 예시");
+                softly.assertThat(prompt).contains("미쳤다");
+                softly.assertThat(prompt).contains("false");
+            });
+        }
+
+        @Test
+        void 여러_피드백이_모두_포함된다() {
+            final List<PlayerNameFeedbackEntity> feedbacks = List.of(
+                    new PlayerNameFeedbackEntity("씨발", true, null, OperatorDecision.BLOCKED, "욕설"),
+                    new PlayerNameFeedbackEntity("미쳤다", false, null, OperatorDecision.ALLOWED, "감탄사")
+            );
+
+            final String prompt = template.buildUserMessage(List.of("씨발", "미쳤다"), feedbacks);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(prompt).contains("씨발");
+                softly.assertThat(prompt).contains("미쳤다");
+            });
+        }
+    }
+
+    @Nested
+    class 시스템_지시사항 {
+
+        @Test
+        void 검열_기준과_응답_형식이_포함된다() {
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(PlayerNameAuditPromptTemplate.SYSTEM_INSTRUCTION).contains("닉네임 검열 전문가");
+                softly.assertThat(PlayerNameAuditPromptTemplate.SYSTEM_INSTRUCTION).contains("JSON 배열");
+                softly.assertThat(PlayerNameAuditPromptTemplate.SYSTEM_INSTRUCTION).contains("비속어 판단 기준");
+            });
+        }
+
+        @Test
+        void 사용자_메시지에는_지시사항이_포함되지_않는다() {
+            final String userMessage = template.buildUserMessage(List.of("닉네임"), List.of());
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(userMessage).doesNotContain("닉네임 검열 전문가");
+                softly.assertThat(userMessage).doesNotContain("비속어 판단 기준");
+            });
+        }
+    }
+
+    @Nested
+    class 프롬프트_구조 {
+
+        @Test
+        void 닉네임_목록_섹션이_피드백_예시_뒤에_위치한다() {
+            final PlayerNameFeedbackEntity feedback = new PlayerNameFeedbackEntity(
+                    "씨발", true, null, OperatorDecision.BLOCKED, "욕설"
+            );
+
+            final String prompt = template.buildUserMessage(List.of("테스트닉네임"), List.of(feedback));
+
+            final int feedbackIndex = prompt.indexOf("운영자 피드백 기반 추가 예시");
+            final int nicknameListIndex = prompt.indexOf("검열할 닉네임 목록");
+            assertThat(feedbackIndex).isLessThan(nicknameListIndex);
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
+++ b/backend/src/test/java/coffeeshout/room/infra/PlayerNameAuditPromptTemplateTest.java
@@ -1,10 +1,15 @@
 package coffeeshout.room.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity;
 import coffeeshout.room.infra.persistence.nickname.PlayerNameFeedbackEntity.OperatorDecision;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +23,35 @@ class PlayerNameAuditPromptTemplateTest {
     @BeforeEach
     void setUp() {
         template = new PlayerNameAuditPromptTemplate(new ObjectMapper());
+    }
+
+    @Nested
+    class 직렬화_실패 {
+
+        @Test
+        void 피드백_예시_직렬화_실패_시_IllegalStateException을_던진다() throws Exception {
+            final ObjectMapper mockMapper = mock(ObjectMapper.class);
+            when(mockMapper.writeValueAsString(any())).thenThrow(new JsonMappingException(null, "직렬화 실패"));
+            final PlayerNameAuditPromptTemplate failTemplate = new PlayerNameAuditPromptTemplate(mockMapper);
+            final PlayerNameFeedbackEntity feedback = new PlayerNameFeedbackEntity(
+                    "씨발", true, null, OperatorDecision.BLOCKED, "욕설"
+            );
+
+            assertThatThrownBy(() -> failTemplate.buildUserMessage(List.of("씨발"), List.of(feedback)))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("피드백 예시 직렬화 실패");
+        }
+
+        @Test
+        void 닉네임_목록_직렬화_실패_시_IllegalStateException을_던진다() throws Exception {
+            final ObjectMapper mockMapper = mock(ObjectMapper.class);
+            when(mockMapper.writeValueAsString(any())).thenThrow(new JsonMappingException(null, "직렬화 실패"));
+            final PlayerNameAuditPromptTemplate failTemplate = new PlayerNameAuditPromptTemplate(mockMapper);
+
+            assertThatThrownBy(() -> failTemplate.buildUserMessage(List.of("닉네임"), List.of()))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("닉네임 목록 직렬화 실패");
+        }
     }
 
     @Nested


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. **Fail-Open → Fail-Safe 전환**
   - 전체 응답 파싱 실패 시 `List.of()` 반환 대신 `InfrastructureException` throw → `@Retry` 위임
   - 항목 단위 파싱 실패 시 해당 닉네임 skip 대신 `PENDING` 상태로 포함 (욕설 통과 방지)
   - `response.text() == null` 체크 추가

2. **Gemini 구조화 출력 강화**
   - `responseMimeType` 단독 사용 → `responseSchema` 추가로 필드 구조까지 강제
   - `GenerateContentConfig.systemInstruction()`으로 정적 지시사항 분리 (기존엔 user 메시지에 혼재)

3. **`PlayerNameAuditPromptTemplate` 분리**
   - `GeminiPlayerNameAuditor` 내 프롬프트 조립 로직을 별도 컴포넌트로 추출
   - `SYSTEM_INSTRUCTION` (정적, `systemInstruction`으로 전달) / `buildUserMessage()` (동적, 피드백 예시 + 닉네임 목록) 명확히 분리

4. **`PlayerNameAuditErrorCode` 추가** (`domain/audit` 위치, 도메인 용어 사용)
   - `RuntimeException` 직접 사용 → `InfrastructureException(에러코드)` 형태로 교체
   - 에러코드 이름을 Gemini 등 인프라 기술 용어 없이 도메인 용어로 명명 (`AI_CALL_FAILED` 등)

5. **`@PostConstruct` 제거**
   - 메트릭 변수(`apiCallTimer` 등) `final` 보장을 위해 생성자에서 직접 초기화

6. **테스트 업데이트**
   - 파싱 실패 기대값 변경 (빈 리스트 → 예외 / PENDING)
   - `assertCoffeeShoutException` 사용
   - `PlayerNameAuditPromptTemplateTest` 신규 작성

# 💬 리뷰 중점사항

- **Fail-Safe 정책**: 항목 파싱 실패 시 `PENDING` 처리가 맞는지 — 운영자 확인 대기가 욕설 통과보다 안전하다고 판단
- **`systemInstruction` vs user 메시지 혼재**: Gemini는 `systemInstruction`을 더 강하게 따르며 프롬프트 캐싱 대상이 될 수 있음
- **`responseSchema`**: 필드 구조까지 강제하므로 응답 형식 일관성이 높아지나, Gemini 버전 업 시 스키마 API 변경 가능성 주의
- **`PlayerNameAuditErrorCode` 위치**: 에러코드를 `domain/audit`에 둔 이유 — 검열 실패는 도메인 관심사이며, 인프라 기술(Gemini)에 종속된 이름을 피하기 위함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 플레이어 닉네임 검사 중 AI 호출 오류에 대한 향상된 에러 처리 추가
  * AI 응답 파싱 실패 시 더 명확한 오류 메시지 제공
  * 잘못된 응답 데이터에 대한 안정성 개선

* **개선사항**
  * 플레이어 닉네임 검사 시스템의 내부 구조 재정비로 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->