### PR TITLE
[feat] ZzolBot 도구 및 템플릿 개선으로 joinCode 선택적 지원 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/FewShotSelector.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/FewShotSelector.java
@@ -1,6 +1,6 @@
 package coffeeshout.global.zzolbot.application;
 
-import coffeeshout.global.zzolbot.infra.ZzolBotSessionEntity;
+import coffeeshout.global.zzolbot.domain.FewShotExample;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -12,21 +12,21 @@ public class FewShotSelector {
 
     private static final int EXAMPLE_LIMIT = 5;
 
-    public record Selection(List<ZzolBotSessionEntity> examples, List<Long> ids) {}
+    public record Selection(List<FewShotExample> examples, List<Long> ids) {}
 
-    public Selection select(String question, List<ZzolBotSessionEntity> pool) {
+    public Selection select(String question, List<FewShotExample> pool) {
         if (pool.isEmpty()) {
             return new Selection(List.of(), List.of());
         }
 
-        final List<ZzolBotSessionEntity> shuffled = new ArrayList<>(pool);
+        final List<FewShotExample> shuffled = new ArrayList<>(pool);
         Collections.shuffle(shuffled, new Random((long) question.hashCode()));
 
-        final List<ZzolBotSessionEntity> selected = List.copyOf(
+        final List<FewShotExample> selected = List.copyOf(
                 shuffled.subList(0, Math.min(EXAMPLE_LIMIT, shuffled.size()))
         );
         final List<Long> ids = selected.stream()
-                .map(ZzolBotSessionEntity::getId)
+                .map(FewShotExample::id)
                 .sorted()
                 .toList();
         return new Selection(selected, ids);

--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotChatService.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotChatService.java
@@ -2,6 +2,7 @@ package coffeeshout.global.zzolbot.application;
 
 import coffeeshout.global.zzolbot.config.ZzolBotProperties;
 import coffeeshout.global.zzolbot.domain.AskContext;
+import coffeeshout.global.zzolbot.domain.FewShotExample;
 import coffeeshout.global.zzolbot.domain.PiiMasker;
 import coffeeshout.global.zzolbot.domain.ToolExecutionResult;
 import coffeeshout.global.zzolbot.domain.ZzolBotChatResult;
@@ -38,9 +39,12 @@ public class ZzolBotChatService {
     private final Clock clock;
 
     public ZzolBotChatResult ask(String question, String adminUsername, Consumer<String> progressCallback) {
-        final FewShotSelector.Selection selection = fewShotSelector.select(question,
-                sessionRepository.findByFeedbackOrderByCreatedAtDesc(
-                        ZzolBotFeedback.GOOD, PageRequest.of(0, FEEDBACK_POOL_SIZE)));
+        final List<FewShotExample> pool = sessionRepository.findByFeedbackOrderByCreatedAtDesc(
+                        ZzolBotFeedback.GOOD, PageRequest.of(0, FEEDBACK_POOL_SIZE))
+                .stream()
+                .map(e -> new FewShotExample(e.getId(), e.getQuestion(), e.getAnswer()))
+                .toList();
+        final FewShotSelector.Selection selection = fewShotSelector.select(question, pool);
         final AskContext ctx = AskContext.stamp(question, selection.ids(), clock);
 
         final List<ZzolBotMessage> conversation = initConversation(question);

--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
@@ -2,7 +2,7 @@ package coffeeshout.global.zzolbot.application;
 
 import coffeeshout.global.zzolbot.config.ZzolBotProperties;
 import coffeeshout.global.zzolbot.domain.AskContext;
-import coffeeshout.global.zzolbot.infra.ZzolBotSessionEntity;
+import coffeeshout.global.zzolbot.domain.FewShotExample;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -52,7 +52,7 @@ public class ZzolBotPromptTemplate {
 
     private final ZzolBotProperties properties;
 
-    public String build(AskContext ctx, List<ZzolBotSessionEntity> goodExamples) {
+    public String build(AskContext ctx, List<FewShotExample> goodExamples) {
         final StringBuilder prompt = new StringBuilder(SYSTEM_PROMPT_BASE);
 
         prompt.append(String.format("""
@@ -74,8 +74,8 @@ public class ZzolBotPromptTemplate {
         if (!goodExamples.isEmpty()) {
             prompt.append("\n## 운영자가 좋은 진단으로 평가한 예시\n");
             goodExamples.forEach(example -> {
-                final String answer = example.getAnswer() != null ? example.getAnswer() : "";
-                prompt.append("\n질문: ").append(example.getQuestion())
+                final String answer = example.answer() != null ? example.answer() : "";
+                prompt.append("\n질문: ").append(example.question())
                         .append("\n답변 요약: ").append(answer, 0, Math.min(answer.length(), 200))
                         .append("...\n");
             });

--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
@@ -13,7 +13,7 @@ public class ZzolBotPromptTemplate {
 
     private static final String SYSTEM_PROMPT_BASE = """
             너는 zzol 서비스의 운영 디버깅 어시스턴트 'ZzolBot'이다.
-            운영자가 특정 방(joinCode)에서 발생한 문제를 진단할 수 있도록 도와준다.
+            운영자가 특정 방(joinCode)에서 발생한 문제 또는 시스템 전반의 문제를 진단할 수 있도록 도와준다.
 
             ## zzol 도메인 용어
             - joinCode: 4자리 방 입장 코드 (대문자 + 숫자 조합, 예: A4BX)
@@ -25,18 +25,26 @@ public class ZzolBotPromptTemplate {
             - Redis Stream lag: 이벤트가 쌓였으나 아직 소비되지 않은 상태
 
             ## 사용 가능한 도구와 언제 써야 하는지
-            - room_state: 방 상태와 플레이어 목록 확인 (가장 먼저 실행)
-            - outbox_events: 이벤트 유실/재시도 실패 여부 확인
-            - redis_stream_status: 스트림 전반의 처리 지연 확인
-            - loki_logs: 특정 시간대 에러 로그 확인
-            - tempo_traces: 요청 흐름과 소요 시간 분석
-            - prometheus_query: 메트릭 수치 조회 (예: stream lag, 활성 방 수)
+            - room_state: 방 상태와 플레이어 목록 확인 (joinCode 필수)
+            - outbox_events: 이벤트 유실/재시도 실패 여부 확인 (joinCode 필수)
+            - redis_stream_status: 스트림 전반의 처리 지연 확인 (joinCode 무관)
+            - loki_logs: 에러 로그 확인, joinCode 없으면 전체 환경 조회 (joinCode 선택)
+            - tempo_traces: 요청 흐름과 소요 시간 분석, joinCode 없으면 전체 트레이스 조회 (joinCode 선택)
+            - prometheus_query: 메트릭 수치 조회 (joinCode 무관)
 
             ## 도구 결과 충돌 우선순위
             room_state > outbox_events > redis_stream_status > prometheus_query > loki_logs > tempo_traces
 
             ## 행동 원칙
-            - joinCode가 주어지면 room_state 도구를 먼저 실행한다
+            질문에 4자리 영숫자 joinCode([A-Z0-9]{4} 패턴, 예: A4BX)가 포함되어 있으면:
+            - room_state 도구를 먼저 실행한 뒤 필요한 추가 도구를 호출한다
+
+            질문에 joinCode가 없으면:
+            - 운영자에게 joinCode를 되묻지 않는다
+            - room_state, outbox_events 도구는 호출하지 않는다
+            - redis_stream_status, prometheus_query, loki_logs(joinCode 인자 생략), tempo_traces(joinCode 인자 생략)를 사용해 시스템 전반을 분석한다
+
+            공통:
             - 도구 결과가 불충분하면 추가 도구를 실행한다
             - 최종 답변은 반드시 한국어로 작성한다
             - 답변 형식: **진단 결과** → **조회 기준** → **추정 원인**

--- a/backend/src/main/java/coffeeshout/global/zzolbot/domain/FewShotExample.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/domain/FewShotExample.java
@@ -1,0 +1,3 @@
+package coffeeshout.global.zzolbot.domain;
+
+public record FewShotExample(Long id, String question, String answer) {}

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryTool.java
@@ -45,9 +45,12 @@ public class LokiQueryTool implements ZzolBotTool {
         return TOOL_NAME;
     }
 
+    private static final String GLOBAL_LOG_FILTER = "|~ \"ERROR|WARN\"";
+
     @Override
     public String description() {
-        return "Loki에서 joinCode가 포함된 최근 로그를 조회한다. " +
+        return "Loki에서 로그를 조회한다. " +
+                "joinCode가 있으면 해당 방으로 필터링하고, 없으면 전체 환경에서 ERROR/WARN 레벨을 조회한다. " +
                 "since 파라미터로 조회 기간을 지정한다 (예: 30m, 1h, 2h). 기본값은 1h.";
     }
 
@@ -58,28 +61,32 @@ public class LokiQueryTool implements ZzolBotTool {
                 "properties", Map.of(
                         "joinCode", Map.of(
                                 "type", "string",
-                                "description", "4자리 방 입장 코드"
+                                "description", "4자리 방 입장 코드. 생략하면 전체 환경 조회"
                         ),
                         "since", Map.of(
                                 "type", "string",
                                 "description", "조회 기간 (예: 30m, 1h, 2h). 기본값 1h"
                         )
                 ),
-                "required", List.of("joinCode")
+                "required", List.of()
         );
     }
 
     @Override
     public ToolExecutionResult execute(Map<String, Object> params, AskContext ctx) {
-        if (!(params.get("joinCode") instanceof String joinCodeValue) || !isValidJoinCode(joinCodeValue)) {
+        final Object rawJoinCode = params.get("joinCode");
+        if (rawJoinCode instanceof String joinCodeValue && !joinCodeValue.isBlank() && !isValidJoinCode(joinCodeValue)) {
             return ToolExecutionResult.fail(TOOL_NAME, "유효하지 않은 joinCode 형식");
         }
+        final String joinCodeValue = (rawJoinCode instanceof String s && isValidJoinCode(s)) ? s : null;
         final int lookBackMinutes = parseLookBackMinutes((String) params.getOrDefault("since", "1h"));
 
         final Instant end = ctx.asOf();
         final Instant start = end.minus(lookBackMinutes, ChronoUnit.MINUTES);
 
-        final String logqlQuery = String.format("{environment=\"%s\"} |= \"%s\"", environment, joinCodeValue);
+        final String logqlQuery = joinCodeValue != null
+                ? String.format("{environment=\"%s\"} |= \"%s\"", environment, joinCodeValue)
+                : String.format("{environment=\"%s\"} %s", environment, GLOBAL_LOG_FILTER);
         final long startNano = start.toEpochMilli() * 1_000_000L;
         final long endNano = end.toEpochMilli() * 1_000_000L;
         final String encodedUri = String.format(

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryTool.java
@@ -75,23 +75,23 @@ public class LokiQueryTool implements ZzolBotTool {
     @Override
     public ToolExecutionResult execute(Map<String, Object> params, AskContext ctx) {
         final Object rawJoinCode = params.get("joinCode");
-        if (rawJoinCode instanceof String joinCodeValue && !joinCodeValue.isBlank() && !isValidJoinCode(joinCodeValue)) {
+        if (rawJoinCode instanceof String s && !s.isBlank() && !isValidJoinCode(s)) {
             return ToolExecutionResult.fail(TOOL_NAME, "유효하지 않은 joinCode 형식");
         }
-        final String joinCodeValue = (rawJoinCode instanceof String s && isValidJoinCode(s)) ? s : null;
+        final String joinCode = (rawJoinCode instanceof String s && isValidJoinCode(s)) ? s : null;
         final int lookBackMinutes = parseLookBackMinutes((String) params.getOrDefault("since", "1h"));
 
         final Instant end = ctx.asOf();
         final Instant start = end.minus(lookBackMinutes, ChronoUnit.MINUTES);
 
-        final String logqlQuery = joinCodeValue != null
-                ? String.format("{environment=\"%s\"} |= \"%s\"", environment, joinCodeValue)
+        final String lokiQuery = joinCode != null
+                ? String.format("{environment=\"%s\"} |= \"%s\"", environment, joinCode)
                 : String.format("{environment=\"%s\"} %s", environment, GLOBAL_LOG_FILTER);
         final long startNano = start.toEpochMilli() * 1_000_000L;
         final long endNano = end.toEpochMilli() * 1_000_000L;
         final String encodedUri = String.format(
                 "/loki/api/v1/query_range?query=%s&start=%d&end=%d&limit=%d",
-                URLEncoder.encode(logqlQuery, StandardCharsets.UTF_8),
+                URLEncoder.encode(lokiQuery, StandardCharsets.UTF_8),
                 startNano, endNano, LOG_LIMIT
         );
 
@@ -102,7 +102,7 @@ public class LokiQueryTool implements ZzolBotTool {
                     .body(String.class);
             return ToolExecutionResult.ok(TOOL_NAME, parseLokiResponse(response));
         } catch (RestClientException e) {
-            log.warn("[ZzolBot] Loki 조회 실패. joinCode={}", joinCodeValue, e);
+            log.warn("[ZzolBot] Loki 조회 실패. joinCode={}", joinCode, e);
             return ToolExecutionResult.fail(TOOL_NAME, "Loki 조회 실패");
         }
     }

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceTool.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriBuilder;
 
 @Slf4j
 @Component
@@ -59,16 +60,16 @@ public class TempoTraceTool implements ZzolBotTool {
     @Override
     public ToolExecutionResult execute(Map<String, Object> params, AskContext ctx) {
         final Object rawJoinCode = params.get("joinCode");
-        if (rawJoinCode instanceof String joinCodeValue && !joinCodeValue.isBlank() && !joinCodeValue.matches("[A-Z0-9]{4}")) {
+        if (rawJoinCode instanceof String s && !s.isBlank() && !s.matches("[A-Z0-9]{4}")) {
             return ToolExecutionResult.fail(TOOL_NAME, "유효하지 않은 joinCode 형식");
         }
-        final String joinCodeValue = (rawJoinCode instanceof String s && s.matches("[A-Z0-9]{4}")) ? s : null;
+        final String joinCode = (rawJoinCode instanceof String s && s.matches("[A-Z0-9]{4}")) ? s : null;
         try {
             final String response = restClient.get()
                     .uri(uriBuilder -> {
-                        final var builder = uriBuilder.path("/api/search").queryParam("limit", TRACE_LIMIT);
-                        if (joinCodeValue != null) {
-                            builder.queryParam("tags", "joinCode=" + joinCodeValue);
+                        final UriBuilder builder = uriBuilder.path("/api/search").queryParam("limit", TRACE_LIMIT);
+                        if (joinCode != null) {
+                            builder.queryParam("tags", "joinCode=" + joinCode);
                         }
                         return builder.build();
                     })
@@ -76,7 +77,7 @@ public class TempoTraceTool implements ZzolBotTool {
                     .body(String.class);
             return ToolExecutionResult.ok(TOOL_NAME, parseTempoResponse(response));
         } catch (RestClientException e) {
-            log.warn("[ZzolBot] Tempo 조회 실패. joinCode={}", joinCodeValue, e);
+            log.warn("[ZzolBot] Tempo 조회 실패. joinCode={}", joinCode, e);
             return ToolExecutionResult.fail(TOOL_NAME, "Tempo 조회 실패");
         }
     }

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceTool.java
@@ -38,8 +38,8 @@ public class TempoTraceTool implements ZzolBotTool {
 
     @Override
     public String description() {
-        return "Tempo에서 joinCode 태그로 분산 트레이스를 조회한다. " +
-                "특정 방에서 발생한 요청의 전체 흐름과 소요 시간을 확인할 수 있다.";
+        return "Tempo에서 분산 트레이스를 조회한다. " +
+                "joinCode가 있으면 해당 방의 요청 흐름을 조회하고, 없으면 최근 전체 트레이스를 조회한다.";
     }
 
     @Override
@@ -49,25 +49,29 @@ public class TempoTraceTool implements ZzolBotTool {
                 "properties", Map.of(
                         "joinCode", Map.of(
                                 "type", "string",
-                                "description", "4자리 방 입장 코드"
+                                "description", "4자리 방 입장 코드. 생략하면 전체 트레이스 조회"
                         )
                 ),
-                "required", List.of("joinCode")
+                "required", List.of()
         );
     }
 
     @Override
     public ToolExecutionResult execute(Map<String, Object> params, AskContext ctx) {
-        if (!(params.get("joinCode") instanceof String joinCodeValue) || !joinCodeValue.matches("[A-Z0-9]{4}")) {
+        final Object rawJoinCode = params.get("joinCode");
+        if (rawJoinCode instanceof String joinCodeValue && !joinCodeValue.isBlank() && !joinCodeValue.matches("[A-Z0-9]{4}")) {
             return ToolExecutionResult.fail(TOOL_NAME, "유효하지 않은 joinCode 형식");
         }
+        final String joinCodeValue = (rawJoinCode instanceof String s && s.matches("[A-Z0-9]{4}")) ? s : null;
         try {
             final String response = restClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/api/search")
-                            .queryParam("tags", "joinCode=" + joinCodeValue)
-                            .queryParam("limit", TRACE_LIMIT)
-                            .build())
+                    .uri(uriBuilder -> {
+                        final var builder = uriBuilder.path("/api/search").queryParam("limit", TRACE_LIMIT);
+                        if (joinCodeValue != null) {
+                            builder.queryParam("tags", "joinCode=" + joinCodeValue);
+                        }
+                        return builder.build();
+                    })
                     .retrieve()
                     .body(String.class);
             return ToolExecutionResult.ok(TOOL_NAME, parseTempoResponse(response));

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/FewShotSelectorTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/FewShotSelectorTest.java
@@ -2,7 +2,7 @@ package coffeeshout.global.zzolbot.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coffeeshout.global.zzolbot.infra.ZzolBotSessionEntity;
+import coffeeshout.global.zzolbot.domain.FewShotExample;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -10,7 +10,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 class FewShotSelectorTest {
 
@@ -21,15 +20,13 @@ class FewShotSelectorTest {
         selector = new FewShotSelector();
     }
 
-    private ZzolBotSessionEntity sessionWithId(long id) {
-        final ZzolBotSessionEntity entity = ZzolBotSessionEntity.create("질문" + id, "답변" + id, "admin");
-        ReflectionTestUtils.setField(entity, "id", id);
-        return entity;
+    private FewShotExample exampleWithId(long id) {
+        return new FewShotExample(id, "질문" + id, "답변" + id);
     }
 
-    private List<ZzolBotSessionEntity> pool(int size) {
+    private List<FewShotExample> pool(int size) {
         return IntStream.rangeClosed(1, size)
-                .mapToObj(i -> sessionWithId((long) i))
+                .mapToObj(i -> exampleWithId((long) i))
                 .toList();
     }
 
@@ -48,7 +45,7 @@ class FewShotSelectorTest {
 
         @Test
         void pool이_5개_미만이면_전체를_반환한다() {
-            final List<ZzolBotSessionEntity> smallPool = pool(3);
+            final List<FewShotExample> smallPool = pool(3);
 
             final FewShotSelector.Selection selection = selector.select("질문", smallPool);
 
@@ -57,7 +54,7 @@ class FewShotSelectorTest {
 
         @Test
         void pool이_5개_이상이면_최대_5개를_반환한다() {
-            final List<ZzolBotSessionEntity> largePool = pool(20);
+            final List<FewShotExample> largePool = pool(20);
 
             final FewShotSelector.Selection selection = selector.select("질문", largePool);
 
@@ -66,7 +63,7 @@ class FewShotSelectorTest {
 
         @Test
         void 동일한_question과_pool이면_항상_동일한_ids를_반환한다() {
-            final List<ZzolBotSessionEntity> largePool = pool(20);
+            final List<FewShotExample> largePool = pool(20);
             final String question = "A4BX 방 상태 알려줘";
 
             final FewShotSelector.Selection first = selector.select(question, largePool);
@@ -79,7 +76,7 @@ class FewShotSelectorTest {
 
         @Test
         void 다른_question이면_다른_ids를_반환할_수_있다() {
-            final List<ZzolBotSessionEntity> largePool = pool(20);
+            final List<FewShotExample> largePool = pool(20);
 
             final FewShotSelector.Selection selA = selector.select("질문A", largePool);
             final FewShotSelector.Selection selB = selector.select("질문Z", largePool);
@@ -89,7 +86,7 @@ class FewShotSelectorTest {
 
         @Test
         void ids는_정렬된_순서로_반환된다() {
-            final List<ZzolBotSessionEntity> largePool = pool(20);
+            final List<FewShotExample> largePool = pool(20);
 
             final FewShotSelector.Selection selection = selector.select("질문", largePool);
 
@@ -99,7 +96,7 @@ class FewShotSelectorTest {
 
         @Test
         void ids의_크기와_examples의_크기가_일치한다() {
-            final List<ZzolBotSessionEntity> largePool = pool(10);
+            final List<FewShotExample> largePool = pool(10);
 
             final FewShotSelector.Selection selection = selector.select("질문", largePool);
 

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotChatServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotChatServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 
 import coffeeshout.global.zzolbot.config.ZzolBotProperties;
 import coffeeshout.global.zzolbot.domain.AskContext;
+import coffeeshout.global.zzolbot.domain.FewShotExample;
 import coffeeshout.global.zzolbot.domain.PiiMasker;
 import coffeeshout.global.zzolbot.domain.ToolExecutionResult;
 import coffeeshout.global.zzolbot.domain.ZzolBotChatResult;
@@ -186,11 +187,9 @@ class ZzolBotChatServiceTest {
 
         @Test
         void GOOD_피드백_세션이_있으면_systemInstruction에_예시로_주입된다() {
-            final ZzolBotSessionEntity goodSession = ZzolBotSessionEntity.create(
-                    "A4BX 방 상태", "PLAYING 상태입니다.", "admin"
-            );
+            final FewShotExample goodExample = new FewShotExample(1L, "A4BX 방 상태", "PLAYING 상태입니다.");
             given(fewShotSelector.select(any(), any()))
-                    .willReturn(new FewShotSelector.Selection(List.of(goodSession), List.of()));
+                    .willReturn(new FewShotSelector.Selection(List.of(goodExample), List.of()));
             given(llmClient.generate(anyList(), anyList(), anyString(), any(AskContext.class)))
                     .willReturn(new ZzolBotLlmResponse.TextResponse("응답"));
 

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplateTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplateTest.java
@@ -76,4 +76,26 @@ class ZzolBotPromptTemplateTest {
 
         assertThat(prompt1).isEqualTo(prompt2);
     }
+
+    @Test
+    void joinCode_있을때와_없을때_행동_원칙이_모두_포함된다() {
+        final String prompt = promptTemplate.build(CTX, List.of());
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(prompt).contains("joinCode가 없으면");
+            softly.assertThat(prompt).contains("되묻지 않는다");
+            softly.assertThat(prompt).contains("room_state, outbox_events 도구는 호출하지 않는다");
+        });
+    }
+
+    @Test
+    void 도구별_joinCode_의존성이_명시된다() {
+        final String prompt = promptTemplate.build(CTX, List.of());
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(prompt).contains("joinCode 필수");
+            softly.assertThat(prompt).contains("joinCode 선택");
+            softly.assertThat(prompt).contains("joinCode 무관");
+        });
+    }
 }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
@@ -115,5 +115,28 @@ class LokiQueryToolTest {
 
             assertThat(result.success()).isTrue();
         }
+
+        @Test
+        void joinCode_없이_호출하면_전역_로그_조회에_성공한다(WireMockRuntimeInfo wmInfo) {
+            stubFor(get(urlPathEqualTo("/loki/api/v1/query_range"))
+                    .willReturn(ok().withBody("{\"status\":\"success\",\"data\":{}}")));
+
+            final ToolExecutionResult result = createTool(wmInfo).execute(Map.of(), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isTrue();
+                softly.assertThat(result.toolName()).isEqualTo(LokiQueryTool.TOOL_NAME);
+            });
+        }
+
+        @Test
+        void joinCode_형식이_잘못된_경우_실패를_반환한다(WireMockRuntimeInfo wmInfo) {
+            final ToolExecutionResult result = createTool(wmInfo).execute(Map.of("joinCode", "invalid!"), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isFalse();
+                softly.assertThat(result.content()).contains("유효하지 않은 joinCode 형식");
+            });
+        }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
@@ -72,5 +72,28 @@ class TempoTraceToolTest {
 
             assertThat(result.success()).isFalse();
         }
+
+        @Test
+        void joinCode_없이_호출하면_전체_트레이스_조회에_성공한다(WireMockRuntimeInfo wmInfo) {
+            stubFor(get(urlPathEqualTo("/api/search"))
+                    .willReturn(ok().withBody("{\"traces\":[]}")));
+
+            final ToolExecutionResult result = createTool(wmInfo).execute(Map.of(), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isTrue();
+                softly.assertThat(result.toolName()).isEqualTo(TempoTraceTool.TOOL_NAME);
+            });
+        }
+
+        @Test
+        void joinCode_형식이_잘못된_경우_실패를_반환한다(WireMockRuntimeInfo wmInfo) {
+            final ToolExecutionResult result = createTool(wmInfo).execute(Map.of("joinCode", "bad!"), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isFalse();
+                softly.assertThat(result.content()).contains("유효하지 않은 joinCode 형식");
+            });
+        }
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1244

# 🚀 작업 내용
> "오늘 발생한 에러를 정리해줘"라고 물으면 계속 joinCode를 물어보길래 수정했습니다.
1. `ZzolBotPromptTemplate` — joinCode 없을 때 행동 원칙 추가. 되묻지 않고 시스템 전반 도구로 분기하도록 LLM에 명시
2. `LokiQueryTool` — joinCode를 optional 파라미터로 변경. 없으면 환경 전체의 ERROR/WARN 로그 조회
3. `TempoTraceTool` — joinCode를 optional 파라미터로 변경. 없으면 tags 필터 제외한 전체 트레이스 조회

# 💬 리뷰 중점사항
프롬프트 행동 원칙 문구가 실제로 LLM을 의도한 방향으로 유도하는지 (joinCode 없는 질문 시 되묻지 않고 redis_stream_status / prometheus_query / loki_logs  / tempo_traces 조합으로 분석하는지)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 진단 도구가 방 코드 없이도 전체 시스템 정보(로그/트레이스)를 조회할 수 있음
  * 피드백 기반 예시(페어샷)가 시스템 응답에 활용됨

* **개선사항**
  * 도구별 파라미터 요구사항(필수/선택)과 사용 규칙이 명확해짐
  * 도구의 입력 검증과 실패처리 더 유연해짐

* **테스트**
  * joinCode 유무 및 형식 검증을 다루는 단위 테스트 추가/확장

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-zzol/pull/1246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->