### PR TITLE
[feat] 친구 관리 도메인 및 서비스 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,10 +2,12 @@ import { ThemeProvider } from '@emotion/react';
 import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 import { WebSocketProvider } from './apis/websocket/contexts/WebSocketProvider';
+import { UserSocketProvider } from './apis/websocket/contexts/UserSocketProvider';
 import GlobalErrorBoundary from './components/@common/ErrorBoundary/GlobalErrorBoundary';
 import { ModalProvider } from './components/@common/Modal/ModalContext';
 import { ToastProvider } from './components/@common/Toast/ToastContext';
 import { AuthProvider } from './features/auth/contexts/AuthProvider';
+import { FriendsProvider } from './features/friends/contexts/FriendsProvider';
 import { IdentifierProvider } from './contexts/Identifier/IdentifierProvider';
 import { ParticipantsProvider } from './contexts/Participants/ParticipantsProvider';
 import { PlayerTypeProvider } from './contexts/PlayerType/PlayerTypeProvider';
@@ -25,25 +27,29 @@ const App = () => {
       <UpdateBanner />
 
       <AuthProvider>
-        <IdentifierProvider>
-          <ParticipantsProvider>
-            <WebSocketProvider>
-              <PlayerTypeProvider>
-                <ProbabilityHistoryProvider>
-                  <GlobalErrorBoundary>
-                    <ToastProvider>
-                      <ModalProvider>
-                        <Suspense fallback={<div>Loading...</div>}>
-                          <Outlet />
-                        </Suspense>
-                      </ModalProvider>
-                    </ToastProvider>
-                  </GlobalErrorBoundary>
-                </ProbabilityHistoryProvider>
-              </PlayerTypeProvider>
-            </WebSocketProvider>
-          </ParticipantsProvider>
-        </IdentifierProvider>
+        <UserSocketProvider>
+          <IdentifierProvider>
+            <ParticipantsProvider>
+              <WebSocketProvider>
+                <PlayerTypeProvider>
+                  <ProbabilityHistoryProvider>
+                    <GlobalErrorBoundary>
+                      <ToastProvider>
+                        <ModalProvider>
+                          <FriendsProvider>
+                            <Suspense fallback={<div>Loading...</div>}>
+                              <Outlet />
+                            </Suspense>
+                          </FriendsProvider>
+                        </ModalProvider>
+                      </ToastProvider>
+                    </GlobalErrorBoundary>
+                  </ProbabilityHistoryProvider>
+                </PlayerTypeProvider>
+              </WebSocketProvider>
+            </ParticipantsProvider>
+          </IdentifierProvider>
+        </UserSocketProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/frontend/src/apis/websocket/contexts/UserSocketContext.ts
+++ b/frontend/src/apis/websocket/contexts/UserSocketContext.ts
@@ -1,0 +1,17 @@
+import { Client, StompSubscription } from '@stomp/stompjs';
+import { createContext, useContext } from 'react';
+
+export type UserSocketContextType = {
+  isConnected: boolean;
+  client: Client | null;
+  subscribe: <T>(destination: string, onData: (data: T) => void) => StompSubscription | null;
+  reconnect: () => void;
+};
+
+export const UserSocketContext = createContext<UserSocketContextType | null>(null);
+
+export const useUserSocket = (): UserSocketContextType => {
+  const ctx = useContext(UserSocketContext);
+  if (!ctx) throw new Error('useUserSocket은 UserSocketProvider 안에서 사용해야 합니다.');
+  return ctx;
+};

--- a/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
@@ -1,0 +1,88 @@
+import { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { tokenStore } from '@/features/auth/tokens';
+import { createUserStompClient } from '../utils/createUserStompClient';
+import { UserSocketContext, UserSocketContextType } from './UserSocketContext';
+
+export const UserSocketProvider = ({ children }: PropsWithChildren) => {
+  const { isAuthenticated } = useAuth();
+  const [client, setClient] = useState<Client | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const clientRef = useRef<Client | null>(null);
+
+  const connect = useCallback(() => {
+    const token = tokenStore.getAccessToken();
+    if (!token) return;
+
+    const stompClient = createUserStompClient(token);
+    stompClient.onConnect = () => {
+      setIsConnected(true);
+      console.log('✅ [UserSocket] 연결 성공');
+    };
+    stompClient.onDisconnect = () => {
+      setIsConnected(false);
+      console.log('❌ [UserSocket] 연결 해제');
+    };
+    stompClient.onStompError = (frame) => {
+      setIsConnected(false);
+      console.error('❌ [UserSocket] STOMP 에러', frame);
+    };
+    stompClient.activate();
+    clientRef.current = stompClient;
+    setClient(stompClient);
+  }, []);
+
+  const disconnect = useCallback(() => {
+    if (clientRef.current) {
+      clientRef.current.deactivate();
+      clientRef.current = null;
+      setClient(null);
+      setIsConnected(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      connect();
+    } else {
+      disconnect();
+    }
+    return disconnect;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    const handleExpired = () => {
+      disconnect();
+    };
+    window.addEventListener('auth:expired', handleExpired);
+    return () => window.removeEventListener('auth:expired', handleExpired);
+  }, [disconnect]);
+
+  const subscribe = useCallback(
+    <T,>(destination: string, onData: (data: T) => void): StompSubscription | null => {
+      if (!clientRef.current || !isConnected) return null;
+      return clientRef.current.subscribe(destination, (msg: IMessage) => {
+        try {
+          const parsed = JSON.parse(msg.body) as T;
+          onData(parsed);
+        } catch {
+          console.error('[UserSocket] 메시지 파싱 실패', msg.body);
+        }
+      });
+    },
+    [isConnected]
+  );
+
+  // 토큰 갱신 후 새 토큰으로 STOMP 재연결
+  const reconnect = useCallback(() => {
+    console.log('🔄 [UserSocket] 토큰 갱신으로 인한 재연결');
+    disconnect();
+    connect();
+  }, [disconnect, connect]);
+
+  const contextValue: UserSocketContextType = { isConnected, client, subscribe, reconnect };
+
+  return <UserSocketContext.Provider value={contextValue}>{children}</UserSocketContext.Provider>;
+};

--- a/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
@@ -33,9 +33,9 @@ export const UserSocketProvider = ({ children }: PropsWithChildren) => {
     setClient(stompClient);
   }, []);
 
-  const disconnect = useCallback(() => {
+  const disconnect = useCallback(async () => {
     if (clientRef.current) {
-      clientRef.current.deactivate();
+      await clientRef.current.deactivate();
       clientRef.current = null;
       setClient(null);
       setIsConnected(false);
@@ -46,9 +46,11 @@ export const UserSocketProvider = ({ children }: PropsWithChildren) => {
     if (isAuthenticated) {
       connect();
     } else {
-      disconnect();
+      void disconnect();
     }
-    return disconnect;
+    return () => {
+      void disconnect();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated]);
 
@@ -76,9 +78,8 @@ export const UserSocketProvider = ({ children }: PropsWithChildren) => {
   );
 
   // 토큰 갱신 후 새 토큰으로 STOMP 재연결
-  const reconnect = useCallback(() => {
-    console.log('🔄 [UserSocket] 토큰 갱신으로 인한 재연결');
-    disconnect();
+  const reconnect = useCallback(async () => {
+    await disconnect();
     connect();
   }, [disconnect, connect]);
 

--- a/frontend/src/apis/websocket/hooks/useUserSocketSubscription.ts
+++ b/frontend/src/apis/websocket/hooks/useUserSocketSubscription.ts
@@ -1,0 +1,29 @@
+import { StompSubscription } from '@stomp/stompjs';
+import { useEffect, useRef } from 'react';
+import { useUserSocket } from '../contexts/UserSocketContext';
+
+export const useUserSocketSubscription = <T>(
+  destination: string,
+  onData: (data: T) => void,
+  enabled: boolean = true
+) => {
+  const { isConnected, subscribe } = useUserSocket();
+  const subscriptionRef = useRef<StompSubscription | null>(null);
+  const onDataRef = useRef(onData);
+
+  useEffect(() => {
+    onDataRef.current = onData;
+  }, [onData]);
+
+  useEffect(() => {
+    if (!enabled || !isConnected) return;
+
+    const sub = subscribe<T>(destination, (data) => onDataRef.current(data));
+    subscriptionRef.current = sub;
+
+    return () => {
+      subscriptionRef.current?.unsubscribe();
+      subscriptionRef.current = null;
+    };
+  }, [destination, enabled, isConnected, subscribe]);
+};

--- a/frontend/src/apis/websocket/utils/createUserStompClient.ts
+++ b/frontend/src/apis/websocket/utils/createUserStompClient.ts
@@ -1,0 +1,18 @@
+import { Client, ReconnectionTimeMode } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+import { getWebSocketUrl } from './getWebSocketUrl';
+
+export const createUserStompClient = (accessToken: string) => {
+  const wsUrl = getWebSocketUrl();
+
+  return new Client({
+    webSocketFactory: () => new SockJS(wsUrl),
+    debug: (msg) => console.log('[USER-STOMP]', msg),
+    reconnectDelay: 1000,
+    reconnectTimeMode: ReconnectionTimeMode.EXPONENTIAL,
+    maxReconnectDelay: 30000,
+    heartbeatIncoming: 4000,
+    heartbeatOutgoing: 4000,
+    connectHeaders: { Authorization: `Bearer ${accessToken}` },
+  });
+};

--- a/frontend/src/features/auth/contexts/AuthProvider.tsx
+++ b/frontend/src/features/auth/contexts/AuthProvider.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'rea
 import * as Sentry from '@sentry/react';
 import { authApi } from '../api/authApi';
 import { BackendRedirectAuthService } from '../services/BackendRedirectAuthService';
-import { MockAuthService } from '../services/MockAuthService';
 import { tokenStore } from '../tokens';
 import { User } from '../types';
 import { AuthContext } from './AuthContext';
@@ -15,14 +14,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const authServiceRef = useRef(
-    isDev
-      ? new MockAuthService(tokenStore, {
-          onLogin: (u) => setUser(u),
-          onLogout: () => setUser(null),
-        })
-      : new BackendRedirectAuthService(tokenStore)
-  );
+  const authServiceRef = useRef(new BackendRedirectAuthService(tokenStore));
 
   const handleLogout = useCallback(async () => {
     await authServiceRef.current.logout();

--- a/frontend/src/features/friends/api/friendsApi.ts
+++ b/frontend/src/features/friends/api/friendsApi.ts
@@ -1,0 +1,48 @@
+import { api } from '@/apis/rest/api';
+import { Friend, ReceivedRequest, SearchedUser, SentRequest } from '../types';
+
+type SendFriendRequestResponse = {
+  requestId: number;
+  targetUserId: number;
+  status: string;
+  createdAt: string;
+};
+
+type AcceptRequestResponse = {
+  friendUserId: number;
+  friendUserCode: string;
+  friendNickname: string;
+};
+
+export const friendsApi = {
+  searchByUserCode: (userCode: string) =>
+    api.get<SearchedUser[]>(`/users/search?userCode=${encodeURIComponent(userCode)}`),
+
+  searchByNickname: (nickname: string) =>
+    api.get<SearchedUser[]>(`/users/search?nickname=${encodeURIComponent(nickname)}`),
+
+  sendFriendRequest: (targetUserId: number) =>
+    api.post<SendFriendRequestResponse, { targetUserId: number }>('/users/me/friends/requests', {
+      targetUserId,
+    }),
+
+  getReceivedRequests: () => api.get<ReceivedRequest[]>('/users/me/friends/requests/received'),
+
+  getSentRequests: () => api.get<SentRequest[]>('/users/me/friends/requests/sent'),
+
+  acceptRequest: (requestId: number) =>
+    api.post<AcceptRequestResponse, undefined>(
+      `/users/me/friends/requests/${requestId}/accept`,
+      undefined
+    ),
+
+  rejectRequest: (requestId: number) =>
+    api.post<void, undefined>(`/users/me/friends/requests/${requestId}/reject`, undefined),
+
+  getFriends: () => api.get<Friend[]>('/users/me/friends'),
+
+  removeFriend: (friendUserId: number) => api.delete<void>(`/users/me/friends/${friendUserId}`),
+
+  inviteToRoom: (joinCode: string, targetUserId: number) =>
+    api.post<void, { targetUserId: number }>(`/rooms/${joinCode}/invitations`, { targetUserId }),
+};

--- a/frontend/src/features/friends/components/RoomInvitationModal.tsx
+++ b/frontend/src/features/friends/components/RoomInvitationModal.tsx
@@ -1,0 +1,76 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Button from '@/components/@common/Button/Button';
+import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useReplaceNavigate } from '@/hooks/useReplaceNavigate';
+import { theme } from '@/styles/theme';
+
+type Props = {
+  inviterNickname: string;
+  joinCode: string;
+  onClose: () => void;
+};
+
+const RoomInvitationModal = ({ inviterNickname, joinCode, onClose }: Props) => {
+  const navigate = useReplaceNavigate();
+  const { joinCode: currentJoinCode } = useIdentifier();
+
+  const handleJoin = () => {
+    onClose();
+    if (currentJoinCode) {
+      // 이미 방에 있는 경우 — 현재 구현에서는 그냥 이동 (navigate to join)
+      // 기존 방 입장 흐름 재사용 (닉네임 입력 → POST /rooms/{joinCode})
+    }
+    navigate(`/join/${joinCode}`);
+  };
+
+  return (
+    <S.Container>
+      <S.Text>
+        <S.Nickname>{inviterNickname}</S.Nickname> 님이 방에 초대했습니다
+      </S.Text>
+      <S.JoinCode>방 코드: {joinCode}</S.JoinCode>
+      <S.ButtonRow>
+        <Button variant="secondary" onClick={onClose} width="100%">
+          거절
+        </Button>
+        <Button variant="primary" onClick={handleJoin} width="100%">
+          참여
+        </Button>
+      </S.ButtonRow>
+    </S.Container>
+  );
+};
+
+export default RoomInvitationModal;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 8px 0 4px;
+  `,
+
+  Text: styled.p`
+    ${css(theme.typography.paragraph)}
+    color: ${theme.color.gray[800]};
+    text-align: center;
+  `,
+
+  Nickname: styled.span`
+    font-weight: 700;
+    color: ${theme.color.gray[900]};
+  `,
+
+  JoinCode: styled.p`
+    ${css(theme.typography.small)}
+    color: ${theme.color.gray[500]};
+    text-align: center;
+  `,
+
+  ButtonRow: styled.div`
+    display: flex;
+    gap: 8px;
+  `,
+};

--- a/frontend/src/features/friends/contexts/FriendsContext.ts
+++ b/frontend/src/features/friends/contexts/FriendsContext.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+import { Friend, ReceivedRequest, SentRequest } from '../types';
+
+export type FriendsContextType = {
+  friends: Friend[];
+  receivedRequests: ReceivedRequest[];
+  sentRequests: SentRequest[];
+  pendingReceivedCount: number;
+  updateFriendOnline: (userId: number, online: boolean) => void;
+  removeFriendFromStore: (userId: number) => void;
+  addFriend: (friend: Friend) => void;
+  addReceivedRequest: (req: ReceivedRequest) => void;
+  removeReceivedRequest: (requestId: number) => void;
+  removeSentRequest: (requestId: number) => void;
+};
+
+export const FriendsContext = createContext<FriendsContextType | null>(null);
+
+export const useFriendsContext = (): FriendsContextType => {
+  const ctx = useContext(FriendsContext);
+  if (!ctx) throw new Error('useFriendsContext는 FriendsProvider 안에서 사용해야 합니다.');
+  return ctx;
+};

--- a/frontend/src/features/friends/contexts/FriendsProvider.tsx
+++ b/frontend/src/features/friends/contexts/FriendsProvider.tsx
@@ -1,0 +1,205 @@
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import useModal from '@/components/@common/Modal/useModal';
+import useToast from '@/components/@common/Toast/useToast';
+import { useUserSocketSubscription } from '@/apis/websocket/hooks/useUserSocketSubscription';
+import { useUserSocket } from '@/apis/websocket/contexts/UserSocketContext';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { tokenStore } from '@/features/auth/tokens';
+import { friendsApi } from '../api/friendsApi';
+import RoomInvitationModal from '../components/RoomInvitationModal';
+import {
+  Friend,
+  FriendPresenceEvent,
+  FriendRemovedEvent,
+  FriendRequestEvent,
+  FriendResponseEvent,
+  ReceivedRequest,
+  RoomInvitationEvent,
+  SentRequest,
+} from '../types';
+import { FriendsContext, FriendsContextType } from './FriendsContext';
+
+export const FriendsProvider = ({ children }: PropsWithChildren) => {
+  const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
+  const { openModal, closeModal } = useModal();
+  const { reconnect } = useUserSocket();
+  const { pathname } = useLocation();
+  const isInRoom = pathname.startsWith('/room/');
+
+  const [friends, setFriends] = useState<Friend[]>([]);
+  const [receivedRequests, setReceivedRequests] = useState<ReceivedRequest[]>([]);
+  const [sentRequests, setSentRequests] = useState<SentRequest[]>([]);
+
+  // 로그인 시 초기 데이터 로드
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setFriends([]);
+      setReceivedRequests([]);
+      setSentRequests([]);
+      return;
+    }
+
+    const load = async () => {
+      try {
+        // 토큰 만료 감지: 백엔드는 만료 토큰으로도 STOMP 연결을 허용(sessionId fallback)하므로
+        // REST 호출 결과로만 실제 인증 상태를 확인할 수 있다.
+        // 갱신 전 토큰을 저장해 두고, 성공 후 비교해 갱신 여부를 판단한다.
+        const tokenBefore = tokenStore.getAccessToken();
+        const [friendsList, received, sent] = await Promise.all([
+          friendsApi.getFriends(),
+          friendsApi.getReceivedRequests(),
+          friendsApi.getSentRequests(),
+        ]);
+        setFriends(friendsList);
+        setReceivedRequests(received);
+        setSentRequests(sent);
+        // 토큰이 갱신됐으면 STOMP도 새 토큰으로 재연결
+        if (tokenBefore !== tokenStore.getAccessToken()) {
+          reconnect();
+        }
+      } catch {
+        // 초기 로드 실패 시 조용히 빈 상태 유지
+      }
+    };
+
+    load();
+  }, [isAuthenticated, reconnect]);
+
+  // 친구 요청 수신
+  useUserSocketSubscription<FriendRequestEvent>(
+    '/user/queue/friends/requests',
+    useCallback(
+      (event) => {
+        const { data } = event;
+        const req: ReceivedRequest = {
+          requestId: data.requestId,
+          userId: data.fromUserId,
+          userCode: data.fromUserCode,
+          nickname: data.fromNickname,
+          createdAt: data.createdAt,
+        };
+        setReceivedRequests((prev) => [req, ...prev]);
+        showToast({
+          message: `${req.nickname ?? '누군가'} 님이 친구 요청을 보냈습니다`,
+          type: 'info',
+        });
+      },
+      [showToast]
+    ),
+    isAuthenticated
+  );
+
+  // 내가 보낸 요청 응답 수신
+  useUserSocketSubscription<FriendResponseEvent>(
+    '/user/queue/friends/responses',
+    useCallback(
+      (event) => {
+        const { data } = event;
+        setSentRequests((prev) => prev.filter((r) => r.requestId !== data.requestId));
+
+        if (data.accepted) {
+          const newFriend: Friend = {
+            userId: data.counterpartUserId,
+            userCode: data.counterpartUserCode,
+            nickname: data.counterpartNickname,
+            since: new Date().toISOString(),
+            online: false,
+          };
+          setFriends((prev) =>
+            prev.some((f) => f.userId === newFriend.userId) ? prev : [...prev, newFriend]
+          );
+          showToast({
+            message: `${data.counterpartNickname} 님과 친구가 되었습니다`,
+            type: 'success',
+          });
+        } else {
+          showToast({ message: '친구 요청이 거절되었습니다', type: 'info' });
+        }
+      },
+      [showToast]
+    ),
+    isAuthenticated
+  );
+
+  // 친구 끊기 알림 수신
+  useUserSocketSubscription<FriendRemovedEvent>(
+    '/user/queue/friends/removed',
+    useCallback((event) => {
+      setFriends((prev) => prev.filter((f) => f.userId !== event.data.removedByUserId));
+    }, []),
+    isAuthenticated
+  );
+
+  // 방 초대 수신
+  useUserSocketSubscription<RoomInvitationEvent>(
+    '/user/queue/rooms/invitations',
+    useCallback(
+      (event) => {
+        if (isInRoom) return;
+        const { data } = event;
+        openModal(
+          <RoomInvitationModal
+            inviterNickname={data.inviterNickname}
+            joinCode={data.joinCode}
+            onClose={closeModal}
+          />,
+          { title: '방 초대', showCloseButton: false }
+        );
+      },
+      [isInRoom, openModal, closeModal]
+    ),
+    isAuthenticated
+  );
+
+  // 친구 온라인/오프라인 전이
+  useUserSocketSubscription<FriendPresenceEvent>(
+    '/user/queue/friends/presence',
+    useCallback((event) => {
+      setFriends((prev) =>
+        prev.map((f) => (f.userId === event.userId ? { ...f, online: event.online } : f))
+      );
+    }, []),
+    isAuthenticated
+  );
+
+  const updateFriendOnline = useCallback((userId: number, online: boolean) => {
+    setFriends((prev) => prev.map((f) => (f.userId === userId ? { ...f, online } : f)));
+  }, []);
+
+  const removeFriendFromStore = useCallback((userId: number) => {
+    setFriends((prev) => prev.filter((f) => f.userId !== userId));
+  }, []);
+
+  const addFriend = useCallback((friend: Friend) => {
+    setFriends((prev) => (prev.some((f) => f.userId === friend.userId) ? prev : [...prev, friend]));
+  }, []);
+
+  const addReceivedRequest = useCallback((req: ReceivedRequest) => {
+    setReceivedRequests((prev) => [req, ...prev]);
+  }, []);
+
+  const removeReceivedRequest = useCallback((requestId: number) => {
+    setReceivedRequests((prev) => prev.filter((r) => r.requestId !== requestId));
+  }, []);
+
+  const removeSentRequest = useCallback((requestId: number) => {
+    setSentRequests((prev) => prev.filter((r) => r.requestId !== requestId));
+  }, []);
+
+  const contextValue: FriendsContextType = {
+    friends,
+    receivedRequests,
+    sentRequests,
+    pendingReceivedCount: receivedRequests.length,
+    updateFriendOnline,
+    removeFriendFromStore,
+    addFriend,
+    addReceivedRequest,
+    removeReceivedRequest,
+    removeSentRequest,
+  };
+
+  return <FriendsContext.Provider value={contextValue}>{children}</FriendsContext.Provider>;
+};

--- a/frontend/src/features/friends/contexts/FriendsProvider.tsx
+++ b/frontend/src/features/friends/contexts/FriendsProvider.tsx
@@ -10,16 +10,19 @@ import { FriendsContext, FriendsContextType } from './FriendsContext';
 
 export const FriendsProvider = ({ children }: PropsWithChildren) => {
   const { isAuthenticated } = useAuth();
-  const { reconnect } = useUserSocket();
+  const { reconnect, isConnected } = useUserSocket();
   const { pathname } = useLocation();
 
   const [friends, setFriends] = useState<Friend[]>([]);
   const [receivedRequests, setReceivedRequests] = useState<ReceivedRequest[]>([]);
   const [sentRequests, setSentRequests] = useState<SentRequest[]>([]);
+  const [isFriendsLoaded, setIsFriendsLoaded] = useState(false);
 
   // ref로 관리해 deps 없이 최신 값 참조
   const isInRoomRef = useRef(false);
   const reconnectRef = useRef(reconnect);
+  // STOMP 연결 후 1회만 초기 로드 (재연결 시 중복 로드 방지)
+  const initialLoadDoneRef = useRef(false);
 
   useEffect(() => {
     isInRoomRef.current = pathname.startsWith('/room/');
@@ -29,14 +32,23 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
     reconnectRef.current = reconnect;
   }, [reconnect]);
 
-  // 로그인 시 초기 데이터 로드
+  // 로그인 해제 시 상태 초기화
   useEffect(() => {
     if (!isAuthenticated) {
       setFriends([]);
       setReceivedRequests([]);
       setSentRequests([]);
-      return;
+      setIsFriendsLoaded(false);
+      initialLoadDoneRef.current = false;
     }
+  }, [isAuthenticated]);
+
+  // STOMP 연결 완료 후 초기 로드 — presence 이벤트 유실 방지
+  // (구독 전에 REST를 호출하면 presence 이벤트가 빈 friends 배열에 적용되어 소실됨)
+  useEffect(() => {
+    if (!isAuthenticated || !isConnected || initialLoadDoneRef.current) return;
+
+    initialLoadDoneRef.current = true;
 
     const load = async () => {
       try {
@@ -49,6 +61,7 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
         setFriends(friendsList);
         setReceivedRequests(received);
         setSentRequests(sent);
+        setIsFriendsLoaded(true);
         if (tokenBefore !== tokenStore.getAccessToken()) {
           reconnectRef.current();
         }
@@ -58,14 +71,16 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
     };
 
     load();
-  }, [isAuthenticated]);
+  }, [isAuthenticated, isConnected]);
 
   // STOMP 이벤트 처리 — 별도 훅으로 분리
+  // presence 구독은 REST 완료(isFriendsLoaded) 후 활성화
   useFriendSocketEvents({
     setFriends,
     setReceivedRequests,
     setSentRequests,
     isAuthenticated,
+    isFriendsLoaded,
     isInRoomRef,
   });
 

--- a/frontend/src/features/friends/contexts/FriendsProvider.tsx
+++ b/frontend/src/features/friends/contexts/FriendsProvider.tsx
@@ -1,36 +1,33 @@
-import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import useModal from '@/components/@common/Modal/useModal';
-import useToast from '@/components/@common/Toast/useToast';
-import { useUserSocketSubscription } from '@/apis/websocket/hooks/useUserSocketSubscription';
 import { useUserSocket } from '@/apis/websocket/contexts/UserSocketContext';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { tokenStore } from '@/features/auth/tokens';
 import { friendsApi } from '../api/friendsApi';
-import RoomInvitationModal from '../components/RoomInvitationModal';
-import {
-  Friend,
-  FriendPresenceEvent,
-  FriendRemovedEvent,
-  FriendRequestEvent,
-  FriendResponseEvent,
-  ReceivedRequest,
-  RoomInvitationEvent,
-  SentRequest,
-} from '../types';
+import { useFriendSocketEvents } from '../hooks/useFriendSocketEvents';
+import { Friend, ReceivedRequest, SentRequest } from '../types';
 import { FriendsContext, FriendsContextType } from './FriendsContext';
 
 export const FriendsProvider = ({ children }: PropsWithChildren) => {
   const { isAuthenticated } = useAuth();
-  const { showToast } = useToast();
-  const { openModal, closeModal } = useModal();
   const { reconnect } = useUserSocket();
   const { pathname } = useLocation();
-  const isInRoom = pathname.startsWith('/room/');
 
   const [friends, setFriends] = useState<Friend[]>([]);
   const [receivedRequests, setReceivedRequests] = useState<ReceivedRequest[]>([]);
   const [sentRequests, setSentRequests] = useState<SentRequest[]>([]);
+
+  // ref로 관리해 deps 없이 최신 값 참조
+  const isInRoomRef = useRef(false);
+  const reconnectRef = useRef(reconnect);
+
+  useEffect(() => {
+    isInRoomRef.current = pathname.startsWith('/room/');
+  }, [pathname]);
+
+  useEffect(() => {
+    reconnectRef.current = reconnect;
+  }, [reconnect]);
 
   // 로그인 시 초기 데이터 로드
   useEffect(() => {
@@ -43,9 +40,6 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
 
     const load = async () => {
       try {
-        // 토큰 만료 감지: 백엔드는 만료 토큰으로도 STOMP 연결을 허용(sessionId fallback)하므로
-        // REST 호출 결과로만 실제 인증 상태를 확인할 수 있다.
-        // 갱신 전 토큰을 저장해 두고, 성공 후 비교해 갱신 여부를 판단한다.
         const tokenBefore = tokenStore.getAccessToken();
         const [friendsList, received, sent] = await Promise.all([
           friendsApi.getFriends(),
@@ -55,9 +49,8 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
         setFriends(friendsList);
         setReceivedRequests(received);
         setSentRequests(sent);
-        // 토큰이 갱신됐으면 STOMP도 새 토큰으로 재연결
         if (tokenBefore !== tokenStore.getAccessToken()) {
-          reconnect();
+          reconnectRef.current();
         }
       } catch {
         // 초기 로드 실패 시 조용히 빈 상태 유지
@@ -65,104 +58,16 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
     };
 
     load();
-  }, [isAuthenticated, reconnect]);
+  }, [isAuthenticated]);
 
-  // 친구 요청 수신
-  useUserSocketSubscription<FriendRequestEvent>(
-    '/user/queue/friends/requests',
-    useCallback(
-      (event) => {
-        const { data } = event;
-        const req: ReceivedRequest = {
-          requestId: data.requestId,
-          userId: data.fromUserId,
-          userCode: data.fromUserCode,
-          nickname: data.fromNickname,
-          createdAt: data.createdAt,
-        };
-        setReceivedRequests((prev) => [req, ...prev]);
-        showToast({
-          message: `${req.nickname ?? '누군가'} 님이 친구 요청을 보냈습니다`,
-          type: 'info',
-        });
-      },
-      [showToast]
-    ),
-    isAuthenticated
-  );
-
-  // 내가 보낸 요청 응답 수신
-  useUserSocketSubscription<FriendResponseEvent>(
-    '/user/queue/friends/responses',
-    useCallback(
-      (event) => {
-        const { data } = event;
-        setSentRequests((prev) => prev.filter((r) => r.requestId !== data.requestId));
-
-        if (data.accepted) {
-          const newFriend: Friend = {
-            userId: data.counterpartUserId,
-            userCode: data.counterpartUserCode,
-            nickname: data.counterpartNickname,
-            since: new Date().toISOString(),
-            online: false,
-          };
-          setFriends((prev) =>
-            prev.some((f) => f.userId === newFriend.userId) ? prev : [...prev, newFriend]
-          );
-          showToast({
-            message: `${data.counterpartNickname} 님과 친구가 되었습니다`,
-            type: 'success',
-          });
-        } else {
-          showToast({ message: '친구 요청이 거절되었습니다', type: 'info' });
-        }
-      },
-      [showToast]
-    ),
-    isAuthenticated
-  );
-
-  // 친구 끊기 알림 수신
-  useUserSocketSubscription<FriendRemovedEvent>(
-    '/user/queue/friends/removed',
-    useCallback((event) => {
-      setFriends((prev) => prev.filter((f) => f.userId !== event.data.removedByUserId));
-    }, []),
-    isAuthenticated
-  );
-
-  // 방 초대 수신
-  useUserSocketSubscription<RoomInvitationEvent>(
-    '/user/queue/rooms/invitations',
-    useCallback(
-      (event) => {
-        if (isInRoom) return;
-        const { data } = event;
-        openModal(
-          <RoomInvitationModal
-            inviterNickname={data.inviterNickname}
-            joinCode={data.joinCode}
-            onClose={closeModal}
-          />,
-          { title: '방 초대', showCloseButton: false }
-        );
-      },
-      [isInRoom, openModal, closeModal]
-    ),
-    isAuthenticated
-  );
-
-  // 친구 온라인/오프라인 전이
-  useUserSocketSubscription<FriendPresenceEvent>(
-    '/user/queue/friends/presence',
-    useCallback((event) => {
-      setFriends((prev) =>
-        prev.map((f) => (f.userId === event.userId ? { ...f, online: event.online } : f))
-      );
-    }, []),
-    isAuthenticated
-  );
+  // STOMP 이벤트 처리 — 별도 훅으로 분리
+  useFriendSocketEvents({
+    setFriends,
+    setReceivedRequests,
+    setSentRequests,
+    isAuthenticated,
+    isInRoomRef,
+  });
 
   const updateFriendOnline = useCallback((userId: number, online: boolean) => {
     setFriends((prev) => prev.map((f) => (f.userId === userId ? { ...f, online } : f)));
@@ -188,18 +93,31 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
     setSentRequests((prev) => prev.filter((r) => r.requestId !== requestId));
   }, []);
 
-  const contextValue: FriendsContextType = {
-    friends,
-    receivedRequests,
-    sentRequests,
-    pendingReceivedCount: receivedRequests.length,
-    updateFriendOnline,
-    removeFriendFromStore,
-    addFriend,
-    addReceivedRequest,
-    removeReceivedRequest,
-    removeSentRequest,
-  };
+  const contextValue: FriendsContextType = useMemo(
+    () => ({
+      friends,
+      receivedRequests,
+      sentRequests,
+      pendingReceivedCount: receivedRequests.length,
+      updateFriendOnline,
+      removeFriendFromStore,
+      addFriend,
+      addReceivedRequest,
+      removeReceivedRequest,
+      removeSentRequest,
+    }),
+    [
+      friends,
+      receivedRequests,
+      sentRequests,
+      updateFriendOnline,
+      removeFriendFromStore,
+      addFriend,
+      addReceivedRequest,
+      removeReceivedRequest,
+      removeSentRequest,
+    ]
+  );
 
   return <FriendsContext.Provider value={contextValue}>{children}</FriendsContext.Provider>;
 };

--- a/frontend/src/features/friends/hooks/useFriendSocketEvents.tsx
+++ b/frontend/src/features/friends/hooks/useFriendSocketEvents.tsx
@@ -1,0 +1,137 @@
+import { Dispatch, MutableRefObject, SetStateAction, useCallback } from 'react';
+import { useUserSocketSubscription } from '@/apis/websocket/hooks/useUserSocketSubscription';
+import useModal from '@/components/@common/Modal/useModal';
+import useToast from '@/components/@common/Toast/useToast';
+import RoomInvitationModal from '../components/RoomInvitationModal';
+import {
+  Friend,
+  FriendPresenceEvent,
+  FriendRemovedEvent,
+  FriendRequestEvent,
+  FriendResponseEvent,
+  ReceivedRequest,
+  RoomInvitationEvent,
+} from '../types';
+
+type Actions = {
+  setFriends: Dispatch<SetStateAction<Friend[]>>;
+  setReceivedRequests: Dispatch<SetStateAction<ReceivedRequest[]>>;
+  setSentRequests: Dispatch<SetStateAction<ReceivedRequest[]>>;
+  isAuthenticated: boolean;
+  isInRoomRef: MutableRefObject<boolean>;
+};
+
+export const useFriendSocketEvents = ({
+  setFriends,
+  setReceivedRequests,
+  setSentRequests,
+  isAuthenticated,
+  isInRoomRef,
+}: Actions) => {
+  const { showToast } = useToast();
+  const { openModal, closeModal } = useModal();
+
+  // 친구 요청 수신
+  useUserSocketSubscription<FriendRequestEvent>(
+    '/user/queue/friends/requests',
+    useCallback(
+      (event) => {
+        const { data } = event;
+        const req: ReceivedRequest = {
+          requestId: data.requestId,
+          userId: data.fromUserId,
+          userCode: data.fromUserCode,
+          nickname: data.fromNickname,
+          createdAt: data.createdAt,
+        };
+        setReceivedRequests((prev) => [req, ...prev]);
+        showToast({
+          message: `${req.nickname ?? '누군가'} 님이 친구 요청을 보냈습니다`,
+          type: 'info',
+        });
+      },
+      [setReceivedRequests, showToast]
+    ),
+    isAuthenticated
+  );
+
+  // 내가 보낸 요청 응답 수신
+  useUserSocketSubscription<FriendResponseEvent>(
+    '/user/queue/friends/responses',
+    useCallback(
+      (event) => {
+        const { data } = event;
+        setSentRequests((prev) => prev.filter((r) => r.requestId !== data.requestId));
+
+        if (data.accepted) {
+          const newFriend: Friend = {
+            userId: data.counterpartUserId,
+            userCode: data.counterpartUserCode,
+            nickname: data.counterpartNickname,
+            since: new Date().toISOString(),
+            online: false,
+          };
+          setFriends((prev) =>
+            prev.some((f) => f.userId === newFriend.userId) ? prev : [...prev, newFriend]
+          );
+          showToast({
+            message: `${data.counterpartNickname} 님과 친구가 되었습니다`,
+            type: 'success',
+          });
+        } else {
+          showToast({ message: '친구 요청이 거절되었습니다', type: 'info' });
+        }
+      },
+      [setFriends, setSentRequests, showToast]
+    ),
+    isAuthenticated
+  );
+
+  // 친구 끊기 알림 수신
+  useUserSocketSubscription<FriendRemovedEvent>(
+    '/user/queue/friends/removed',
+    useCallback(
+      (event) => {
+        setFriends((prev) => prev.filter((f) => f.userId !== event.data.removedByUserId));
+      },
+      [setFriends]
+    ),
+    isAuthenticated
+  );
+
+  // 방 초대 수신 — 방 안에 있으면 무시
+  useUserSocketSubscription<RoomInvitationEvent>(
+    '/user/queue/rooms/invitations',
+    useCallback(
+      (event) => {
+        if (isInRoomRef.current) return;
+        const { data } = event;
+        openModal(
+          <RoomInvitationModal
+            inviterNickname={data.inviterNickname}
+            joinCode={data.joinCode}
+            onClose={closeModal}
+          />,
+          { title: '방 초대', showCloseButton: false }
+        );
+      },
+      [isInRoomRef, openModal, closeModal]
+    ),
+    isAuthenticated
+  );
+
+  // 친구 온라인/오프라인 전이
+  useUserSocketSubscription<FriendPresenceEvent>(
+    '/user/queue/friends/presence',
+    useCallback(
+      (event) => {
+        const { data } = event;
+        setFriends((prev) =>
+          prev.map((f) => (f.userId === data.userId ? { ...f, online: data.online } : f))
+        );
+      },
+      [setFriends]
+    ),
+    isAuthenticated
+  );
+};

--- a/frontend/src/features/friends/hooks/useFriendSocketEvents.tsx
+++ b/frontend/src/features/friends/hooks/useFriendSocketEvents.tsx
@@ -18,6 +18,7 @@ type Actions = {
   setReceivedRequests: Dispatch<SetStateAction<ReceivedRequest[]>>;
   setSentRequests: Dispatch<SetStateAction<ReceivedRequest[]>>;
   isAuthenticated: boolean;
+  isFriendsLoaded: boolean;
   isInRoomRef: MutableRefObject<boolean>;
 };
 
@@ -26,6 +27,7 @@ export const useFriendSocketEvents = ({
   setReceivedRequests,
   setSentRequests,
   isAuthenticated,
+  isFriendsLoaded,
   isInRoomRef,
 }: Actions) => {
   const { showToast } = useToast();
@@ -121,6 +123,7 @@ export const useFriendSocketEvents = ({
   );
 
   // 친구 온라인/오프라인 전이
+  // REST 완료(isFriendsLoaded) 후 구독 — 서버 일괄 푸시가 friends 배열에 정상 반영되도록 순서 보장
   useUserSocketSubscription<FriendPresenceEvent>(
     '/user/queue/friends/presence',
     useCallback(
@@ -132,6 +135,6 @@ export const useFriendSocketEvents = ({
       },
       [setFriends]
     ),
-    isAuthenticated
+    isAuthenticated && isFriendsLoaded
   );
 };

--- a/frontend/src/features/friends/hooks/useFriends.ts
+++ b/frontend/src/features/friends/hooks/useFriends.ts
@@ -1,0 +1,1 @@
+export { useFriendsContext as useFriends } from '../contexts/FriendsContext';

--- a/frontend/src/features/friends/types.ts
+++ b/frontend/src/features/friends/types.ts
@@ -71,6 +71,9 @@ export type RoomInvitationEvent = {
 };
 
 export type FriendPresenceEvent = {
-  userId: number;
-  online: boolean;
+  success: boolean;
+  data: {
+    userId: number;
+    online: boolean;
+  };
 };

--- a/frontend/src/features/friends/types.ts
+++ b/frontend/src/features/friends/types.ts
@@ -1,0 +1,76 @@
+export type RelationStatus = 'NONE' | 'PENDING_OUTGOING' | 'PENDING_INCOMING' | 'FRIEND' | 'SELF';
+
+export type SearchedUser = {
+  userId: number;
+  userCode: string;
+  nickname: string;
+  relationStatus: RelationStatus;
+  online: boolean;
+};
+
+export type Friend = {
+  userId: number;
+  userCode: string;
+  nickname: string;
+  since: string;
+  online: boolean;
+};
+
+export type ReceivedRequest = {
+  requestId: number;
+  userId: number;
+  userCode: string;
+  nickname: string;
+  createdAt: string | number;
+};
+
+export type SentRequest = {
+  requestId: number;
+  userId: number;
+  userCode: string;
+  nickname: string;
+  createdAt: string | number;
+};
+
+export type FriendRequestEvent = {
+  success: boolean;
+  data: {
+    requestId: number;
+    fromUserId: number;
+    fromUserCode: string;
+    fromNickname: string;
+    createdAt: string | number;
+  };
+};
+
+export type FriendResponseEvent = {
+  success: boolean;
+  data: {
+    requestId: number;
+    accepted: boolean;
+    counterpartUserId: number;
+    counterpartUserCode: string;
+    counterpartNickname: string;
+  };
+};
+
+export type FriendRemovedEvent = {
+  success: boolean;
+  data: {
+    removedByUserId: number;
+  };
+};
+
+export type RoomInvitationEvent = {
+  success: boolean;
+  data: {
+    inviterUserId: number;
+    inviterNickname: string;
+    joinCode: string;
+  };
+};
+
+export type FriendPresenceEvent = {
+  userId: number;
+  online: boolean;
+};

--- a/frontend/src/features/home/components/FriendsTab/FriendRow.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendRow.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+import { theme } from '@/styles/theme';
+
+type Props = {
+  nickname?: string;
+  userCode?: string;
+  online?: boolean;
+  showOnlineDot?: boolean;
+  right?: ReactNode;
+};
+
+const FriendRow = ({ nickname, userCode, online = false, showOnlineDot = false, right }: Props) => (
+  <S.Row>
+    <S.AvatarWrap>
+      <S.Avatar>{nickname?.slice(0, 1) ?? '?'}</S.Avatar>
+      {showOnlineDot && <S.OnlineDot $online={online} />}
+    </S.AvatarWrap>
+    <S.Info>
+      <S.Nickname>{nickname}</S.Nickname>
+      <S.Code># {userCode}</S.Code>
+    </S.Info>
+    {right && <S.Right>{right}</S.Right>}
+  </S.Row>
+);
+
+export default FriendRow;
+
+const S = {
+  Row: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background: ${theme.color.white};
+  `,
+
+  AvatarWrap: styled.div`
+    position: relative;
+    flex-shrink: 0;
+  `,
+
+  Avatar: styled.div`
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: ${theme.color.point[100]};
+    color: ${theme.color.point[500]};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 16px;
+  `,
+
+  OnlineDot: styled.div<{ $online: boolean }>`
+    position: absolute;
+    bottom: 1px;
+    right: 1px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 2px solid ${theme.color.white};
+    background: ${({ $online }) =>
+      $online ? theme.color.status.online : theme.color.status.offline};
+  `,
+
+  Info: styled.div`
+    flex: 1;
+    min-width: 0;
+  `,
+
+  Nickname: styled.p`
+    ${theme.typography.h4}
+    color: ${theme.color.gray[900]};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.2;
+  `,
+
+  Code: styled.p`
+    ${theme.typography.caption}
+    color: ${theme.color.gray[400]};
+    margin-top: 0;
+    line-height: 1.2;
+  `,
+
+  Right: styled.div`
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    flex-shrink: 0;
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/FriendRow.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendRow.tsx
@@ -44,13 +44,19 @@ const S = {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: ${theme.color.point[100]};
-    color: ${theme.color.point[500]};
+    background: linear-gradient(
+      135deg,
+      ${theme.color.point[200]} 0%,
+      ${theme.color.point[400]} 100%
+    );
+    color: ${theme.color.white};
     display: flex;
     align-items: center;
     justify-content: center;
-    font-weight: 700;
+    font-weight: 800;
     font-size: 16px;
+    letter-spacing: -0.02em;
+    box-shadow: 0 2px 6px rgba(253, 108, 110, 0.3);
   `,
 
   OnlineDot: styled.div<{ $online: boolean }>`

--- a/frontend/src/features/home/components/FriendsTab/FriendsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsList.tsx
@@ -1,0 +1,217 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { ApiError } from '@/apis/rest/error';
+import Button from '@/components/@common/Button/Button';
+import useModal from '@/components/@common/Modal/useModal';
+import useToast from '@/components/@common/Toast/useToast';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { useFriends } from '@/features/friends/hooks/useFriends';
+import { Friend } from '@/features/friends/types';
+import { theme } from '@/styles/theme';
+import FriendRow from './FriendRow';
+
+const getErrorCode = (err: unknown): string | undefined =>
+  err instanceof ApiError ? (err.data as { errorCode?: string } | null)?.errorCode : undefined;
+
+const RemoveConfirm = ({
+  friend,
+  onConfirm,
+  onCancel,
+}: {
+  friend: Friend;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) => (
+  <S.ConfirmBox>
+    <S.ConfirmText>
+      <strong>{friend.nickname}</strong> 님을 친구 목록에서 삭제할까요?
+    </S.ConfirmText>
+    <S.ConfirmButtons>
+      <Button variant="secondary" onClick={onCancel} width="100%">
+        취소
+      </Button>
+      <Button variant="primary" onClick={onConfirm} width="100%">
+        삭제
+      </Button>
+    </S.ConfirmButtons>
+  </S.ConfirmBox>
+);
+
+const FriendItem = ({ friend }: { friend: Friend }) => {
+  const { showToast } = useToast();
+  const { openModal, closeModal } = useModal();
+  const { removeFriendFromStore } = useFriends();
+  const [loading, setLoading] = useState(false);
+
+  const handleRemove = () => {
+    openModal(
+      <RemoveConfirm
+        friend={friend}
+        onConfirm={async () => {
+          try {
+            setLoading(true);
+            await friendsApi.removeFriend(friend.userId);
+            removeFriendFromStore(friend.userId);
+            closeModal();
+            showToast({ message: '친구를 삭제했습니다', type: 'info' });
+          } catch (err) {
+            const code = getErrorCode(err);
+            if (code === 'NOT_FRIEND') {
+              showToast({ message: '이미 친구 관계가 아닙니다', type: 'error' });
+            } else {
+              showToast({ message: '친구 삭제에 실패했습니다', type: 'error' });
+            }
+          } finally {
+            setLoading(false);
+          }
+        }}
+        onCancel={closeModal}
+      />,
+      { title: '친구 삭제', showCloseButton: true }
+    );
+  };
+
+  return (
+    <FriendRow
+      nickname={friend.nickname}
+      userCode={friend.userCode}
+      online={friend.online}
+      showOnlineDot
+      right={
+        <S.DeleteButton onClick={handleRemove} disabled={loading} aria-label="친구 삭제">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="3 6 5 6 21 6" />
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            <path d="M10 11v6M14 11v6" />
+            <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+          </svg>
+        </S.DeleteButton>
+      }
+    />
+  );
+};
+
+const FriendsList = () => {
+  const { friends } = useFriends();
+
+  const sorted = [...friends].sort((a, b) => Number(b.online) - Number(a.online));
+
+  if (sorted.length === 0) {
+    return (
+      <S.Empty>
+        <svg
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke={theme.color.gray[300]}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          aria-hidden="true"
+        >
+          <circle cx="9" cy="7" r="4" />
+          <path d="M2 21v-2a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4v2" />
+          <path d="M19 8v6M22 11h-6" />
+        </svg>
+        <S.EmptyText>아직 친구가 없어요</S.EmptyText>
+        <S.EmptyDesc>검색으로 친구를 추가해보세요</S.EmptyDesc>
+      </S.Empty>
+    );
+  }
+
+  return (
+    <S.List>
+      {sorted.map((friend) => (
+        <S.Item key={friend.userId}>
+          <FriendItem friend={friend} />
+        </S.Item>
+      ))}
+    </S.List>
+  );
+};
+
+export default FriendsList;
+
+const S = {
+  List: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  Item: styled.div`
+    border-bottom: 1px solid ${theme.color.gray[100]};
+    &:last-of-type {
+      border-bottom: none;
+    }
+  `,
+
+  Empty: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 48px 16px;
+    gap: 8px;
+    text-align: center;
+  `,
+
+  EmptyText: styled.p`
+    ${theme.typography.h4}
+    color: ${theme.color.gray[700]};
+  `,
+
+  EmptyDesc: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+  `,
+
+  DeleteButton: styled.button`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: ${theme.color.gray[300]};
+    padding: 6px;
+    border-radius: 8px;
+    transition:
+      color 0.12s,
+      background 0.12s;
+    &:hover {
+      color: ${theme.color.point[400]};
+      background: ${theme.color.point[50]};
+    }
+    &:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+  `,
+
+  ConfirmBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 8px 0 4px;
+  `,
+
+  ConfirmText: styled.p`
+    ${theme.typography.paragraph}
+    color: ${theme.color.gray[700]};
+    text-align: center;
+  `,
+
+  ConfirmButtons: styled.div`
+    display: flex;
+    gap: 8px;
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/FriendsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsList.tsx
@@ -52,8 +52,8 @@ const FriendItem = ({ friend }: { friend: Friend }) => {
             setLoading(true);
             await friendsApi.removeFriend(friend.userId);
             removeFriendFromStore(friend.userId);
-            closeModal();
             showToast({ message: '친구를 삭제했습니다', type: 'info' });
+            closeModal();
           } catch (err) {
             const code = getErrorCode(err);
             if (code === 'NOT_FRIEND') {
@@ -61,7 +61,6 @@ const FriendItem = ({ friend }: { friend: Friend }) => {
             } else {
               showToast({ message: '친구 삭제에 실패했습니다', type: 'error' });
             }
-          } finally {
             setLoading(false);
           }
         }}

--- a/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
@@ -1,10 +1,9 @@
 import styled from '@emotion/styled';
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useAuth } from '@/features/auth/hooks/useAuth';
-import { friendsApi } from '@/features/friends/api/friendsApi';
 import { useFriends } from '@/features/friends/hooks/useFriends';
-import { SearchedUser } from '@/features/friends/types';
 import useToast from '@/components/@common/Toast/useToast';
+import { useFriendSearch } from '@/features/home/hooks/useFriendSearch';
 import { theme } from '@/styles/theme';
 import FriendsList from './FriendsList';
 import LoginRequiredView from './LoginRequiredView';
@@ -15,12 +14,21 @@ import SentRequestsList from './SentRequestsList';
 type TabKey = '친구' | '받은 요청' | '보낸 요청';
 type SearchMode = '닉네임' | '유저코드';
 
-const DEBOUNCE_MS = 300;
-
 const FriendsTab = () => {
   const { isAuthenticated, user } = useAuth();
   const { friends, receivedRequests, sentRequests } = useFriends();
   const { showToast } = useToast();
+  const {
+    searchQuery,
+    searchMode,
+    searchResults,
+    searchLoading,
+    isSearching,
+    handleSearchChange,
+    handleModeChange,
+  } = useFriendSearch();
+
+  const [activeTab, setActiveTab] = useState<TabKey>('친구');
 
   const handleCopyCode = () => {
     if (!user) return;
@@ -28,66 +36,10 @@ const FriendsTab = () => {
     showToast({ message: '유저코드가 복사되었습니다', type: 'success' });
   };
 
-  const [activeTab, setActiveTab] = useState<TabKey>('친구');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchMode, setSearchMode] = useState<SearchMode>('닉네임');
-  const [searchResults, setSearchResults] = useState<SearchedUser[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const searchIdRef = useRef(0);
-
-  const doSearch = useCallback(async (query: string, mode: SearchMode) => {
-    if (!query.trim()) {
-      setSearchResults([]);
-      return;
-    }
-    if (mode === '유저코드' && query.trim().length !== 5) return;
-
-    const id = ++searchIdRef.current;
-    try {
-      setSearchLoading(true);
-      const results =
-        mode === '닉네임'
-          ? await friendsApi.searchByNickname(query.trim())
-          : await friendsApi.searchByUserCode(query.trim());
-      if (id === searchIdRef.current) setSearchResults(results);
-    } catch {
-      if (id === searchIdRef.current) setSearchResults([]);
-    } finally {
-      if (id === searchIdRef.current) setSearchLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (!searchQuery.trim()) {
-      setSearchResults([]);
-      return;
-    }
-    debounceRef.current = setTimeout(() => {
-      doSearch(searchQuery, searchMode);
-    }, DEBOUNCE_MS);
-
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [searchQuery, searchMode, doSearch]);
-
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(e.target.value);
-  };
-
-  const handleModeChange = (mode: SearchMode) => {
-    setSearchMode(mode);
-    setSearchQuery('');
-    setSearchResults([]);
-  };
-
   if (!isAuthenticated) {
     return <LoginRequiredView />;
   }
 
-  const isSearching = searchQuery.trim().length > 0;
   const tabLabels: TabKey[] = ['친구', '받은 요청', '보낸 요청'];
   const tabCounts: Record<TabKey, number> = {
     친구: friends.length,

--- a/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
@@ -34,6 +34,7 @@ const FriendsTab = () => {
   const [searchResults, setSearchResults] = useState<SearchedUser[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchIdRef = useRef(0);
 
   const doSearch = useCallback(async (query: string, mode: SearchMode) => {
     if (!query.trim()) {
@@ -42,17 +43,18 @@ const FriendsTab = () => {
     }
     if (mode === '유저코드' && query.trim().length !== 5) return;
 
+    const id = ++searchIdRef.current;
     try {
       setSearchLoading(true);
       const results =
         mode === '닉네임'
           ? await friendsApi.searchByNickname(query.trim())
           : await friendsApi.searchByUserCode(query.trim());
-      setSearchResults(results);
+      if (id === searchIdRef.current) setSearchResults(results);
     } catch {
-      setSearchResults([]);
+      if (id === searchIdRef.current) setSearchResults([]);
     } finally {
-      setSearchLoading(false);
+      if (id === searchIdRef.current) setSearchLoading(false);
     }
   }, []);
 

--- a/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
@@ -1,0 +1,317 @@
+import styled from '@emotion/styled';
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { useFriends } from '@/features/friends/hooks/useFriends';
+import { SearchedUser } from '@/features/friends/types';
+import useToast from '@/components/@common/Toast/useToast';
+import { theme } from '@/styles/theme';
+import FriendsList from './FriendsList';
+import LoginRequiredView from './LoginRequiredView';
+import ReceivedRequestsList from './ReceivedRequestsList';
+import SearchPanel from './SearchPanel';
+import SentRequestsList from './SentRequestsList';
+
+type TabKey = '친구' | '받은 요청' | '보낸 요청';
+type SearchMode = '닉네임' | '유저코드';
+
+const DEBOUNCE_MS = 300;
+
+const FriendsTab = () => {
+  const { isAuthenticated, user } = useAuth();
+  const { friends, receivedRequests, sentRequests } = useFriends();
+  const { showToast } = useToast();
+
+  const handleCopyCode = () => {
+    if (!user) return;
+    navigator.clipboard.writeText(user.userCode);
+    showToast({ message: '유저코드가 복사되었습니다', type: 'success' });
+  };
+
+  const [activeTab, setActiveTab] = useState<TabKey>('친구');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchMode, setSearchMode] = useState<SearchMode>('닉네임');
+  const [searchResults, setSearchResults] = useState<SearchedUser[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const doSearch = useCallback(async (query: string, mode: SearchMode) => {
+    if (!query.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    if (mode === '유저코드' && query.trim().length !== 5) return;
+
+    try {
+      setSearchLoading(true);
+      const results =
+        mode === '닉네임'
+          ? await friendsApi.searchByNickname(query.trim())
+          : await friendsApi.searchByUserCode(query.trim());
+      setSearchResults(results);
+    } catch {
+      setSearchResults([]);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      doSearch(searchQuery, searchMode);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, searchMode, doSearch]);
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleModeChange = (mode: SearchMode) => {
+    setSearchMode(mode);
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  if (!isAuthenticated) {
+    return <LoginRequiredView />;
+  }
+
+  const isSearching = searchQuery.trim().length > 0;
+  const tabLabels: TabKey[] = ['친구', '받은 요청', '보낸 요청'];
+  const tabCounts: Record<TabKey, number> = {
+    친구: friends.length,
+    '받은 요청': receivedRequests.length,
+    '보낸 요청': sentRequests.length,
+  };
+
+  return (
+    <S.Container>
+      <S.Header>
+        <S.Title>친구</S.Title>
+      </S.Header>
+
+      {user && (
+        <S.MyCodeCard>
+          <S.MyCodeLabel>내 친구 코드</S.MyCodeLabel>
+          <S.MyCodeRow>
+            <S.MyCode># {user.userCode}</S.MyCode>
+            <S.MyCodeCopy type="button" onClick={handleCopyCode}>
+              복사
+            </S.MyCodeCopy>
+          </S.MyCodeRow>
+        </S.MyCodeCard>
+      )}
+
+      <S.SearchArea>
+        <S.ModeRow>
+          {(['닉네임', '유저코드'] as SearchMode[]).map((mode) => (
+            <S.ModeChip
+              key={mode}
+              $active={searchMode === mode}
+              onClick={() => handleModeChange(mode)}
+            >
+              {mode}
+            </S.ModeChip>
+          ))}
+        </S.ModeRow>
+        <S.SearchInput
+          type="text"
+          value={searchQuery}
+          onChange={handleSearchChange}
+          placeholder={searchMode === '닉네임' ? '닉네임으로 검색' : '5자리 유저코드 입력'}
+          maxLength={searchMode === '유저코드' ? 5 : 20}
+        />
+      </S.SearchArea>
+
+      {isSearching ? (
+        <SearchPanel results={searchResults} loading={searchLoading} />
+      ) : (
+        <>
+          <S.TabRow>
+            {tabLabels.map((tab) => (
+              <S.TabChip key={tab} $active={activeTab === tab} onClick={() => setActiveTab(tab)}>
+                {tab}
+                {tabCounts[tab] > 0 && <S.Badge>{tabCounts[tab]}</S.Badge>}
+              </S.TabChip>
+            ))}
+          </S.TabRow>
+
+          <S.Content>
+            {activeTab === '친구' && <FriendsList />}
+            {activeTab === '받은 요청' && <ReceivedRequestsList />}
+            {activeTab === '보낸 요청' && <SentRequestsList />}
+          </S.Content>
+        </>
+      )}
+    </S.Container>
+  );
+};
+
+export default FriendsTab;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  `,
+
+  Header: styled.div`
+    padding: 24px 16px 8px;
+  `,
+
+  Title: styled.h2`
+    font-size: 22px;
+    font-weight: 800;
+    color: ${theme.color.gray[900]};
+    letter-spacing: -0.02em;
+  `,
+
+  MyCodeCard: styled.div`
+    margin: 0 16px 4px;
+    padding: 14px 16px;
+    background: ${theme.color.point[50]};
+    border: 1px solid ${theme.color.point[100]};
+    border-radius: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  `,
+
+  MyCodeLabel: styled.span`
+    font-size: 11px;
+    font-weight: 600;
+    color: ${theme.color.point[400]};
+    letter-spacing: 0.02em;
+  `,
+
+  MyCodeRow: styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  `,
+
+  MyCode: styled.span`
+    font-size: 18px;
+    font-weight: 800;
+    color: ${theme.color.gray[900]};
+    letter-spacing: 0.06em;
+  `,
+
+  MyCodeCopy: styled.button`
+    padding: 4px 12px;
+    border: 1.5px solid ${theme.color.point[300]};
+    border-radius: 8px;
+    background: ${theme.color.white};
+    color: ${theme.color.point[500]};
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.12s;
+
+    &:active {
+      background: ${theme.color.point[50]};
+    }
+  `,
+
+  SearchArea: styled.div`
+    padding: 8px 16px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `,
+
+  ModeRow: styled.div`
+    display: flex;
+    gap: 6px;
+  `,
+
+  ModeChip: styled.button<{ $active: boolean }>`
+    padding: 5px 12px;
+    border-radius: 20px;
+    border: 1.5px solid
+      ${({ $active }) => ($active ? theme.color.point[400] : theme.color.gray[200])};
+    background: ${({ $active }) => ($active ? theme.color.point[50] : theme.color.white)};
+    color: ${({ $active }) => ($active ? theme.color.point[500] : theme.color.gray[500])};
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+  `,
+
+  SearchInput: styled.input`
+    width: 100%;
+    height: 44px;
+    padding: 0 16px;
+    border: 1.5px solid ${theme.color.gray[200]};
+    border-radius: 12px;
+    font-size: 15px;
+    color: ${theme.color.gray[800]};
+    background: ${theme.color.gray[50]};
+    box-sizing: border-box;
+    outline: none;
+    transition: border-color 0.15s;
+
+    &::placeholder {
+      color: ${theme.color.gray[300]};
+    }
+
+    &:focus {
+      border-color: ${theme.color.point[400]};
+      background: ${theme.color.white};
+    }
+  `,
+
+  TabRow: styled.div`
+    display: flex;
+    padding: 0 16px;
+    gap: 6px;
+    border-bottom: 1px solid ${theme.color.gray[100]};
+    padding-bottom: 12px;
+    margin-bottom: 4px;
+  `,
+
+  TabChip: styled.button<{ $active: boolean }>`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 14px;
+    border-radius: 20px;
+    border: none;
+    background: ${({ $active }) => ($active ? theme.color.gray[900] : theme.color.gray[100])};
+    color: ${({ $active }) => ($active ? theme.color.white : theme.color.gray[500])};
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  `,
+
+  Badge: styled.span`
+    background: ${theme.color.point[400]};
+    color: ${theme.color.white};
+    font-size: 11px;
+    font-weight: 700;
+    border-radius: 10px;
+    padding: 1px 6px;
+    min-width: 18px;
+    text-align: center;
+  `,
+
+  Content: styled.div`
+    flex: 1;
+    background: ${theme.color.white};
+    border-top: 1px solid ${theme.color.gray[100]};
+    margin: 0 16px;
+    border-radius: 16px 16px 0 0;
+    overflow: hidden;
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/LoginRequiredView.tsx
+++ b/frontend/src/features/home/components/FriendsTab/LoginRequiredView.tsx
@@ -1,0 +1,122 @@
+import styled from '@emotion/styled';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import ProviderButton from '@/features/auth/components/ProviderButton/ProviderButton';
+import { OAuthProvider } from '@/features/auth/types';
+import { theme } from '@/styles/theme';
+
+const PROVIDERS: OAuthProvider[] = ['kakao', 'google', 'naver'];
+
+const FriendsIllustration = () => (
+  <svg
+    width="96"
+    height="80"
+    viewBox="0 0 96 80"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    {/* 왼쪽 사람 */}
+    <circle cx="28" cy="22" r="12" fill={theme.color.point[100]} />
+    <circle cx="28" cy="22" r="8" fill={theme.color.point[200]} />
+    <path
+      d="M8 60c0-11 9-18 20-18s20 7 20 18"
+      stroke={theme.color.point[300]}
+      strokeWidth="3"
+      strokeLinecap="round"
+      fill="none"
+    />
+    {/* 오른쪽 사람 */}
+    <circle cx="68" cy="22" r="12" fill={theme.color.point[100]} />
+    <circle cx="68" cy="22" r="8" fill={theme.color.point[200]} />
+    <path
+      d="M48 60c0-11 9-18 20-18s20 7 20 18"
+      stroke={theme.color.point[300]}
+      strokeWidth="3"
+      strokeLinecap="round"
+      fill="none"
+    />
+    {/* 연결선 */}
+    <path
+      d="M40 30 Q48 20 56 30"
+      stroke={theme.color.point[300]}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeDasharray="3 3"
+      fill="none"
+    />
+    {/* 하트 */}
+    <path
+      d="M48 18 c0-2.5 3.5-4 4.5-1.5 1 2.5-4.5 7-4.5 7 0 0-5.5-4.5-4.5-7 1-2.5 4.5-1 4.5 1.5z"
+      fill={theme.color.point[400]}
+    />
+  </svg>
+);
+
+const LoginRequiredView = () => {
+  const { login } = useAuth();
+
+  return (
+    <S.Container>
+      <S.IllustrationWrap>
+        <FriendsIllustration />
+      </S.IllustrationWrap>
+
+      <S.TextGroup>
+        <S.Title>친구와 함께 더 재미있게</S.Title>
+        <S.Desc>로그인하면 친구를 추가하고{'\n'}게임에 함께 초대할 수 있어요</S.Desc>
+      </S.TextGroup>
+
+      <S.LoginSection>
+        {PROVIDERS.map((provider) => (
+          <ProviderButton key={provider} provider={provider} onClick={login} />
+        ))}
+      </S.LoginSection>
+    </S.Container>
+  );
+};
+
+export default LoginRequiredView;
+
+const S = {
+  Container: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 48px 24px 32px;
+    gap: 0;
+  `,
+
+  IllustrationWrap: styled.div`
+    margin-bottom: 24px;
+  `,
+
+  TextGroup: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 36px;
+    text-align: center;
+  `,
+
+  Title: styled.p`
+    font-size: 20px;
+    font-weight: 700;
+    color: ${theme.color.gray[900]};
+    letter-spacing: -0.02em;
+  `,
+
+  Desc: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+    white-space: pre-line;
+    line-height: 1.7;
+  `,
+
+  LoginSection: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
@@ -1,0 +1,142 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { ApiError } from '@/apis/rest/error';
+import Button from '@/components/@common/Button/Button';
+import useToast from '@/components/@common/Toast/useToast';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { useFriends } from '@/features/friends/hooks/useFriends';
+import { ReceivedRequest } from '@/features/friends/types';
+import { theme } from '@/styles/theme';
+
+const getErrorCode = (err: unknown): string | undefined =>
+  err instanceof ApiError ? (err.data as { errorCode?: string } | null)?.errorCode : undefined;
+import FriendRow from './FriendRow';
+
+const RequestItem = ({ request }: { request: ReceivedRequest }) => {
+  const { showToast } = useToast();
+  const { removeReceivedRequest, addFriend } = useFriends();
+  const [loading, setLoading] = useState(false);
+
+  const handleAccept = async () => {
+    try {
+      setLoading(true);
+      const result = await friendsApi.acceptRequest(request.requestId);
+      addFriend({
+        userId: result.friendUserId,
+        userCode: result.friendUserCode,
+        nickname: result.friendNickname,
+        since: new Date().toISOString(),
+        online: false,
+      });
+      removeReceivedRequest(request.requestId);
+      showToast({ message: `${result.friendNickname} 님과 친구가 되었습니다`, type: 'success' });
+    } catch (err) {
+      const code = getErrorCode(err);
+      if (code === 'FRIEND_REQUEST_NOT_FOUND') {
+        showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
+        showToast({ message: '이미 처리된 요청입니다', type: 'error' });
+      } else {
+        showToast({ message: '수락에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReject = async () => {
+    try {
+      setLoading(true);
+      await friendsApi.rejectRequest(request.requestId);
+      removeReceivedRequest(request.requestId);
+    } catch (err) {
+      const code = getErrorCode(err);
+      if (code === 'FRIEND_REQUEST_NOT_FOUND') {
+        showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
+        showToast({ message: '이미 처리된 요청입니다', type: 'error' });
+      } else {
+        showToast({ message: '거절에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <FriendRow
+      nickname={request.nickname}
+      userCode={request.userCode}
+      right={
+        <>
+          <Button
+            variant="primary"
+            onClick={handleAccept}
+            isLoading={loading}
+            width="60px"
+            height="small"
+          >
+            수락
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleReject}
+            isLoading={loading}
+            width="60px"
+            height="small"
+          >
+            거절
+          </Button>
+        </>
+      }
+    />
+  );
+};
+
+const ReceivedRequestsList = () => {
+  const { receivedRequests } = useFriends();
+
+  if (receivedRequests.length === 0) {
+    return (
+      <S.Empty>
+        <S.EmptyText>받은 친구 요청이 없습니다</S.EmptyText>
+      </S.Empty>
+    );
+  }
+
+  return (
+    <S.List>
+      {receivedRequests.map((req) => (
+        <S.Item key={req.requestId}>
+          <RequestItem request={req} />
+        </S.Item>
+      ))}
+    </S.List>
+  );
+};
+
+export default ReceivedRequestsList;
+
+const S = {
+  List: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  Item: styled.div`
+    border-bottom: 1px solid ${theme.color.gray[100]};
+    &:last-of-type {
+      border-bottom: none;
+    }
+  `,
+
+  Empty: styled.div`
+    padding: 48px 16px;
+    text-align: center;
+  `,
+
+  EmptyText: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
@@ -15,11 +15,11 @@ const getErrorCode = (err: unknown): string | undefined =>
 const RequestItem = ({ request }: { request: ReceivedRequest }) => {
   const { showToast } = useToast();
   const { removeReceivedRequest, addFriend } = useFriends();
-  const [loading, setLoading] = useState(false);
+  const [loadingAction, setLoadingAction] = useState<'accept' | 'reject' | null>(null);
 
   const handleAccept = async () => {
     try {
-      setLoading(true);
+      setLoadingAction('accept');
       const result = await friendsApi.acceptRequest(request.requestId);
       addFriend({
         userId: result.friendUserId,
@@ -42,13 +42,13 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
         showToast({ message: '수락에 실패했습니다', type: 'error' });
       }
     } finally {
-      setLoading(false);
+      setLoadingAction(null);
     }
   };
 
   const handleReject = async () => {
     try {
-      setLoading(true);
+      setLoadingAction('reject');
       await friendsApi.rejectRequest(request.requestId);
       removeReceivedRequest(request.requestId);
     } catch (err) {
@@ -63,7 +63,7 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
         showToast({ message: '거절에 실패했습니다', type: 'error' });
       }
     } finally {
-      setLoading(false);
+      setLoadingAction(null);
     }
   };
 
@@ -76,7 +76,7 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
           <Button
             variant="primary"
             onClick={handleAccept}
-            isLoading={loading}
+            isLoading={loadingAction === 'accept'}
             width="60px"
             height="small"
           >
@@ -85,7 +85,7 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
           <Button
             variant="secondary"
             onClick={handleReject}
-            isLoading={loading}
+            isLoading={loadingAction === 'reject'}
             width="60px"
             height="small"
           >

--- a/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
@@ -7,10 +7,10 @@ import { friendsApi } from '@/features/friends/api/friendsApi';
 import { useFriends } from '@/features/friends/hooks/useFriends';
 import { ReceivedRequest } from '@/features/friends/types';
 import { theme } from '@/styles/theme';
+import FriendRow from './FriendRow';
 
 const getErrorCode = (err: unknown): string | undefined =>
   err instanceof ApiError ? (err.data as { errorCode?: string } | null)?.errorCode : undefined;
-import FriendRow from './FriendRow';
 
 const RequestItem = ({ request }: { request: ReceivedRequest }) => {
   const { showToast } = useToast();

--- a/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/ReceivedRequestsList.tsx
@@ -34,6 +34,8 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
       const code = getErrorCode(err);
       if (code === 'FRIEND_REQUEST_NOT_FOUND') {
         showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_FORBIDDEN') {
+        showToast({ message: '수락 권한이 없습니다', type: 'error' });
       } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
         showToast({ message: '이미 처리된 요청입니다', type: 'error' });
       } else {
@@ -53,6 +55,8 @@ const RequestItem = ({ request }: { request: ReceivedRequest }) => {
       const code = getErrorCode(err);
       if (code === 'FRIEND_REQUEST_NOT_FOUND') {
         showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_FORBIDDEN') {
+        showToast({ message: '거절 권한이 없습니다', type: 'error' });
       } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
         showToast({ message: '이미 처리된 요청입니다', type: 'error' });
       } else {

--- a/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
@@ -29,6 +29,10 @@ const ActionButton = ({ user, onRelationChange }: ActionProps) => {
   const [localStatus, setLocalStatus] = useState<RelationStatus>(user.relationStatus);
   const [loading, setLoading] = useState(false);
 
+  useEffect(() => {
+    setLocalStatus(user.relationStatus);
+  }, [user.relationStatus]);
+
   const incomingRequest = receivedRequests.find((r) => r.userId === user.userId);
 
   const handleSendRequest = async () => {

--- a/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
@@ -69,6 +69,8 @@ const ActionButton = ({ user, onRelationChange }: ActionProps) => {
       const code = getErrorCode(err);
       if (code === 'FRIEND_REQUEST_NOT_FOUND') {
         showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_FORBIDDEN') {
+        showToast({ message: '수락 권한이 없습니다', type: 'error' });
       } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
         showToast({ message: '이미 처리된 요청입니다', type: 'error' });
       } else {
@@ -91,6 +93,8 @@ const ActionButton = ({ user, onRelationChange }: ActionProps) => {
       const code = getErrorCode(err);
       if (code === 'FRIEND_REQUEST_NOT_FOUND') {
         showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_FORBIDDEN') {
+        showToast({ message: '거절 권한이 없습니다', type: 'error' });
       } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
         showToast({ message: '이미 처리된 요청입니다', type: 'error' });
       } else {

--- a/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
@@ -1,0 +1,291 @@
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError } from '@/apis/rest/error';
+import useToast from '@/components/@common/Toast/useToast';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { useFriends } from '@/features/friends/hooks/useFriends';
+import { RelationStatus, SearchedUser } from '@/features/friends/types';
+import { theme } from '@/styles/theme';
+import FriendRow from './FriendRow';
+
+const getErrorCode = (err: unknown): string | undefined =>
+  err instanceof ApiError ? (err.data as { errorCode?: string } | null)?.errorCode : undefined;
+
+const FRIEND_REQUEST_MESSAGES: Record<string, string> = {
+  CANNOT_FRIEND_SELF: '자기 자신에게는 친구 요청을 할 수 없습니다',
+  USER_NOT_FOUND: '존재하지 않는 사용자입니다',
+  FRIEND_ALREADY_EXISTS: '이미 친구입니다',
+  FRIEND_REQUEST_ALREADY_SENT: '이미 친구 요청을 보냈습니다',
+};
+
+type ActionProps = {
+  user: SearchedUser;
+  onRelationChange: (userId: number, status: RelationStatus) => void;
+};
+
+const ActionButton = ({ user, onRelationChange }: ActionProps) => {
+  const { showToast } = useToast();
+  const { receivedRequests, addFriend, removeReceivedRequest } = useFriends();
+  const [localStatus, setLocalStatus] = useState<RelationStatus>(user.relationStatus);
+  const [loading, setLoading] = useState(false);
+
+  const incomingRequest = receivedRequests.find((r) => r.userId === user.userId);
+
+  const handleSendRequest = async () => {
+    try {
+      setLoading(true);
+      await friendsApi.sendFriendRequest(user.userId);
+      setLocalStatus('PENDING_OUTGOING');
+      onRelationChange(user.userId, 'PENDING_OUTGOING');
+      showToast({ message: '친구 요청을 보냈습니다', type: 'success' });
+    } catch (err) {
+      const code = getErrorCode(err);
+      showToast({
+        message: FRIEND_REQUEST_MESSAGES[code ?? ''] ?? '친구 요청에 실패했습니다',
+        type: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAccept = async () => {
+    if (!incomingRequest) return;
+    try {
+      setLoading(true);
+      const result = await friendsApi.acceptRequest(incomingRequest.requestId);
+      addFriend({
+        userId: result.friendUserId,
+        userCode: result.friendUserCode,
+        nickname: result.friendNickname,
+        since: new Date().toISOString(),
+        online: false,
+      });
+      removeReceivedRequest(incomingRequest.requestId);
+      setLocalStatus('FRIEND');
+      onRelationChange(user.userId, 'FRIEND');
+      showToast({ message: `${user.nickname} 님과 친구가 되었습니다`, type: 'success' });
+    } catch (err) {
+      const code = getErrorCode(err);
+      if (code === 'FRIEND_REQUEST_NOT_FOUND') {
+        showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
+        showToast({ message: '이미 처리된 요청입니다', type: 'error' });
+      } else {
+        showToast({ message: '수락에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!incomingRequest) return;
+    try {
+      setLoading(true);
+      await friendsApi.rejectRequest(incomingRequest.requestId);
+      removeReceivedRequest(incomingRequest.requestId);
+      setLocalStatus('NONE');
+      onRelationChange(user.userId, 'NONE');
+    } catch (err) {
+      const code = getErrorCode(err);
+      if (code === 'FRIEND_REQUEST_NOT_FOUND') {
+        showToast({ message: '친구 요청을 찾을 수 없습니다', type: 'error' });
+      } else if (code === 'FRIEND_REQUEST_INVALID_STATE') {
+        showToast({ message: '이미 처리된 요청입니다', type: 'error' });
+      } else {
+        showToast({ message: '거절에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRemoveFriend = async () => {
+    try {
+      setLoading(true);
+      await friendsApi.removeFriend(user.userId);
+      setLocalStatus('NONE');
+      onRelationChange(user.userId, 'NONE');
+      showToast({ message: '친구를 삭제했습니다', type: 'info' });
+    } catch (err) {
+      const code = getErrorCode(err);
+      if (code === 'NOT_FRIEND') {
+        showToast({ message: '이미 친구 관계가 아닙니다', type: 'error' });
+      } else {
+        showToast({ message: '친구 삭제에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (localStatus === 'NONE') {
+    return (
+      <S.AddButton onClick={handleSendRequest} disabled={loading}>
+        {loading ? '...' : '+ 친구 추가'}
+      </S.AddButton>
+    );
+  }
+  if (localStatus === 'PENDING_OUTGOING') {
+    return <S.StatusChip $color="gray">요청됨</S.StatusChip>;
+  }
+  if (localStatus === 'PENDING_INCOMING') {
+    return (
+      <>
+        <S.AcceptButton onClick={handleAccept} disabled={loading}>
+          수락
+        </S.AcceptButton>
+        <S.RejectButton onClick={handleReject} disabled={loading}>
+          거절
+        </S.RejectButton>
+      </>
+    );
+  }
+  if (localStatus === 'FRIEND') {
+    return (
+      <S.RemoveButton onClick={handleRemoveFriend} disabled={loading}>
+        친구 끊기
+      </S.RemoveButton>
+    );
+  }
+  return null;
+};
+
+type Props = {
+  results: SearchedUser[];
+  loading: boolean;
+};
+
+const SearchPanel = ({ results, loading }: Props) => {
+  const [localResults, setLocalResults] = useState(results);
+
+  useEffect(() => {
+    setLocalResults(results);
+  }, [results]);
+
+  const handleRelationChange = useCallback((userId: number, status: RelationStatus) => {
+    setLocalResults((prev) =>
+      prev.map((u) => (u.userId === userId ? { ...u, relationStatus: status } : u))
+    );
+  }, []);
+
+  if (loading) {
+    return (
+      <S.StateBox>
+        <S.StateText>검색 중...</S.StateText>
+      </S.StateBox>
+    );
+  }
+  if (localResults.length === 0) {
+    return (
+      <S.StateBox>
+        <S.StateText>검색 결과가 없습니다</S.StateText>
+      </S.StateBox>
+    );
+  }
+
+  return (
+    <S.Card>
+      {localResults.map((user, i) => (
+        <S.Row key={user.userId} $last={i === localResults.length - 1}>
+          <FriendRow
+            nickname={user.nickname}
+            userCode={user.userCode}
+            right={<ActionButton user={user} onRelationChange={handleRelationChange} />}
+          />
+        </S.Row>
+      ))}
+    </S.Card>
+  );
+};
+
+export default SearchPanel;
+
+const baseButtonStyle = `
+  border: none;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 6px 12px;
+  transition: opacity 0.12s;
+  white-space: nowrap;
+  &:disabled { opacity: 0.5; cursor: default; }
+`;
+
+const S = {
+  Card: styled.div`
+    margin: 0 16px;
+    background: ${theme.color.white};
+    border: 1px solid ${theme.color.gray[100]};
+    border-radius: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+  `,
+
+  Row: styled.div<{ $last: boolean }>`
+    border-bottom: ${({ $last }) => ($last ? 'none' : `1px solid ${theme.color.gray[50]}`)};
+  `,
+
+  StateBox: styled.div`
+    padding: 40px 16px;
+    text-align: center;
+  `,
+
+  StateText: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+  `,
+
+  AddButton: styled.button`
+    ${baseButtonStyle}
+    background: ${theme.color.point[50]};
+    color: ${theme.color.point[500]};
+    border: 1.5px solid ${theme.color.point[200]};
+    &:hover:not(:disabled) {
+      background: ${theme.color.point[100]};
+    }
+  `,
+
+  AcceptButton: styled.button`
+    ${baseButtonStyle}
+    background: ${theme.color.point[400]};
+    color: ${theme.color.white};
+    &:hover:not(:disabled) {
+      background: ${theme.color.point[500]};
+    }
+  `,
+
+  RejectButton: styled.button`
+    ${baseButtonStyle}
+    background: ${theme.color.gray[100]};
+    color: ${theme.color.gray[600]};
+    &:hover:not(:disabled) {
+      background: ${theme.color.gray[200]};
+    }
+  `,
+
+  RemoveButton: styled.button`
+    ${baseButtonStyle}
+    background: transparent;
+    color: ${theme.color.gray[400]};
+    border: 1px solid ${theme.color.gray[200]};
+    &:hover:not(:disabled) {
+      background: ${theme.color.gray[50]};
+    }
+  `,
+
+  StatusChip: styled.span<{ $color: 'gray' | 'point' }>`
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 10px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    background: ${({ $color }) =>
+      $color === 'point' ? theme.color.point[50] : theme.color.gray[100]};
+    color: ${({ $color }) => ($color === 'point' ? theme.color.point[500] : theme.color.gray[400])};
+  `,
+};

--- a/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
@@ -139,6 +139,9 @@ const ActionButton = ({ user, onRelationChange }: ActionProps) => {
     return <S.StatusChip $color="gray">요청됨</S.StatusChip>;
   }
   if (localStatus === 'PENDING_INCOMING') {
+    if (!incomingRequest) {
+      return <S.StatusChip $color="gray">요청됨</S.StatusChip>;
+    }
     return (
       <>
         <S.AcceptButton onClick={handleAccept} disabled={loading}>

--- a/frontend/src/features/home/components/FriendsTab/SentRequestsList.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SentRequestsList.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+import { useFriends } from '@/features/friends/hooks/useFriends';
+import { theme } from '@/styles/theme';
+import FriendRow from './FriendRow';
+
+const SentRequestsList = () => {
+  const { sentRequests } = useFriends();
+
+  if (sentRequests.length === 0) {
+    return (
+      <S.Empty>
+        <S.EmptyText>보낸 친구 요청이 없습니다</S.EmptyText>
+      </S.Empty>
+    );
+  }
+
+  return (
+    <S.List>
+      {sentRequests.map((req) => (
+        <S.Item key={req.requestId}>
+          <FriendRow
+            nickname={req.nickname}
+            userCode={req.userCode}
+            right={<S.PendingLabel>대기 중</S.PendingLabel>}
+          />
+        </S.Item>
+      ))}
+    </S.List>
+  );
+};
+
+export default SentRequestsList;
+
+const S = {
+  List: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  Item: styled.div`
+    border-bottom: 1px solid ${theme.color.gray[100]};
+    &:last-of-type {
+      border-bottom: none;
+    }
+  `,
+
+  Empty: styled.div`
+    padding: 48px 16px;
+    text-align: center;
+  `,
+
+  EmptyText: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+  `,
+
+  PendingLabel: styled.span`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+    background: ${theme.color.gray[100]};
+    padding: 4px 10px;
+    border-radius: 20px;
+  `,
+};

--- a/frontend/src/features/home/components/HomeBottomTab/HomeBottomTab.styled.ts
+++ b/frontend/src/features/home/components/HomeBottomTab/HomeBottomTab.styled.ts
@@ -29,6 +29,24 @@ export const TabButton = styled.button<{ $active: boolean }>`
   }
 `;
 
+export const IconWrap = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const TabBadge = styled.div`
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.color.point[400]};
+  border: 2px solid ${({ theme }) => theme.color.white};
+`;
+
 export const TabLabel = styled.span<{ $active: boolean }>`
   font-size: 10px;
   font-weight: ${({ $active }) => ($active ? 600 : 500)};

--- a/frontend/src/features/home/components/HomeBottomTab/HomeBottomTab.tsx
+++ b/frontend/src/features/home/components/HomeBottomTab/HomeBottomTab.tsx
@@ -1,20 +1,22 @@
-import { HomeIcon, MenuIcon, RankingIcon } from './tabIcons';
+import { FriendsIcon, HomeIcon, MenuIcon, RankingIcon } from './tabIcons';
 import * as S from './HomeBottomTab.styled';
 
-export type HomeTabType = 'home' | 'ranking' | 'menu';
+export type HomeTabType = 'home' | 'ranking' | 'friends' | 'menu';
 
 const TABS: { key: HomeTabType; label: string; Icon: typeof HomeIcon }[] = [
   { key: 'home', label: '홈', Icon: HomeIcon },
   { key: 'ranking', label: '랭킹', Icon: RankingIcon },
+  { key: 'friends', label: '친구', Icon: FriendsIcon },
   { key: 'menu', label: '더보기', Icon: MenuIcon },
 ];
 
 type Props = {
   activeTab: HomeTabType;
   onTabChange: (tab: HomeTabType) => void;
+  friendsBadgeCount?: number;
 };
 
-const HomeBottomTab = ({ activeTab, onTabChange }: Props) => (
+const HomeBottomTab = ({ activeTab, onTabChange, friendsBadgeCount = 0 }: Props) => (
   <S.TabBar role="tablist">
     {TABS.map(({ key, label, Icon }) => (
       <S.TabButton
@@ -24,7 +26,10 @@ const HomeBottomTab = ({ activeTab, onTabChange }: Props) => (
         $active={activeTab === key}
         onClick={() => onTabChange(key)}
       >
-        <Icon />
+        <S.IconWrap>
+          <Icon />
+          {key === 'friends' && friendsBadgeCount > 0 && <S.TabBadge />}
+        </S.IconWrap>
         <S.TabLabel $active={activeTab === key}>{label}</S.TabLabel>
       </S.TabButton>
     ))}

--- a/frontend/src/features/home/components/HomeBottomTab/tabIcons.tsx
+++ b/frontend/src/features/home/components/HomeBottomTab/tabIcons.tsx
@@ -16,6 +16,12 @@ export const RankingIcon = (props: IconProps) => (
   </svg>
 );
 
+export const FriendsIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width="22" height="22" {...props}>
+    <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+  </svg>
+);
+
 export const MenuIcon = (props: IconProps) => (
   <svg viewBox="0 0 24 24" fill="currentColor" width="22" height="22" {...props}>
     <rect x="3" y="5" width="18" height="2.5" rx="1.25" />

--- a/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.styled.ts
+++ b/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.styled.ts
@@ -149,6 +149,36 @@ export const Provider = styled.span`
   color: ${({ theme }) => theme.color.gray[400]};
 `;
 
+export const UserCodeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+`;
+
+export const UserCode = styled.span`
+  font-size: 12px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.color.gray[500]};
+  letter-spacing: 0.04em;
+`;
+
+export const CopyButton = styled.button`
+  padding: 1px 7px;
+  border: 1px solid ${({ theme }) => theme.color.gray[200]};
+  border-radius: 5px;
+  background: transparent;
+  color: ${({ theme }) => theme.color.gray[400]};
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.12s;
+
+  &:active {
+    background: ${({ theme }) => theme.color.gray[50]};
+  }
+`;
+
 export const LogoutButton = styled.button`
   padding: 7px 14px;
   border: 1px solid ${({ theme }) => theme.color.gray[200]};

--- a/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.tsx
+++ b/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.tsx
@@ -102,6 +102,19 @@ const AccountSection = () => {
                 </S.NicknameRow>
               )}
               <S.Provider>{PROVIDER_LABEL[user.provider] ?? user.provider}</S.Provider>
+              <S.UserCodeRow>
+                <S.UserCode># {user.userCode}</S.UserCode>
+                <S.CopyButton
+                  type="button"
+                  onClick={() => {
+                    navigator.clipboard.writeText(user.userCode);
+                    showToast({ message: '유저코드가 복사되었습니다', type: 'success' });
+                  }}
+                  aria-label="유저코드 복사"
+                >
+                  복사
+                </S.CopyButton>
+              </S.UserCodeRow>
             </S.UserInfo>
             {!isEditing && (
               <S.LogoutButton type="button" onClick={() => logout()}>

--- a/frontend/src/features/home/hooks/useFriendSearch.ts
+++ b/frontend/src/features/home/hooks/useFriendSearch.ts
@@ -1,0 +1,76 @@
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { SearchedUser } from '@/features/friends/types';
+
+type SearchMode = '닉네임' | '유저코드';
+
+const DEBOUNCE_MS = 300;
+
+export const useFriendSearch = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchMode, setSearchMode] = useState<SearchMode>('닉네임');
+  const [searchResults, setSearchResults] = useState<SearchedUser[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchIdRef = useRef(0);
+
+  const doSearch = useCallback(async (query: string, mode: SearchMode) => {
+    if (!query.trim()) {
+      setSearchResults([]);
+      return;
+    }
+    if (mode === '유저코드' && query.trim().length !== 5) return;
+
+    const id = ++searchIdRef.current;
+    try {
+      setSearchLoading(true);
+      const results =
+        mode === '닉네임'
+          ? await friendsApi.searchByNickname(query.trim())
+          : await friendsApi.searchByUserCode(query.trim());
+      if (id === searchIdRef.current) setSearchResults(results);
+    } catch {
+      if (id === searchIdRef.current) setSearchResults([]);
+    } finally {
+      if (id === searchIdRef.current) setSearchLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults([]);
+      return () => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+      };
+    }
+    debounceRef.current = setTimeout(() => {
+      doSearch(searchQuery, searchMode);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, searchMode, doSearch]);
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = searchMode === '유저코드' ? e.target.value.toUpperCase() : e.target.value;
+    setSearchQuery(value);
+  };
+
+  const handleModeChange = (mode: SearchMode) => {
+    setSearchMode(mode);
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  return {
+    searchQuery,
+    searchMode,
+    searchResults,
+    searchLoading,
+    isSearching: searchQuery.trim().length > 0,
+    handleSearchChange,
+    handleModeChange,
+  };
+};

--- a/frontend/src/features/home/pages/HomePage.tsx
+++ b/frontend/src/features/home/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useWebSocket } from '@/apis/websocket/contexts/WebSocketContext';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
+import { useFriends } from '@/features/friends/hooks/useFriends';
 import { storageManager, STORAGE_KEYS } from '@/utils/StorageManager';
 import HomeHeader from '../components/HomeHeader/HomeHeader';
 import HomeBottomTab, { type HomeTabType } from '../components/HomeBottomTab/HomeBottomTab';
@@ -8,6 +9,7 @@ import { type MenuView } from '../components/MenuTab/MenuTab';
 import HomeTab from '../components/tabs/HomeTab/HomeTab';
 import RankingTab from '../components/RankingTab/RankingTab';
 import MenuTab from '../components/MenuTab/MenuTab';
+import FriendsTab from '../components/FriendsTab/FriendsTab';
 import Splash from '../components/Splash/Splash';
 import * as S from './HomePage.styled';
 
@@ -17,6 +19,7 @@ const HomePage = () => {
   const [menuInitialView, setMenuInitialView] = useState<MenuView | null>(null);
   const { clearIdentifier } = useIdentifier();
   const { isConnected, stopSocket } = useWebSocket();
+  const { pendingReceivedCount } = useFriends();
 
   useEffect(() => {
     if (isConnected) stopSocket();
@@ -62,9 +65,14 @@ const HomePage = () => {
           />
         )}
         {activeTab === 'ranking' && <RankingTab />}
+        {activeTab === 'friends' && <FriendsTab />}
         {activeTab === 'menu' && <MenuTab initialView={menuInitialView} />}
       </S.ScrollArea>
-      <HomeBottomTab activeTab={activeTab} onTabChange={setActiveTab} />
+      <HomeBottomTab
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        friendsBadgeCount={pendingReceivedCount}
+      />
     </S.PageContainer>
   );
 };

--- a/frontend/src/features/room/lobby/components/InviteFriendModal/InviteFriendModal.tsx
+++ b/frontend/src/features/room/lobby/components/InviteFriendModal/InviteFriendModal.tsx
@@ -1,0 +1,219 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { ApiError } from '@/apis/rest/error';
+import Button from '@/components/@common/Button/Button';
+import useToast from '@/components/@common/Toast/useToast';
+import { friendsApi } from '@/features/friends/api/friendsApi';
+import { Friend } from '@/features/friends/types';
+import { theme } from '@/styles/theme';
+
+const getErrorCode = (err: unknown): string | undefined =>
+  err instanceof ApiError ? (err.data as { errorCode?: string } | null)?.errorCode : undefined;
+
+type Props = {
+  joinCode: string;
+  friends: Friend[];
+  participantNames: Set<string>;
+  onClose: () => void;
+};
+
+const FriendInviteRow = ({
+  friend,
+  joinCode,
+  isParticipant,
+}: {
+  friend: Friend;
+  joinCode: string;
+  isParticipant: boolean;
+}) => {
+  const { showToast } = useToast();
+  const [invited, setInvited] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleInvite = async () => {
+    try {
+      setLoading(true);
+      await friendsApi.inviteToRoom(joinCode, friend.userId);
+      setInvited(true);
+      showToast({ message: `${friend.nickname} 님에게 초대장을 보냈습니다`, type: 'success' });
+      setTimeout(() => setInvited(false), 3000);
+    } catch (err: unknown) {
+      const code = getErrorCode(err);
+      if (code === 'ROOM_FULL') {
+        showToast({ message: '방이 가득 찼습니다', type: 'error' });
+      } else if (code === 'ROOM_INVITATION_NOT_LOBBY') {
+        showToast({ message: '게임이 시작된 방에는 초대할 수 없습니다', type: 'error' });
+      } else if (code === 'NOT_FRIEND') {
+        showToast({ message: '친구 관계가 아닙니다', type: 'error' });
+      } else if (code === 'ROOM_NOT_FOUND') {
+        showToast({ message: '존재하지 않는 방입니다', type: 'error' });
+      } else {
+        showToast({ message: '초대에 실패했습니다', type: 'error' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <S.Row>
+      <S.AvatarWrap>
+        <S.Avatar>{friend.nickname?.slice(0, 1) ?? '?'}</S.Avatar>
+        <S.OnlineDot $online={friend.online} />
+      </S.AvatarWrap>
+      <S.Info>
+        <S.Nickname>{friend.nickname}</S.Nickname>
+        <S.Code># {friend.userCode}</S.Code>
+      </S.Info>
+      {isParticipant ? (
+        <Button variant="disabled" width="72px" height="small">
+          참가 중
+        </Button>
+      ) : invited ? (
+        <Button variant="disabled" width="72px" height="small">
+          초대됨
+        </Button>
+      ) : (
+        <Button
+          variant="primary"
+          onClick={handleInvite}
+          isLoading={loading}
+          width="72px"
+          height="small"
+        >
+          초대
+        </Button>
+      )}
+    </S.Row>
+  );
+};
+
+const InviteFriendModal = ({ joinCode, friends, participantNames, onClose }: Props) => {
+  const sorted = [...friends].sort((a, b) => Number(b.online) - Number(a.online));
+
+  if (sorted.length === 0) {
+    return (
+      <S.Empty>
+        <S.EmptyText>아직 친구가 없어요</S.EmptyText>
+        <S.EmptyDesc>홈 화면 친구 탭에서 친구를 추가해보세요</S.EmptyDesc>
+        <Button variant="secondary" onClick={onClose} width="120px" height="small">
+          닫기
+        </Button>
+      </S.Empty>
+    );
+  }
+
+  return (
+    <S.Container>
+      <S.List>
+        {sorted.map((friend) => (
+          <S.Item key={friend.userId}>
+            <FriendInviteRow
+              friend={friend}
+              joinCode={joinCode}
+              isParticipant={participantNames.has(friend.nickname)}
+            />
+          </S.Item>
+        ))}
+      </S.List>
+    </S.Container>
+  );
+};
+
+export default InviteFriendModal;
+
+const S = {
+  Container: styled.div`
+    max-height: 360px;
+    overflow-y: auto;
+  `,
+
+  List: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+
+  Item: styled.div`
+    border-bottom: 1px solid ${theme.color.gray[100]};
+    &:last-of-type {
+      border-bottom: none;
+    }
+  `,
+
+  Row: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 0;
+  `,
+
+  AvatarWrap: styled.div`
+    position: relative;
+    flex-shrink: 0;
+  `,
+
+  Avatar: styled.div`
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: ${theme.color.point[100]};
+    color: ${theme.color.point[500]};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 14px;
+  `,
+
+  OnlineDot: styled.div<{ $online: boolean }>`
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    border: 2px solid ${theme.color.white};
+    background: ${({ $online }) =>
+      $online ? theme.color.status.online : theme.color.status.offline};
+  `,
+
+  Info: styled.div`
+    flex: 1;
+    min-width: 0;
+  `,
+
+  Nickname: styled.p`
+    font-size: 14px;
+    font-weight: 600;
+    color: ${theme.color.gray[900]};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+
+  Code: styled.p`
+    font-size: 11px;
+    color: ${theme.color.gray[400]};
+    margin-top: 1px;
+  `,
+
+  Empty: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 32px 16px 16px;
+    text-align: center;
+  `,
+
+  EmptyText: styled.p`
+    ${theme.typography.h4}
+    color: ${theme.color.gray[700]};
+  `,
+
+  EmptyDesc: styled.p`
+    ${theme.typography.small}
+    color: ${theme.color.gray[400]};
+    margin-bottom: 8px;
+  `,
+};

--- a/frontend/src/features/room/lobby/components/InviteFriendModal/InviteFriendModal.tsx
+++ b/frontend/src/features/room/lobby/components/InviteFriendModal/InviteFriendModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { ApiError } from '@/apis/rest/error';
 import Button from '@/components/@common/Button/Button';
 import useToast from '@/components/@common/Toast/useToast';
+import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { friendsApi } from '@/features/friends/api/friendsApi';
 import { Friend } from '@/features/friends/types';
 import { theme } from '@/styles/theme';
@@ -13,7 +14,6 @@ const getErrorCode = (err: unknown): string | undefined =>
 type Props = {
   joinCode: string;
   friends: Friend[];
-  participantNames: Set<string>;
   onClose: () => void;
 };
 
@@ -41,7 +41,7 @@ const FriendInviteRow = ({
       const code = getErrorCode(err);
       if (code === 'ROOM_FULL') {
         showToast({ message: '방이 가득 찼습니다', type: 'error' });
-      } else if (code === 'ROOM_INVITATION_NOT_LOBBY') {
+      } else if (code === 'ROOM_NOT_READY_TO_JOIN') {
         showToast({ message: '게임이 시작된 방에는 초대할 수 없습니다', type: 'error' });
       } else if (code === 'NOT_FRIEND') {
         showToast({ message: '친구 관계가 아닙니다', type: 'error' });
@@ -71,7 +71,7 @@ const FriendInviteRow = ({
         </Button>
       ) : invited ? (
         <Button variant="disabled" width="72px" height="small">
-          초대됨
+          초대완료
         </Button>
       ) : (
         <Button
@@ -88,7 +88,9 @@ const FriendInviteRow = ({
   );
 };
 
-const InviteFriendModal = ({ joinCode, friends, participantNames, onClose }: Props) => {
+const InviteFriendModal = ({ joinCode, friends, onClose }: Props) => {
+  const { participants } = useParticipants();
+  const participantUserIds = new Set(participants.map((p) => p.userId));
   const sorted = [...friends].sort((a, b) => Number(b.online) - Number(a.online));
 
   if (sorted.length === 0) {
@@ -111,7 +113,7 @@ const InviteFriendModal = ({ joinCode, friends, participantNames, onClose }: Pro
             <FriendInviteRow
               friend={friend}
               joinCode={joinCode}
-              isParticipant={participantNames.has(friend.nickname)}
+              isParticipant={participantUserIds.has(friend.userId)}
             />
           </S.Item>
         ))}

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -221,19 +221,10 @@ const LobbyPage = () => {
       showToast({ message: '로그인 후 이용 가능합니다', type: 'info' });
       return;
     }
-    const participantNames = new Set(participants.map((p) => p.playerName));
-    openModal(
-      <InviteFriendModal
-        joinCode={joinCode}
-        friends={friends}
-        participantNames={participantNames}
-        onClose={closeModal}
-      />,
-      {
-        title: '온라인 친구 초대',
-        showCloseButton: true,
-      }
-    );
+    openModal(<InviteFriendModal joinCode={joinCode} friends={friends} onClose={closeModal} />, {
+      title: '온라인 친구 초대',
+      showCloseButton: true,
+    });
   };
 
   const handleMiniGameClick = (miniGameType: MiniGameType) => {

--- a/frontend/src/features/room/lobby/pages/LobbyPage.tsx
+++ b/frontend/src/features/room/lobby/pages/LobbyPage.tsx
@@ -16,6 +16,8 @@ import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import { useProbabilityHistory } from '@/contexts/ProbabilityHistory/ProbabilityHistoryContext';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { useFriends } from '@/features/friends/hooks/useFriends';
 import { useReplaceNavigate } from '@/hooks/useReplaceNavigate';
 import Layout from '@/layouts/Layout';
 import { MiniGameType } from '@/types/miniGame/common';
@@ -29,6 +31,7 @@ import GameStartButton from '../components/GameStartButton/GameStartButton';
 import GuideModal from '../components/GuideModal/GuideModal';
 import HostWaitingButton from '../components/HostWaitingButton/HostWaitingButton';
 import InvitationModal from '../components/InvitationModal/InvitationModal';
+import InviteFriendModal from '../components/InviteFriendModal/InviteFriendModal';
 import { MiniGameSection } from '../components/MiniGameSection/MiniGameSection';
 import { ParticipantSection } from '../components/ParticipantSection/ParticipantSection';
 import { RouletteSection } from '../components/RouletteSection/RouletteSection';
@@ -44,6 +47,8 @@ const LobbyPage = () => {
   const { myName, joinCode, setQrCodeUrl } = useIdentifier();
   const { openModal, closeModal } = useModal();
   const { showToast } = useToast();
+  const { isAuthenticated } = useAuth();
+  const { friends } = useFriends();
   const { playerType, setPlayerType } = usePlayerType();
   const { probabilityHistory, updateCurrentProbabilities } = useProbabilityHistory();
   const { participants, setParticipants, isAllReady, checkPlayerReady } = useParticipants();
@@ -211,6 +216,26 @@ const LobbyPage = () => {
     });
   };
 
+  const handleFriendInvite = () => {
+    if (!isAuthenticated) {
+      showToast({ message: '로그인 후 이용 가능합니다', type: 'info' });
+      return;
+    }
+    const participantNames = new Set(participants.map((p) => p.playerName));
+    openModal(
+      <InviteFriendModal
+        joinCode={joinCode}
+        friends={friends}
+        participantNames={participantNames}
+        onClose={closeModal}
+      />,
+      {
+        title: '온라인 친구 초대',
+        showCloseButton: true,
+      }
+    );
+  };
+
   const handleMiniGameClick = (miniGameType: MiniGameType) => {
     if (playerType === 'GUEST') return;
 
@@ -303,10 +328,15 @@ const LobbyPage = () => {
         </S.Container>
       </Layout.Content>
 
-      <Layout.ButtonBar flexRatios={[5.5, 1]}>
+      <Layout.ButtonBar flexRatios={[5, 1, 1]} gap="8px">
         {renderGameButton()}
-        <Button variant="primary" onClick={handleShare} aria-label="친구 초대하기">
+        <Button variant="primary" onClick={handleShare} aria-label="링크 공유">
           <img src={ShareIcon} aria-hidden="true" alt="" />
+        </Button>
+        <Button variant="primary" onClick={handleFriendInvite} aria-label="온라인 친구 초대">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M16 11c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3 1.34 3 3 3zm-8 0c1.66 0 3-1.34 3-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+          </svg>
         </Button>
       </Layout.ButtonBar>
       <ScreenReaderOnly aria-live="assertive">{announcement}</ScreenReaderOnly>

--- a/frontend/src/layouts/ButtonBar/ButtonBar.styled.ts
+++ b/frontend/src/layouts/ButtonBar/ButtonBar.styled.ts
@@ -6,13 +6,14 @@ type WrapperProps = {
 
 type ContainerProps = {
   $height: string;
+  $gap?: string;
 };
 
 export const Container = styled.div<ContainerProps>`
   width: 100%;
   height: ${({ $height }) => $height};
   display: flex;
-  gap: 1.5rem;
+  gap: ${({ $gap }) => $gap ?? '1.5rem'};
   padding-top: 8px;
 `;
 

--- a/frontend/src/layouts/ButtonBar/ButtonBar.tsx
+++ b/frontend/src/layouts/ButtonBar/ButtonBar.tsx
@@ -3,11 +3,12 @@ import * as S from './ButtonBar.styled';
 
 type ButtonBarProps = {
   height?: string;
+  gap?: string;
   flexRatios?: number[];
   children: ReactElement | ReactElement[];
 };
 
-const ButtonBar = ({ height = 'auto', flexRatios, children }: ButtonBarProps) => {
+const ButtonBar = ({ height = 'auto', gap, flexRatios, children }: ButtonBarProps) => {
   if (flexRatios?.some((ratio) => ratio <= 0)) {
     throw new Error('flexRatio는 0보다 큰 양수여야 합니다');
   }
@@ -16,7 +17,7 @@ const ButtonBar = ({ height = 'auto', flexRatios, children }: ButtonBarProps) =>
   const defaultRatio = 1;
 
   return (
-    <S.Container $height={height}>
+    <S.Container $height={height} $gap={gap}>
       {buttons.map((button, index) => {
         const ratio = flexRatios?.[index] ?? defaultRatio;
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -30,6 +30,11 @@ const color = {
   black: '#000000',
   yellow: '#FFDF20',
 
+  status: {
+    online: '#1FCD7E',
+    offline: '#D1D5DC',
+  },
+
   oauth: {
     google: {
       bg: '#FFFFFF',

--- a/frontend/src/types/player.ts
+++ b/frontend/src/types/player.ts
@@ -1,6 +1,7 @@
 export type PlayerType = 'HOST' | 'GUEST';
 
 export type Player = {
+  userId: number;
   playerName: string;
   playerType: PlayerType;
   isReady: boolean;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1193
# 🚀 작업 내용
 친구 탭 추가
  - 홈 하단 탭바에 친구 탭 추가 (홈 / 랭킹 / 친구 / 더보기)
  - 닉네임 · 유저코드로 친구 검색, 요청 · 수락 · 거절 · 끊기
  - 받은 요청 배지, 온라인 점 표시, 내 유저코드 카드 + 복사

  실시간 알림 (STOMP)
  - 토큰 전용 사용자 STOMP 연결 별도 추가 (UserSocketProvider)
  - 5개 유저 큐 구독: 친구 요청 / 응답 / 끊기 / 방 초대 / 온라인 상태
  - 방 초대 모달은 방 밖에 있을 때만 표시

  로비 친구 초대
  - 로비 버튼바에 친구 초대 버튼 추가
  - 온라인 친구 목록에서 선택해 초대 발송

  기타
  - theme.color.status.online/offline 토큰 추가
  - 더보기 탭 프로필 카드에 유저코드 표시

