### PR TITLE
[feat] ZzolBot sql query 도구 추가 

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -110,6 +110,9 @@ dependencies {
     // --- Gemini AI ---
     implementation("com.google.genai:google-genai:${googleGenAiVersion}")
 
+    // --- SQL AST 파싱 (ZzolBot sql_query 도구 보안 검증용) ---
+    implementation("com.github.jsqlparser:jsqlparser:5.0")
+
     // --- 운영자 대시보드 ---
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")

--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
@@ -1,9 +1,11 @@
 package coffeeshout.global.zzolbot.application;
 
 import coffeeshout.global.zzolbot.config.ZzolBotProperties;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties.TableSchema;
 import coffeeshout.global.zzolbot.domain.AskContext;
 import coffeeshout.global.zzolbot.infra.ZzolBotSessionEntity;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,8 +14,8 @@ import org.springframework.stereotype.Component;
 public class ZzolBotPromptTemplate {
 
     private static final String SYSTEM_PROMPT_BASE = """
-            너는 zzol 서비스의 운영 디버깅 어시스턴트 'ZzolBot'이다.
-            운영자가 특정 방(joinCode)에서 발생한 문제를 진단할 수 있도록 도와준다.
+            너는 zzol 서비스의 운영 어시스턴트 'ZzolBot'이다.
+            운영자가 (1) 특정 방(joinCode)에서 발생한 문제를 진단하거나 (2) 서비스 운영 통계를 조회할 수 있도록 도와준다.
 
             ## zzol 도메인 용어
             - joinCode: 4자리 방 입장 코드 (대문자 + 숫자 조합, 예: A4BX)
@@ -25,29 +27,41 @@ public class ZzolBotPromptTemplate {
             - Redis Stream lag: 이벤트가 쌓였으나 아직 소비되지 않은 상태
 
             ## 사용 가능한 도구와 언제 써야 하는지
-            - room_state: 방 상태와 플레이어 목록 확인 (가장 먼저 실행)
+            - room_state: 방 상태와 플레이어 목록 확인 (방 진단 모드의 첫 번째 도구)
             - outbox_events: 이벤트 유실/재시도 실패 여부 확인
             - redis_stream_status: 스트림 전반의 처리 지연 확인
             - loki_logs: 특정 시간대 에러 로그 확인
             - tempo_traces: 요청 흐름과 소요 시간 분석
             - prometheus_query: 메트릭 수치 조회 (예: stream lag, 활성 방 수)
+            - sql_query: 회원·방·미니게임 등 운영 통계를 SQL로 직접 조회 (joinCode 없는 통계 질문에 사용)
 
-            ## 도구 결과 충돌 우선순위
+            ## 도구 결과 충돌 우선순위 (방 진단 모드)
             room_state > outbox_events > redis_stream_status > prometheus_query > loki_logs > tempo_traces
 
             ## 행동 원칙
-            - joinCode가 주어지면 room_state 도구를 먼저 실행한다
+            - joinCode가 주어지면 room_state 도구를 먼저 실행한다 (방 진단 모드)
+            - joinCode 없이 통계·집계·현황 질문이면 sql_query 도구를 사용한다 (통계 조회 모드)
+            - sql_query는 단일 SELECT, 컬럼 직접 명시, 와일드카드(*) 사용 불가
             - 도구 결과가 불충분하면 추가 도구를 실행한다
             - 최종 답변은 반드시 한국어로 작성한다
-            - 답변 형식: **진단 결과** → **조회 기준** → **추정 원인**
+            - 방 진단 답변 형식: **진단 결과** → **조회 기준** → **추정 원인**
+            - 통계 조회 답변 형식: **조회 결과** → **조회 기준(사용한 SQL, 사용한 도구 목록)**
             """;
 
     private final ZzolBotProperties properties;
 
     public String build(AskContext ctx, List<ZzolBotSessionEntity> goodExamples) {
         final StringBuilder prompt = new StringBuilder(SYSTEM_PROMPT_BASE);
+        prompt.append(buildSqlSchemaSection());
+        prompt.append(buildContextSection(ctx));
+        if (!goodExamples.isEmpty()) {
+            prompt.append(buildFewShotSection(goodExamples));
+        }
+        return prompt.toString();
+    }
 
-        prompt.append(String.format("""
+    private String buildContextSection(AskContext ctx) {
+        return """
 
                 ## 분석 기준 시각(asOf)
                 %s
@@ -57,22 +71,42 @@ public class ZzolBotPromptTemplate {
 
                 ## 답변 schema 강제
                 **진단 결과** → **조회 기준(asOf: %s, 요청ID: %s, 사용한 도구 목록)** → **추정 원인**
-                """,
-                ctx.asOf().toString(),
+                """.formatted(
+                ctx.asOf(),
                 properties.defaultWindowMinutes(),
-                ctx.asOf().toString(),
-                ctx.requestId()));
+                ctx.asOf(),
+                ctx.requestId()
+        );
+    }
 
-        if (!goodExamples.isEmpty()) {
-            prompt.append("\n## 운영자가 좋은 진단으로 평가한 예시\n");
-            goodExamples.forEach(example -> {
-                final String answer = example.getAnswer() != null ? example.getAnswer() : "";
-                prompt.append("\n질문: ").append(example.getQuestion())
-                        .append("\n답변 요약: ").append(answer, 0, Math.min(answer.length(), 200))
-                        .append("...\n");
-            });
+    private String buildFewShotSection(List<ZzolBotSessionEntity> examples) {
+        final StringBuilder sb = new StringBuilder("\n## 운영자가 좋은 진단으로 평가한 예시\n");
+        examples.forEach(example -> sb
+                .append("\n질문: ").append(example.getQuestion())
+                .append("\n답변 요약: ").append(truncateAnswer(example.getAnswer()))
+                .append("...\n"));
+        return sb.toString();
+    }
+
+    private String truncateAnswer(String answer) {
+        if (answer == null) {
+            return "";
         }
+        return answer.substring(0, Math.min(answer.length(), 200));
+    }
 
-        return prompt.toString();
+    private String buildSqlSchemaSection() {
+        final String tableLines = properties.sql().allowedTables().stream()
+                .map(this::formatTableSchema)
+                .collect(Collectors.joining("\n"));
+        return "\n## sql_query 허용 테이블 스키마\n" + tableLines + "\n";
+    }
+
+    private String formatTableSchema(TableSchema schema) {
+        return "- %s(%s)  — %s".formatted(
+                schema.name(),
+                String.join(", ", schema.columns()),
+                schema.description()
+        );
     }
 }

--- a/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplate.java
@@ -69,8 +69,8 @@ public class ZzolBotPromptTemplate {
                 ## 윈도우 규칙
                 도구 결과의 timestamp는 asOf 기준 ±%d분 윈도우만 신뢰한다.
 
-                ## 답변 schema 강제
-                **진단 결과** → **조회 기준(asOf: %s, 요청ID: %s, 사용한 도구 목록)** → **추정 원인**
+                ## 공통 조회 기준 (모든 답변에 포함)
+                asOf: %s, 요청ID: %s, 사용한 도구 목록
                 """.formatted(
                 ctx.asOf(),
                 properties.defaultWindowMinutes(),

--- a/backend/src/main/java/coffeeshout/global/zzolbot/config/ZzolBotProperties.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/config/ZzolBotProperties.java
@@ -4,8 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -18,7 +20,8 @@ public record ZzolBotProperties(
         @NotNull @Valid MonitoringProperties monitoring,
         @NotNull @Valid DeterminismProperties determinism,
         @Positive int defaultWindowMinutes,
-        @Positive long toolTimeoutMillis
+        @Positive long toolTimeoutMillis,
+        @NotNull @Valid SqlProperties sql
 ) {
 
     public record MonitoringProperties(
@@ -32,4 +35,21 @@ public record ZzolBotProperties(
             @DecimalMin("0.0") @DecimalMax("2.0") double temperature,
             @DecimalMin("0.0") @DecimalMax("1.0") double topP
     ) {}
+
+    public record SqlProperties(
+            @NotNull @Valid List<TableSchema> allowedTables,
+            @Positive int maxRows,
+            @Positive int queryTimeoutSeconds
+    ) {}
+
+    public record TableSchema(
+            @NotBlank String name,
+            @NotEmpty List<String> columns,
+            List<String> blockedColumns,
+            @NotBlank String description
+    ) {
+        public TableSchema {
+            blockedColumns = blockedColumns != null ? List.copyOf(blockedColumns) : List.of();
+        }
+    }
 }

--- a/backend/src/main/java/coffeeshout/global/zzolbot/domain/ZzolBotErrorCode.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/domain/ZzolBotErrorCode.java
@@ -1,0 +1,26 @@
+package coffeeshout.global.zzolbot.domain;
+
+import coffeeshout.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ZzolBotErrorCode implements ErrorCode {
+
+    INVALID_SQL(HttpStatus.BAD_REQUEST, "단일 SELECT 문만 허용됩니다."),
+    SQL_TABLE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않은 테이블을 참조하고 있습니다."),
+    SQL_COLUMN_BLOCKED(HttpStatus.BAD_REQUEST, "조회가 차단된 컬럼을 포함하고 있습니다."),
+    SQL_WILDCARD_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "와일드카드(*)는 허용되지 않습니다. 컬럼을 명시해 주세요."),
+    SQL_EXECUTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SQL 실행 중 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryResult.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryResult.java
@@ -1,0 +1,17 @@
+package coffeeshout.global.zzolbot.infra.sql;
+
+import java.util.List;
+import java.util.Map;
+
+public record SqlQueryResult(
+        List<Map<String, Object>> rows,
+        boolean truncated
+) {
+    public SqlQueryResult {
+        rows = List.copyOf(rows);
+    }
+
+    public static SqlQueryResult empty() {
+        return new SqlQueryResult(List.of(), false);
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
@@ -17,21 +17,25 @@ public class SqlQueryRunner {
 
     private final JdbcTemplate jdbcTemplate;
     private final TransactionTemplate readOnlyTx;
+    private final int maxExecutionTimeMs;
 
     public SqlQueryRunner(
             JdbcTemplate jdbcTemplate,
             PlatformTransactionManager txManager,
             ZzolBotProperties properties) {
         this.jdbcTemplate = jdbcTemplate;
+        this.maxExecutionTimeMs = properties.sql().queryTimeoutSeconds() * 1000;
         this.readOnlyTx = new TransactionTemplate(txManager);
         this.readOnlyTx.setReadOnly(true);
         this.readOnlyTx.setTimeout(properties.sql().queryTimeoutSeconds());
     }
 
     public SqlQueryResult run(String validatedSql) {
+        // Spring timeout(드라이버 레벨)과 이중 방어 — DB 엔진이 직접 쿼리를 종료
+        final String hintedSql = injectMaxExecutionTimeHint(validatedSql);
         try {
             final List<Map<String, Object>> rows = readOnlyTx.execute(status ->
-                    jdbcTemplate.queryForList(validatedSql));
+                    jdbcTemplate.queryForList(hintedSql));
             if (rows == null) {
                 return SqlQueryResult.empty();
             }
@@ -39,9 +43,15 @@ public class SqlQueryRunner {
         } catch (InfrastructureException e) {
             throw e;
         } catch (Exception e) {
-            log.warn("[ZzolBot] sql_query 실행 실패. sql={}", validatedSql, e);
+            log.warn("[ZzolBot] sql_query 실행 실패. sql={}", hintedSql, e);
             throw new InfrastructureException(ZzolBotErrorCode.SQL_EXECUTION_FAILED,
                     "SQL 실행 중 오류가 발생했습니다: " + e.getMessage());
         }
+    }
+
+    // SELECT 키워드 대소문자 무관하게 힌트를 삽입 ("select".length() == "SELECT".length() == 6)
+    private String injectMaxExecutionTimeHint(String sql) {
+        return "SELECT /*+ MAX_EXECUTION_TIME(" + maxExecutionTimeMs + ") */ "
+                + sql.substring("select".length());
     }
 }

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
@@ -1,0 +1,49 @@
+package coffeeshout.global.zzolbot.infra.sql;
+
+import coffeeshout.global.exception.custom.InfrastructureException;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties;
+import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Component
+public class SqlQueryRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate readOnlyTx;
+    private final int maxRows;
+
+    public SqlQueryRunner(
+            JdbcTemplate jdbcTemplate,
+            PlatformTransactionManager txManager,
+            ZzolBotProperties properties) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.maxRows = properties.sql().maxRows();
+        this.readOnlyTx = new TransactionTemplate(txManager);
+        this.readOnlyTx.setReadOnly(true);
+        this.readOnlyTx.setTimeout(properties.sql().queryTimeoutSeconds());
+    }
+
+    public SqlQueryResult run(String validatedSql) {
+        try {
+            final List<Map<String, Object>> rows = readOnlyTx.execute(status ->
+                    jdbcTemplate.queryForList(validatedSql));
+            if (rows == null) {
+                return SqlQueryResult.empty();
+            }
+            return new SqlQueryResult(rows, false);
+        } catch (InfrastructureException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("[ZzolBot] sql_query 실행 실패. sql={}", validatedSql, e);
+            throw new InfrastructureException(ZzolBotErrorCode.SQL_EXECUTION_FAILED,
+                    "SQL 실행 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryRunner.java
@@ -17,14 +17,12 @@ public class SqlQueryRunner {
 
     private final JdbcTemplate jdbcTemplate;
     private final TransactionTemplate readOnlyTx;
-    private final int maxRows;
 
     public SqlQueryRunner(
             JdbcTemplate jdbcTemplate,
             PlatformTransactionManager txManager,
             ZzolBotProperties properties) {
         this.jdbcTemplate = jdbcTemplate;
-        this.maxRows = properties.sql().maxRows();
         this.readOnlyTx = new TransactionTemplate(txManager);
         this.readOnlyTx.setReadOnly(true);
         this.readOnlyTx.setTimeout(properties.sql().queryTimeoutSeconds());

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidator.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidator.java
@@ -1,6 +1,7 @@
 package coffeeshout.global.zzolbot.infra.sql;
 
 import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.exception.custom.InfrastructureException;
 import coffeeshout.global.zzolbot.config.ZzolBotProperties;
 import coffeeshout.global.zzolbot.config.ZzolBotProperties.TableSchema;
 import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
@@ -58,9 +60,12 @@ public class SqlQueryValidator {
             return statements;
         } catch (BusinessException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (JSQLParserException e) {
             throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
                     "SQL 파싱에 실패했습니다: " + e.getMessage());
+        } catch (Exception e) {
+            throw new InfrastructureException(ZzolBotErrorCode.SQL_EXECUTION_FAILED,
+                    "SQL 파서 내부 오류가 발생했습니다: " + e.getMessage());
         }
     }
 
@@ -126,42 +131,46 @@ public class SqlQueryValidator {
     }
 
     private void validateBlockedColumns(PlainSelect select) {
-        final Map<String, Set<String>> blockedByTable = properties.sql().allowedTables().stream()
-                .filter(schema -> schema.blockedColumns() != null && !schema.blockedColumns().isEmpty())
+        final Map<String, Set<String>> blockedByTable = buildBlockedByTable();
+        if (blockedByTable.isEmpty()) {
+            return;
+        }
+        select.getSelectItems().stream()
+                .map(item -> item.getExpression())
+                .filter(expr -> expr instanceof Column)
+                .map(expr -> (Column) expr)
+                .forEach(col -> checkBlockedColumn(col, blockedByTable));
+    }
+
+    private Map<String, Set<String>> buildBlockedByTable() {
+        return properties.sql().allowedTables().stream()
+                .filter(schema -> !schema.blockedColumns().isEmpty())
                 .collect(Collectors.toMap(
                         schema -> schema.name().toLowerCase(),
                         schema -> schema.blockedColumns().stream()
                                 .map(String::toLowerCase)
                                 .collect(Collectors.toSet())
                 ));
+    }
 
-        if (blockedByTable.isEmpty()) {
+    private void checkBlockedColumn(Column column, Map<String, Set<String>> blockedByTable) {
+        final String colName = column.getColumnName().toLowerCase();
+        final String tableName = column.getTable() != null
+                ? column.getTable().getName().toLowerCase()
+                : null;
+        if (tableName != null) {
+            final Set<String> blocked = blockedByTable.get(tableName);
+            if (blocked != null && blocked.contains(colName)) {
+                throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
+                        "조회가 차단된 컬럼입니다: " + tableName + "." + colName);
+            }
             return;
         }
-
-        for (final var item : select.getSelectItems()) {
-            if (!(item.getExpression() instanceof Column column)) {
-                continue;
-            }
-            final String colName = column.getColumnName().toLowerCase();
-            final String tableName = column.getTable() != null
-                    ? column.getTable().getName().toLowerCase()
-                    : null;
-
-            if (tableName != null) {
-                final Set<String> blocked = blockedByTable.get(tableName);
-                if (blocked != null && blocked.contains(colName)) {
-                    throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
-                            "조회가 차단된 컬럼입니다: " + tableName + "." + colName);
-                }
-            } else {
-                final boolean isBlockedAnywhere = blockedByTable.values().stream()
-                        .anyMatch(blockedSet -> blockedSet.contains(colName));
-                if (isBlockedAnywhere) {
-                    throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
-                            "조회가 차단된 컬럼입니다: " + colName);
-                }
-            }
+        final boolean isBlockedAnywhere = blockedByTable.values().stream()
+                .anyMatch(blockedSet -> blockedSet.contains(colName));
+        if (isBlockedAnywhere) {
+            throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
+                    "조회가 차단된 컬럼입니다: " + colName);
         }
     }
 

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidator.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidator.java
@@ -1,0 +1,189 @@
+package coffeeshout.global.zzolbot.infra.sql;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties.TableSchema;
+import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.Limit;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SqlQueryValidator {
+
+    private final ZzolBotProperties properties;
+
+    /**
+     * SQL을 검증하고 LIMIT이 없거나 초과한 경우 maxRows로 보정한 SQL을 반환한다.
+     *
+     * @return 실행 가능한 SQL (LIMIT 자동 보정 포함)
+     * @throws BusinessException 검증 실패 시
+     */
+    public String validate(String sql) {
+        final Statements statements = parse(sql);
+        validateSingleSelect(statements);
+
+        final PlainSelect plainSelect = extractPlainSelect(statements);
+        validateNoWildcard(plainSelect);
+        validateAllowedTables(plainSelect);
+        validateBlockedColumns(plainSelect);
+
+        return applyLimitIfNeeded(sql, plainSelect);
+    }
+
+    private Statements parse(String sql) {
+        if (sql == null || sql.isBlank()) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL, "SQL이 비어있습니다.");
+        }
+        try {
+            final Statements statements = CCJSqlParserUtil.parseStatements(sql);
+            if (statements == null) {
+                throw new BusinessException(ZzolBotErrorCode.INVALID_SQL, "SQL 파싱 결과가 없습니다.");
+            }
+            return statements;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "SQL 파싱에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    private void validateSingleSelect(Statements statements) {
+        final List<Statement> stmtList = statements.getStatements();
+        if (stmtList.size() != 1) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "단일 SELECT 문 하나만 허용됩니다. 현재 " + stmtList.size() + "개의 구문이 감지됐습니다.");
+        }
+        if (!(stmtList.get(0) instanceof Select)) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "SELECT 문만 허용됩니다. DDL·DML은 사용할 수 없습니다.");
+        }
+    }
+
+    // JSqlParser 5.x: PlainSelect extends Select extends Statement (SELECT * FROM ... 형태)
+    private PlainSelect extractPlainSelect(Statements statements) {
+        final Select select = (Select) statements.getStatements().get(0);
+        if (!(select instanceof PlainSelect plainSelect)) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "단순 SELECT 형태만 지원합니다. UNION·INTERSECT 등은 허용되지 않습니다.");
+        }
+        if (plainSelect.getIntoTables() != null && !plainSelect.getIntoTables().isEmpty()) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "SELECT INTO는 허용되지 않습니다.");
+        }
+        // JSqlParser 5.x: FOR UPDATE 여부는 Select 부모 클래스의 forUpdateTable 필드
+        if (plainSelect.getForUpdateTable() != null || plainSelect.getForMode() != null) {
+            throw new BusinessException(ZzolBotErrorCode.INVALID_SQL,
+                    "FOR UPDATE는 허용되지 않습니다.");
+        }
+        return plainSelect;
+    }
+
+    // JSqlParser 5.x: AllColumns/AllTableColumns 는 Expression 구현체 → item.getExpression()으로 확인
+    private void validateNoWildcard(PlainSelect select) {
+        final boolean hasWildcard = select.getSelectItems().stream()
+                .anyMatch(item -> item.getExpression() instanceof AllColumns
+                        || item.getExpression() instanceof AllTableColumns);
+        if (hasWildcard) {
+            throw new BusinessException(ZzolBotErrorCode.SQL_WILDCARD_NOT_ALLOWED,
+                    "와일드카드(*)는 허용되지 않습니다. 조회할 컬럼을 직접 명시해 주세요.");
+        }
+    }
+
+    private void validateAllowedTables(PlainSelect select) {
+        final Set<String> allowedTableNames = properties.sql().allowedTables().stream()
+                .map(TableSchema::name)
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+
+        // PlainSelect가 Statement와 Expression 모두 구현하므로 Statement로 명시적 캐스팅
+        final List<String> referencedTables = new TablesNamesFinder().getTableList((Statement) select);
+
+        referencedTables.stream()
+                .map(String::toLowerCase)
+                .filter(table -> !allowedTableNames.contains(table))
+                .findFirst()
+                .ifPresent(blocked -> {
+                    throw new BusinessException(ZzolBotErrorCode.SQL_TABLE_NOT_ALLOWED,
+                            "허용되지 않은 테이블입니다: " + blocked);
+                });
+    }
+
+    private void validateBlockedColumns(PlainSelect select) {
+        final Map<String, Set<String>> blockedByTable = properties.sql().allowedTables().stream()
+                .filter(schema -> schema.blockedColumns() != null && !schema.blockedColumns().isEmpty())
+                .collect(Collectors.toMap(
+                        schema -> schema.name().toLowerCase(),
+                        schema -> schema.blockedColumns().stream()
+                                .map(String::toLowerCase)
+                                .collect(Collectors.toSet())
+                ));
+
+        if (blockedByTable.isEmpty()) {
+            return;
+        }
+
+        for (final var item : select.getSelectItems()) {
+            if (!(item.getExpression() instanceof Column column)) {
+                continue;
+            }
+            final String colName = column.getColumnName().toLowerCase();
+            final String tableName = column.getTable() != null
+                    ? column.getTable().getName().toLowerCase()
+                    : null;
+
+            if (tableName != null) {
+                final Set<String> blocked = blockedByTable.get(tableName);
+                if (blocked != null && blocked.contains(colName)) {
+                    throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
+                            "조회가 차단된 컬럼입니다: " + tableName + "." + colName);
+                }
+            } else {
+                final boolean isBlockedAnywhere = blockedByTable.values().stream()
+                        .anyMatch(blockedSet -> blockedSet.contains(colName));
+                if (isBlockedAnywhere) {
+                    throw new BusinessException(ZzolBotErrorCode.SQL_COLUMN_BLOCKED,
+                            "조회가 차단된 컬럼입니다: " + colName);
+                }
+            }
+        }
+    }
+
+    // 정규식 치환 대신 JSqlParser AST 조작으로 LIMIT 보정 — 문자열 치환의 부정확성을 방지
+    private String applyLimitIfNeeded(String originalSql, PlainSelect plainSelect) {
+        final int maxRows = properties.sql().maxRows();
+        if (plainSelect.getLimit() == null) {
+            final Limit limit = new Limit();
+            limit.setRowCount(new LongValue(maxRows));
+            plainSelect.setLimit(limit);
+            return plainSelect.toString();
+        }
+        final String limitExpr = plainSelect.getLimit().getRowCount().toString();
+        try {
+            final long currentLimit = Long.parseLong(limitExpr);
+            if (currentLimit > maxRows) {
+                plainSelect.getLimit().setRowCount(new LongValue(maxRows));
+                return plainSelect.toString();
+            }
+        } catch (NumberFormatException ignored) {
+            // 동적 파라미터(?) 등은 그대로 통과
+        }
+        return originalSql;
+    }
+}

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryTool.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SqlQueryTool implements ZzolBotTool {
 
-    static final String TOOL_NAME = "sql_query"; // 같은 패키지 테스트에서 참조
+    static final String TOOL_NAME = "sql_query";
 
     private final SqlQueryValidator validator;
     private final SqlQueryRunner runner;

--- a/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryTool.java
+++ b/backend/src/main/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryTool.java
@@ -1,0 +1,82 @@
+package coffeeshout.global.zzolbot.infra.tool;
+
+import coffeeshout.global.exception.custom.CoffeeShoutException;
+import coffeeshout.global.zzolbot.domain.AskContext;
+import coffeeshout.global.zzolbot.domain.ToolExecutionResult;
+import coffeeshout.global.zzolbot.domain.ZzolBotTool;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryResult;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryRunner;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryValidator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SqlQueryTool implements ZzolBotTool {
+
+    static final String TOOL_NAME = "sql_query"; // 같은 패키지 테스트에서 참조
+
+    private final SqlQueryValidator validator;
+    private final SqlQueryRunner runner;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String name() {
+        return TOOL_NAME;
+    }
+
+    @Override
+    public String description() {
+        return "운영 통계 조회용 read-only SQL 도구. " +
+                "회원·방·미니게임 등 운영 데이터를 집계할 때 사용한다. " +
+                "단일 SELECT 문만 허용되며, LIMIT가 없으면 자동으로 제한된다. " +
+                "와일드카드(*)는 사용할 수 없으며 컬럼을 직접 명시해야 한다.";
+    }
+
+    @Override
+    public Map<String, Object> parameterSchema() {
+        return Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "sql", Map.of(
+                                "type", "string",
+                                "description", "실행할 단일 SELECT SQL. 와일드카드(*) 사용 금지, 컬럼 명시 필수. LIMIT 미포함 시 자동 제한됨."
+                        )
+                ),
+                "required", List.of("sql")
+        );
+    }
+
+    @Override
+    public ToolExecutionResult execute(Map<String, Object> params, AskContext ctx) {
+        if (!(params.get("sql") instanceof String rawSql)) {
+            return ToolExecutionResult.fail(TOOL_NAME, "sql 파라미터가 누락되었거나 올바르지 않습니다.");
+        }
+        try {
+            final String validatedSql = validator.validate(rawSql);
+            final SqlQueryResult result = runner.run(validatedSql);
+            return ToolExecutionResult.ok(TOOL_NAME, serialize(validatedSql, result));
+        } catch (CoffeeShoutException e) {
+            return ToolExecutionResult.fail(TOOL_NAME, e.getMessage());
+        } catch (JsonProcessingException e) {
+            log.warn("[ZzolBot] sql_query 결과 직렬화 실패", e);
+            return ToolExecutionResult.fail(TOOL_NAME, "결과 직렬화에 실패했습니다.");
+        }
+    }
+
+    private String serialize(String executedSql, SqlQueryResult result) throws JsonProcessingException {
+        final Map<String, Object> response = new LinkedHashMap<>();
+        response.put("executedSql", executedSql);
+        response.put("rowCount", result.rows().size());
+        response.put("truncated", result.truncated());
+        response.put("rows", result.rows());
+        return objectMapper.writeValueAsString(response);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -363,3 +363,71 @@ zzol-bot:
   determinism:
     temperature: 0.1
     top-p: 0.1
+  sql:
+    max-rows: 1000
+    query-timeout-seconds: 5
+    allowed-tables:
+      - name: app_user
+        description: "회원 정보 (soft-delete 적용 — 활성 회원 집계 시 deleted_at IS NULL 필터 필요)"
+        columns: [id, user_code, nickname, created_at, deleted_at]
+        blocked-columns: [provider_user_id]
+      - name: oauth_account
+        description: "OAuth 연동 계정 (provider/email 수준만 노출)"
+        columns: [id, user_id, provider, email, linked_at]
+        blocked-columns: [provider_user_id]
+      - name: room_session
+        description: "완료된 방 세션 기록 (방 상태는 Redis, 영속 기록은 이 테이블)"
+        columns: [id, join_code, room_status, created_at, finished_at]
+        blocked-columns: []
+      - name: player
+        description: "방 세션별 플레이어 참여 기록"
+        columns: [id, room_session_id, player_name, player_type, user_id, created_at]
+        blocked-columns: []
+      - name: mini_game_play
+        description: "방 세션 내 미니게임 진행 기록"
+        columns: [id, room_session_id, mini_game_type]
+        blocked-columns: []
+      - name: mini_game_result
+        description: "미니게임 참가자별 결과 (순위, 점수)"
+        columns: [id, mini_game_play_id, player_id, player_rank, score, created_at]
+        blocked-columns: []
+      - name: roulette_result
+        description: "룰렛 당첨자 기록"
+        columns: [id, room_session_id, winner_id, winner_probability, created_at]
+        blocked-columns: []
+      - name: user_stats
+        description: "회원별 게임 통계 (승리 횟수, 생존 연속)"
+        columns: [id, user_id, win_count, survival_streak]
+        blocked-columns: []
+      - name: friendship
+        description: "친구 관계 (PENDING/ACCEPTED)"
+        columns: [id, requester_id, addressee_id, status, created_at, updated_at]
+        blocked-columns: []
+      - name: report
+        description: "신고 내역"
+        columns: [id, category, game_type, join_code, content, created_at]
+        blocked-columns: []
+      - name: outbox_event
+        description: "아웃박스 이벤트 (Redis Stream 발행 재시도용)"
+        columns: [id, status, join_code, created_at]
+        blocked-columns: []
+      - name: patch_note
+        description: "운영자 패치노트"
+        columns: [id, category, title, content, created_at, updated_at]
+        blocked-columns: []
+      - name: nickname_audit
+        description: "플레이어명 AI 검열 결과"
+        columns: [id, nickname, status, confidence, reason, created_at, audited_at]
+        blocked-columns: []
+      - name: nickname_feedback
+        description: "플레이어명 검열에 대한 운영자 피드백"
+        columns: [id, nickname, ai_flagged, ai_confidence, operator_decision, reason, created_at]
+        blocked-columns: []
+      - name: custom_profanity
+        description: "커스텀 비속어 목록"
+        columns: [id, word, source, created_at]
+        blocked-columns: []
+      - name: zzolbot_session
+        description: "ZzolBot 대화 이력 (질문/답변/피드백)"
+        columns: [id, question, answer, feedback, admin_username, created_at]
+        blocked-columns: []

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/ToolExecutorTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/ToolExecutorTest.java
@@ -32,7 +32,8 @@ class ToolExecutorTest {
             new ZzolBotProperties.MonitoringProperties("http://loki", "http://tempo", "http://prometheus", "local"),
             new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
             60,
-            10000L
+            10000L,
+            new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
     );
 
     private static final AskContext CTX = AskContext.stamp("test", List.of(), Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotChatServiceTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotChatServiceTest.java
@@ -50,7 +50,8 @@ class ZzolBotChatServiceTest {
             ),
             new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
             60,
-            10000L
+            10000L,
+            new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
     );
 
     @Mock

--- a/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplateTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/application/ZzolBotPromptTemplateTest.java
@@ -10,6 +10,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ZzolBotPromptTemplateTest {
@@ -26,7 +27,19 @@ class ZzolBotPromptTemplateTest {
             ),
             new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
             60,
-            10000L
+            10000L,
+            new ZzolBotProperties.SqlProperties(
+                    List.of(
+                            new ZzolBotProperties.TableSchema(
+                                    "app_user",
+                                    List.of("id", "nickname", "created_at"),
+                                    List.of("provider_user_id"),
+                                    "회원 정보"
+                            )
+                    ),
+                    100,
+                    3
+            )
     );
 
     private static final AskContext CTX = AskContext.stamp("test", List.of(), Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
@@ -75,5 +88,28 @@ class ZzolBotPromptTemplateTest {
         final String prompt2 = promptTemplate.build(CTX, List.of());
 
         assertThat(prompt1).isEqualTo(prompt2);
+    }
+
+    @Nested
+    class sql_query_도구_스키마_섹션 {
+
+        @Test
+        void sql_query_도구와_허용_테이블_스키마가_포함된다() {
+            final String prompt = promptTemplate.build(CTX, List.of());
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(prompt).contains("sql_query");
+                softly.assertThat(prompt).contains("app_user");
+                softly.assertThat(prompt).contains("id, nickname, created_at");
+                softly.assertThat(prompt).contains("회원 정보");
+            });
+        }
+
+        @Test
+        void joinCode_없는_통계_질문에_sql_query를_사용하라는_행동_원칙이_포함된다() {
+            final String prompt = promptTemplate.build(CTX, List.of());
+
+            assertThat(prompt).contains("통계");
+        }
     }
 }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/GeminiZzolBotClientTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/GeminiZzolBotClientTest.java
@@ -45,7 +45,8 @@ class GeminiZzolBotClientTest {
             ),
             new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
             60,
-            10000L
+            10000L,
+            new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
     );
 
     private static final AskContext CTX = AskContext.stamp("test", List.of(), Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidatorTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/sql/SqlQueryValidatorTest.java
@@ -1,0 +1,289 @@
+package coffeeshout.global.zzolbot.infra.sql;
+
+import static coffeeshout.global.ExceptionAssertions.assertCoffeeShoutException;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.global.zzolbot.config.ZzolBotProperties;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties.SqlProperties;
+import coffeeshout.global.zzolbot.config.ZzolBotProperties.TableSchema;
+import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SqlQueryValidatorTest {
+
+    private static final ZzolBotProperties PROPERTIES = new ZzolBotProperties(
+            "key",
+            "model",
+            8,
+            new ZzolBotProperties.MonitoringProperties("l", "t", "p", "test"),
+            new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
+            60,
+            10000L,
+            new SqlProperties(
+                    List.of(
+                            new TableSchema("app_user",
+                                    List.of("id", "nickname", "created_at", "deleted_at"),
+                                    List.of("provider_user_id", "refresh_token"),
+                                    "회원 정보"),
+                            new TableSchema("room",
+                                    List.of("id", "join_code", "room_state", "created_at"),
+                                    List.of(),
+                                    "방 정보")
+                    ),
+                    100,
+                    3
+            )
+    );
+
+    private SqlQueryValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new SqlQueryValidator(PROPERTIES);
+    }
+
+    @Nested
+    class 유효한_SELECT {
+
+        @Test
+        void 단일_SELECT_문은_검증을_통과한다() {
+            final String sql = "SELECT id, nickname FROM app_user";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).contains("LIMIT");
+        }
+
+        @Test
+        void LIMIT_없으면_maxRows로_자동_추가된다() {
+            final String sql = "SELECT id FROM app_user";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).endsWith("LIMIT 100");
+        }
+
+        @Test
+        void LIMIT이_maxRows_이하면_그대로_유지된다() {
+            final String sql = "SELECT id FROM app_user LIMIT 10";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).contains("LIMIT 10");
+        }
+
+        @Test
+        void LIMIT이_maxRows_초과하면_maxRows로_치환된다() {
+            final String sql = "SELECT id FROM app_user LIMIT 9999";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).contains("LIMIT 100");
+            assertThat(result).doesNotContain("9999");
+        }
+
+        @Test
+        void GROUP_BY와_집계함수를_포함한_쿼리가_통과한다() {
+            final String sql = "SELECT room_state, COUNT(id) FROM room GROUP BY room_state LIMIT 50";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result.toLowerCase()).contains("limit 50");
+        }
+
+        @Test
+        void JOIN을_포함한_허용_테이블_쿼리가_통과한다() {
+            final String sql = "SELECT u.id, u.nickname, r.join_code "
+                    + "FROM app_user u JOIN room r ON u.id = r.id LIMIT 20";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        void 끝에_세미콜론이_있어도_LIMIT이_올바르게_추가된다() {
+            final String sql = "SELECT id FROM app_user;";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).contains("LIMIT 100");
+        }
+    }
+
+    @Nested
+    class DDL_DML_거부 {
+
+        @Test
+        void INSERT_문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("INSERT INTO app_user (nickname) VALUES ('test')"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void UPDATE_문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("UPDATE app_user SET nickname = 'x' WHERE id = 1"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void DELETE_문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("DELETE FROM app_user WHERE id = 1"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void DROP_TABLE_문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("DROP TABLE app_user"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void TRUNCATE_문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("TRUNCATE TABLE app_user"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+    }
+
+    @Nested
+    class stacked_statement_거부 {
+
+        @Test
+        void 세미콜론으로_구분된_복수_구문은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id FROM app_user; DROP TABLE app_user"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void SELECT_두개를_나란히_넣으면_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id FROM app_user; SELECT id FROM room"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+    }
+
+    @Nested
+    class 허용되지_않은_테이블 {
+
+        @Test
+        void 화이트리스트에_없는_테이블은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id FROM oauth_account LIMIT 10"),
+                    ZzolBotErrorCode.SQL_TABLE_NOT_ALLOWED
+            );
+        }
+
+        @Test
+        void friendship_테이블은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id FROM friendship LIMIT 10"),
+                    ZzolBotErrorCode.SQL_TABLE_NOT_ALLOWED
+            );
+        }
+    }
+
+    @Nested
+    class 와일드카드_거부 {
+
+        @Test
+        void SELECT_전체_와일드카드는_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT * FROM app_user LIMIT 10"),
+                    ZzolBotErrorCode.SQL_WILDCARD_NOT_ALLOWED
+            );
+        }
+
+        @Test
+        void 테이블_별칭_와일드카드도_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT u.* FROM app_user u LIMIT 10"),
+                    ZzolBotErrorCode.SQL_WILDCARD_NOT_ALLOWED
+            );
+        }
+    }
+
+    @Nested
+    class PII_컬럼_차단 {
+
+        @Test
+        void app_user의_provider_user_id는_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id, provider_user_id FROM app_user LIMIT 10"),
+                    ZzolBotErrorCode.SQL_COLUMN_BLOCKED
+            );
+        }
+
+        @Test
+        void app_user의_refresh_token은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id, refresh_token FROM app_user LIMIT 10"),
+                    ZzolBotErrorCode.SQL_COLUMN_BLOCKED
+            );
+        }
+
+        @Test
+        void 테이블_명시_없이_blocked_컬럼_사용해도_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT provider_user_id FROM app_user LIMIT 10"),
+                    ZzolBotErrorCode.SQL_COLUMN_BLOCKED
+            );
+        }
+
+        @Test
+        void 허용된_컬럼만_사용하면_통과한다() {
+            final String sql = "SELECT id, nickname, created_at FROM app_user LIMIT 10";
+
+            final String result = validator.validate(sql);
+
+            assertThat(result).isNotNull();
+        }
+    }
+
+    @Nested
+    class SELECT_INTO_와_FOR_UPDATE_거부 {
+
+        @Test
+        void FOR_UPDATE는_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELECT id FROM app_user FOR UPDATE"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+    }
+
+    @Nested
+    class SQL_파싱_실패 {
+
+        @Test
+        void 문법_오류_SQL은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate("SELEKT id FORM app_user"),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+
+        @Test
+        void 빈_문자열은_거부된다() {
+            assertCoffeeShoutException(
+                    () -> validator.validate(""),
+                    ZzolBotErrorCode.INVALID_SQL
+            );
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
@@ -41,7 +41,8 @@ class LokiQueryToolTest {
                 ),
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
-                10000L
+                10000L,
+                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
         );
         return new LokiQueryTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/LokiQueryToolTest.java
@@ -42,7 +42,7 @@ class LokiQueryToolTest {
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
                 10000L,
-                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
+                new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
         );
         return new LokiQueryTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/PrometheusQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/PrometheusQueryToolTest.java
@@ -41,7 +41,8 @@ class PrometheusQueryToolTest {
                 ),
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
-                10000L
+                10000L,
+                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
         );
         return new PrometheusQueryTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/PrometheusQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/PrometheusQueryToolTest.java
@@ -42,7 +42,7 @@ class PrometheusQueryToolTest {
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
                 10000L,
-                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
+                new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
         );
         return new PrometheusQueryTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryToolTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 
 import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.exception.custom.InfrastructureException;
 import coffeeshout.global.zzolbot.domain.AskContext;
 import coffeeshout.global.zzolbot.domain.ToolExecutionResult;
 import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
@@ -110,7 +111,7 @@ class SqlQueryToolTest {
         @Test
         void 실행_중_예외가_발생하면_실패_결과를_반환한다() {
             given(validator.validate(any())).willReturn("SELECT id FROM app_user LIMIT 100");
-            willThrow(new BusinessException(ZzolBotErrorCode.SQL_EXECUTION_FAILED, "타임아웃"))
+            willThrow(new InfrastructureException(ZzolBotErrorCode.SQL_EXECUTION_FAILED, "타임아웃"))
                     .given(runner).run(any());
 
             final ToolExecutionResult result = tool.execute(Map.of("sql", "SELECT id FROM app_user"), CTX);

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/SqlQueryToolTest.java
@@ -1,0 +1,148 @@
+package coffeeshout.global.zzolbot.infra.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.zzolbot.domain.AskContext;
+import coffeeshout.global.zzolbot.domain.ToolExecutionResult;
+import coffeeshout.global.zzolbot.domain.ZzolBotErrorCode;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryResult;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryRunner;
+import coffeeshout.global.zzolbot.infra.sql.SqlQueryValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SqlQueryToolTest {
+
+    private static final AskContext CTX = AskContext.stamp("req-1", List.of(),
+            Clock.fixed(Instant.EPOCH, ZoneOffset.UTC));
+
+    @Mock
+    private SqlQueryValidator validator;
+
+    @Mock
+    private SqlQueryRunner runner;
+
+    private SqlQueryTool tool;
+
+    @BeforeEach
+    void setUp() {
+        tool = new SqlQueryTool(validator, runner, new ObjectMapper());
+    }
+
+    @Nested
+    class execute_메서드 {
+
+        @Test
+        void 유효한_SQL이면_실행_결과와_메타를_JSON으로_반환한다() {
+            final String rawSql = "SELECT id FROM app_user";
+            final String validSql = rawSql + " LIMIT 100";
+            given(validator.validate(rawSql)).willReturn(validSql);
+            given(runner.run(validSql)).willReturn(
+                    new SqlQueryResult(List.of(Map.of("id", 1L), Map.of("id", 2L)), false));
+
+            final ToolExecutionResult result = tool.execute(Map.of("sql", rawSql), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isTrue();
+                softly.assertThat(result.toolName()).isEqualTo(SqlQueryTool.TOOL_NAME);
+                softly.assertThat(result.content()).contains("rowCount");
+                softly.assertThat(result.content()).contains("executedSql");
+                softly.assertThat(result.content()).contains("rows");
+            });
+        }
+
+        @Test
+        void 결과가_잘린_경우_truncated_true를_포함한다() {
+            given(validator.validate(any())).willReturn("SELECT id FROM app_user LIMIT 100");
+            given(runner.run(any())).willReturn(new SqlQueryResult(List.of(), true));
+
+            final ToolExecutionResult result = tool.execute(Map.of("sql", "SELECT id FROM app_user"), CTX);
+
+            assertThat(result.content()).contains("\"truncated\":true");
+        }
+
+        @Test
+        void sql_파라미터가_누락되면_실패_결과를_반환한다() {
+            final ToolExecutionResult result = tool.execute(Map.of(), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isFalse();
+                softly.assertThat(result.toolName()).isEqualTo(SqlQueryTool.TOOL_NAME);
+            });
+        }
+
+        @Test
+        void sql_파라미터가_문자열이_아니면_실패_결과를_반환한다() {
+            final ToolExecutionResult result = tool.execute(Map.of("sql", 123), CTX);
+
+            assertThat(result.success()).isFalse();
+        }
+
+        @Test
+        void 검증_실패하면_실패_결과를_반환한다() {
+            willThrow(new BusinessException(ZzolBotErrorCode.INVALID_SQL, "SELECT 문만 허용됩니다."))
+                    .given(validator).validate(any());
+
+            final ToolExecutionResult result = tool.execute(Map.of("sql", "DROP TABLE app_user"), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isFalse();
+                softly.assertThat(result.content()).contains("SELECT 문만 허용됩니다.");
+            });
+        }
+
+        @Test
+        void 실행_중_예외가_발생하면_실패_결과를_반환한다() {
+            given(validator.validate(any())).willReturn("SELECT id FROM app_user LIMIT 100");
+            willThrow(new BusinessException(ZzolBotErrorCode.SQL_EXECUTION_FAILED, "타임아웃"))
+                    .given(runner).run(any());
+
+            final ToolExecutionResult result = tool.execute(Map.of("sql", "SELECT id FROM app_user"), CTX);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.success()).isFalse();
+                softly.assertThat(result.content()).contains("타임아웃");
+            });
+        }
+    }
+
+    @Nested
+    class 메타데이터 {
+
+        @Test
+        void 도구명이_sql_query다() {
+            assertThat(tool.name()).isEqualTo("sql_query");
+        }
+
+        @Test
+        void description이_비어있지_않다() {
+            assertThat(tool.description()).isNotBlank();
+        }
+
+        @Test
+        void parameterSchema에_sql_필드가_required로_포함된다() {
+            final Map<String, Object> schema = tool.parameterSchema();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(schema).containsKey("properties");
+                softly.assertThat(schema.get("required").toString()).contains("sql");
+            });
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
@@ -42,7 +42,7 @@ class TempoTraceToolTest {
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
                 10000L,
-                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
+                new ZzolBotProperties.SqlProperties(List.of(), 100, 3)
         );
         return new TempoTraceTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
+++ b/backend/src/test/java/coffeeshout/global/zzolbot/infra/tool/TempoTraceToolTest.java
@@ -41,7 +41,8 @@ class TempoTraceToolTest {
                 ),
                 new ZzolBotProperties.DeterminismProperties(0.1, 0.1),
                 60,
-                10000L
+                10000L,
+                new ZzolBotProperties.SqlProperties(java.util.List.of(), 100, 3)
         );
         return new TempoTraceTool(props, RestClient.builder(), new ObjectMapper());
     }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -160,3 +160,42 @@ security:
 
 roulette:
   default-adjustment-weight: 0.7
+
+zzol-bot:
+  gemini-api-key: test-key
+  model: gemini-test
+  max-loop-iterations: 3
+  default-window-minutes: 60
+  tool-timeout-millis: 5000
+  monitoring:
+    loki-url: http://loki:3100
+    tempo-url: http://tempo:3200
+    prometheus-url: http://prometheus:9090
+    environment: test
+  determinism:
+    temperature: 0.1
+    top-p: 0.1
+  sql:
+    max-rows: 100
+    query-timeout-seconds: 3
+    allowed-tables:
+      - name: app_user
+        description: "회원 정보"
+        columns: [id, user_code, nickname, created_at, deleted_at]
+        blocked-columns: [provider_user_id]
+      - name: room_session
+        description: "완료된 방 세션 기록"
+        columns: [id, join_code, room_status, created_at, finished_at]
+        blocked-columns: []
+      - name: mini_game_result
+        description: "미니게임 결과"
+        columns: [id, mini_game_play_id, player_id, player_rank, score, created_at]
+        blocked-columns: []
+      - name: outbox_event
+        description: "아웃박스 이벤트"
+        columns: [id, status, join_code, created_at]
+        blocked-columns: []
+
+friend:
+  presence:
+    grace-period-seconds: 1


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1245

# 🚀 작업 내용

> "현재 회원가입한 유저 수를 알려줘" 를 물어보고 싶었어요.

1. sql_query ZzolBotTool 추가 — LLM이 자연어 통계 질문에 대해 직접 SELECT 쿼리를 작성·실행해 답할 수 있음
2. 시스템 프롬프트 확장 — "방 진단 전용" → "방 진단 + 운영 통계 조회" 이중모드 지원 (joinCode 유무로 분기)
3. 보안 다층 방어:
    - JSqlParser AST 파싱으로 단일 SELECT만 허용 (DDL·DML·stacked statement거부)
    - 테이블 화이트리스트 + 컬럼 블랙리스트 (provider_user_id 등 PII 차단)
    - LIMIT 자동 강제 (미포함 시 maxRows 삽입), JDBC 쿼리 타임아웃
    - Read-only 트랜잭션 격리
5. ZzolBotProperties.SqlProperties — 허용 테이블·maxRows·타임아웃 전부 YAML 외부화

# 💬 리뷰 중점사항
- SqlQueryValidator — JSqlParser 5.0 AST 조작으로 LIMIT 보정하는 방식이 적절한지
- sql_query 허용 테이블 목록이 운영 목적에 맞게 설정됐는지 (application.yml zzol-bot.sql.allowed-tables)
- SQL_EXECUTION_FAILED를 InfrastructureException으로 분류한 것이 맞는지
