### PR TITLE
[refactor] WebSocket 인증을 RST(Room Session Token) 기반으로 교체

### DIFF
--- a/frontend/src/apis/websocket/contexts/WebSocketContext.ts
+++ b/frontend/src/apis/websocket/contexts/WebSocketContext.ts
@@ -2,7 +2,7 @@ import { Client, StompSubscription } from '@stomp/stompjs';
 import { createContext, useContext } from 'react';
 
 export type WebSocketContextType = {
-  startSocket: (joinCode: string, myName: string) => void;
+  startSocket: (roomToken: string) => void;
   stopSocket: () => void;
   send: <T>(destination: string, body?: T, onError?: (error: Error) => void) => void;
   subscribe: <T>(

--- a/frontend/src/apis/websocket/hooks/useWebSocketConnection.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketConnection.ts
@@ -35,8 +35,8 @@ export const useWebSocketConnection = () => {
   }, []);
 
   const setupStompClient = useCallback(
-    (joinCode: string, myName: string): Client => {
-      const stompClient = createStompClient({ joinCode, playerName: myName });
+    (roomToken: string): Client => {
+      const stompClient = createStompClient({ roomToken });
       stompClient.onConnect = (frame) => handleConnect(frame);
       stompClient.onDisconnect = handleDisconnect;
       stompClient.onStompError = handleStompError;
@@ -59,22 +59,19 @@ export const useWebSocketConnection = () => {
     return true;
   }, [client, isConnected]);
 
-  const validateConnectionParams = useCallback((joinCode: string, myName: string) => {
-    if (!joinCode || !myName) {
-      console.error('❌ WebSocket 연결 실패: 참여코드 또는 이름이 없습니다.', {
-        joinCode,
-        myName,
-      });
+  const validateConnectionParams = useCallback((roomToken: string) => {
+    if (!roomToken) {
+      console.error('❌ WebSocket 연결 실패: roomToken이 없습니다.');
       return false;
     }
     return true;
   }, []);
 
   const startSocket = useCallback(
-    (joinCode: string, myName: string) => {
-      if (!validateClient() || !validateConnectionParams(joinCode, myName)) return;
-      console.log('🚀 WebSocket 연결 시작', { joinCode, myName });
-      const stompClient = setupStompClient(joinCode, myName);
+    (roomToken: string) => {
+      if (!validateClient() || !validateConnectionParams(roomToken)) return;
+      console.log('🚀 WebSocket 연결 시작');
+      const stompClient = setupStompClient(roomToken);
       setClient(stompClient);
       stompClient.activate();
     },

--- a/frontend/src/apis/websocket/hooks/useWebSocketReconnection.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketReconnection.ts
@@ -4,7 +4,7 @@ import { usePageVisibility } from '@/hooks/usePageVisibility';
 
 type Props = {
   isConnected: boolean;
-  startSocket: (joinCode: string, myName: string) => void;
+  startSocket: (roomToken: string) => void;
   stopSocket: () => void;
   onReconnected?: () => void;
 };
@@ -16,7 +16,7 @@ export const useWebSocketReconnection = ({
   onReconnected,
 }: Props) => {
   const { isVisible } = usePageVisibility();
-  const { joinCode, myName } = useIdentifier();
+  const { roomSessionToken } = useIdentifier();
   const reconnectTimerRef = useRef<number | null>(null);
   const wasBackgrounded = useRef(false);
   const hasCheckedRefresh = useRef(false);
@@ -33,9 +33,9 @@ export const useWebSocketReconnection = ({
     clearReconnectTimer();
     wasDisconnectedRef.current = true;
     reconnectTimerRef.current = window.setTimeout(() => {
-      if (joinCode && myName) startSocket(joinCode, myName);
+      if (roomSessionToken) startSocket(roomSessionToken);
     }, 200);
-  }, [joinCode, myName, startSocket, clearReconnectTimer]);
+  }, [roomSessionToken, startSocket, clearReconnectTimer]);
 
   useEffect(() => {
     if (isConnected && wasDisconnectedRef.current) {
@@ -60,13 +60,13 @@ export const useWebSocketReconnection = ({
       isReload = document.referrer === window.location.href;
     }
 
-    if (isReload && !isConnected && joinCode && myName && startSocket) {
-      console.log('🔄 새로고침 감지 - 웹소켓 재연결 시도:', { myName, joinCode });
+    if (isReload && !isConnected && roomSessionToken && startSocket) {
+      console.log('🔄 새로고침 감지 - 웹소켓 재연결 시도');
       hasCheckedRefresh.current = true;
       wasDisconnectedRef.current = true;
-      startSocket(joinCode, myName);
+      startSocket(roomSessionToken);
     }
-  }, [myName, joinCode, isConnected, startSocket]);
+  }, [roomSessionToken, isConnected, startSocket]);
 
   useEffect(() => {
     if (!isVisible && isConnected) {

--- a/frontend/src/apis/websocket/utils/createStompClient.ts
+++ b/frontend/src/apis/websocket/utils/createStompClient.ts
@@ -3,11 +3,10 @@ import SockJS from 'sockjs-client';
 import { getWebSocketUrl } from './getWebSocketUrl';
 
 type Props = {
-  joinCode: string;
-  playerName: string;
+  roomToken: string;
 };
 
-export const createStompClient = ({ joinCode, playerName }: Props) => {
+export const createStompClient = ({ roomToken }: Props) => {
   const wsUrl = getWebSocketUrl();
 
   const client = new Client({
@@ -18,7 +17,7 @@ export const createStompClient = ({ joinCode, playerName }: Props) => {
     maxReconnectDelay: 30000,
     heartbeatIncoming: 4000,
     heartbeatOutgoing: 4000,
-    connectHeaders: { joinCode, playerName },
+    connectHeaders: { roomToken },
   });
 
   return client;

--- a/frontend/src/contexts/Identifier/IdentifierContext.ts
+++ b/frontend/src/contexts/Identifier/IdentifierContext.ts
@@ -13,6 +13,10 @@ type IdentifierContextType = {
   setQrCodeUrl: (qrCodeUrl: string) => void;
   clearQrCodeUrl: () => void;
 
+  roomSessionToken: string;
+  setRoomSessionToken: (token: string) => void;
+  clearRoomSessionToken: () => void;
+
   clearIdentifier: () => void;
 };
 

--- a/frontend/src/contexts/Identifier/IdentifierProvider.tsx
+++ b/frontend/src/contexts/Identifier/IdentifierProvider.tsx
@@ -12,6 +12,9 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
   const [qrCodeUrl, setQrCodeUrl] = useState<string>(() => {
     return storageManager.getItem(STORAGE_KEYS.QR_CODE_URL, 'sessionStorage', '') as string;
   });
+  const [roomSessionToken, setRoomSessionToken] = useState<string>(() => {
+    return storageManager.getItem(STORAGE_KEYS.ROOM_SESSION_TOKEN, 'sessionStorage', '') as string;
+  });
 
   const joinCodeRef = useRef(joinCode);
   const myNameRef = useRef(myName);
@@ -47,6 +50,14 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
     }
   }, [qrCodeUrl]);
 
+  useEffect(() => {
+    if (roomSessionToken) {
+      storageManager.setItem(STORAGE_KEYS.ROOM_SESSION_TOKEN, roomSessionToken, 'sessionStorage');
+    } else {
+      storageManager.removeItem(STORAGE_KEYS.ROOM_SESSION_TOKEN, 'sessionStorage');
+    }
+  }, [roomSessionToken]);
+
   const clearJoinCode = useCallback(() => {
     setJoinCode('');
   }, []);
@@ -59,6 +70,10 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
     setQrCodeUrl('');
   }, []);
 
+  const clearRoomSessionToken = useCallback(() => {
+    setRoomSessionToken('');
+  }, []);
+
   const clearIdentifier = useCallback(() => {
     const currentJoinCode = joinCodeRef.current;
     if (currentJoinCode) {
@@ -67,7 +82,8 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
     clearJoinCode();
     clearMyName();
     clearQrCodeUrl();
-  }, [clearJoinCode, clearMyName, clearQrCodeUrl]);
+    clearRoomSessionToken();
+  }, [clearJoinCode, clearMyName, clearQrCodeUrl, clearRoomSessionToken]);
 
   return (
     <IdentifierContext.Provider
@@ -81,6 +97,9 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
         qrCodeUrl,
         setQrCodeUrl,
         clearQrCodeUrl,
+        roomSessionToken,
+        setRoomSessionToken,
+        clearRoomSessionToken,
         clearIdentifier,
       }}
     >

--- a/frontend/src/features/entry/pages/EntryNamePage/hooks/useRoomManagement.ts
+++ b/frontend/src/features/entry/pages/EntryNamePage/hooks/useRoomManagement.ts
@@ -13,13 +13,14 @@ type RoomRequest = {
 
 type RoomResponse = {
   joinCode: string;
+  roomSessionToken: string;
 };
 
 export const useRoomManagement = () => {
   const navigate = useReplaceNavigate();
   const { startSocket } = useWebSocket();
   const { playerType } = usePlayerType();
-  const { joinCode, setJoinCode } = useIdentifier();
+  const { joinCode, setJoinCode, setRoomSessionToken } = useIdentifier();
   const { showToast } = useToast();
 
   const endpoint = useMemo(() => getRoomEndpoint(playerType, joinCode), [playerType, joinCode]);
@@ -27,10 +28,11 @@ export const useRoomManagement = () => {
   const createOrJoinRoom = useMutation<RoomResponse, RoomRequest>({
     endpoint,
     method: 'POST',
-    onSuccess: (data, variables) => {
-      const { joinCode } = data;
+    onSuccess: (data) => {
+      const { joinCode, roomSessionToken } = data;
       setJoinCode(joinCode);
-      startSocket(joinCode, variables.playerName);
+      setRoomSessionToken(roomSessionToken);
+      startSocket(roomSessionToken);
       if (joinCode) navigate(`/room/${joinCode}/lobby`);
     },
     errorDisplayMode: 'toast',

--- a/frontend/src/utils/StorageManager.ts
+++ b/frontend/src/utils/StorageManager.ts
@@ -12,6 +12,7 @@ export const STORAGE_KEYS = {
   ACCESS_TOKEN: 'zzol-access-token',
   REFRESH_TOKEN: 'zzol-refresh-token',
   TEMP_TOKEN: 'zzol-temp-token',
+  ROOM_SESSION_TOKEN: 'zzol-room-session-token',
 } as const;
 
 type StorageType = 'localStorage' | 'sessionStorage';


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1239

# 🚀 작업 내용

1. STOMP CONNECT 헤더에서 `joinCode`, `playerName` 직접 전달 방식 제거
2. 방 입장/생성 API 응답의 `roomSessionToken`을 `IdentifierContext`에 저장 (sessionStorage 연동)
3. STOMP CONNECT 헤더를 `roomToken: {RST}` 단일 헤더로 교체 (`createStompClient`, `WebSocketContext`)
4. `useWebSocketReconnection` — 재접속 시 `joinCode+myName` 대신 `roomSessionToken` 재사용하도록 수정
5. `StorageManager`에 `ROOM_SESSION_TOKEN` 키 추가

# 💬 리뷰 중점사항

- `useWebSocketReconnection`의 재접속 흐름: 백그라운드 복귀·네트워크 복구·새로고침 세 경로 모두 `roomSessionToken`을 sessionStorage에서 읽어 재사용합니다. RST TTL(기본 1시간)이 만료된 경우 재발급 없이 연결 실패로 처리하는 것은 ADR-0009 결정 사항입니다.
- `Authorization` 헤더(기존 accessToken)는 ADR에 따라 서버에서 무시되므로 STOMP CONNECT 시 전달하지 않습니다.