### PR TITLE
[fix] 최소 확률 당첨 조회에 닉네임 및 유저코드 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/dashboard/application/DashboardService.java
+++ b/backend/src/main/java/coffeeshout/dashboard/application/DashboardService.java
@@ -36,7 +36,7 @@ public class DashboardService {
         final LocalDateTime endOfMonth = getEndOfMonth();
 
         return dashboardStatisticsRepository.findLowestProbabilityWinner(startOfMonth, endOfMonth, TOP_PLAYER_LIMIT)
-                .orElse(null);
+                .orElse(LowestProbabilityWinnerResponse.empty());
     }
 
     public List<GamePlayCountResponse> getGamePlayCounts() {

--- a/backend/src/main/java/coffeeshout/dashboard/domain/LowestProbabilityWinnerResponse.java
+++ b/backend/src/main/java/coffeeshout/dashboard/domain/LowestProbabilityWinnerResponse.java
@@ -4,12 +4,19 @@ import java.util.List;
 
 public record LowestProbabilityWinnerResponse(
         Double probability,
-        List<String> playerNames
+        List<PlayerInfo> players
 ) {
-    public static LowestProbabilityWinnerResponse of(Integer dbProbability, List<String> playerNames) {
+    public record PlayerInfo(String nickname, String userCode) {
+    }
+
+    public static LowestProbabilityWinnerResponse of(Integer dbProbability, List<PlayerInfo> players) {
         return new LowestProbabilityWinnerResponse(
                 dbProbability / 100.0,
-                playerNames
+                players
         );
+    }
+
+    public static LowestProbabilityWinnerResponse empty() {
+        return new LowestProbabilityWinnerResponse(0.0, List.of());
     }
 }

--- a/backend/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
+++ b/backend/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
@@ -80,7 +80,8 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
         final List<Tuple> results = queryFactory
                 .select(
                         ROULETTE_RESULT.winnerProbability,
-                        PLAYER.playerName
+                        USER.nickname,
+                        USER.userCode
                 )
                 .from(ROULETTE_RESULT)
                 .join(ROULETTE_RESULT.winner, PLAYER)
@@ -90,15 +91,18 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                         ROULETTE_RESULT.winnerProbability.eq(minProbability)
                 )
                 .distinct()
-                .orderBy(PLAYER.playerName.asc())
+                .orderBy(USER.nickname.asc())
                 .limit(limit)
                 .fetch();
 
-        final List<String> nicknames = results.stream()
-                .map(tuple -> tuple.get(PLAYER.playerName))
+        final List<LowestProbabilityWinnerResponse.PlayerInfo> players = results.stream()
+                .map(tuple -> new LowestProbabilityWinnerResponse.PlayerInfo(
+                        tuple.get(USER.nickname),
+                        tuple.get(USER.userCode)
+                ))
                 .toList();
 
-        return Optional.of(LowestProbabilityWinnerResponse.of(minProbability, nicknames));
+        return Optional.of(LowestProbabilityWinnerResponse.of(minProbability, players));
     }
 
     @Override

--- a/backend/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
+++ b/backend/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
@@ -190,7 +190,7 @@ class DashboardServiceTest extends ServiceTest {
     class GetLowestProbabilityWinnerTest {
 
         @Test
-        void 이번달_최소_확률로_당첨된_로그인_사용자_닉네임을_조회한다() {
+        void 이번달_최소_확률로_당첨된_로그인_사용자_닉네임과_유저코드를_조회한다() {
             // given
             final RoomEntity room = roomJpaRepository.save(new RoomEntity("DDDD"));
 
@@ -216,8 +216,12 @@ class DashboardServiceTest extends ServiceTest {
             final LowestProbabilityWinnerResponse result = dashboardService.getLowestProbabilityWinner();
 
             // then
-            assertThat(result.probability()).isEqualTo(0.05);
-            assertThat(result.playerNames()).containsExactly("민수");
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.probability()).isEqualTo(0.05);
+                softly.assertThat(result.players()).hasSize(1);
+                softly.assertThat(result.players().getFirst().nickname()).isEqualTo("민수");
+                softly.assertThat(result.players().getFirst().userCode()).isEqualTo("GH7KL");
+            });
         }
 
         @Test
@@ -248,7 +252,9 @@ class DashboardServiceTest extends ServiceTest {
 
             // then
             assertThat(result.probability()).isEqualTo(0.03);
-            assertThat(result.playerNames()).containsExactlyInAnyOrder("영희", "민수");
+            assertThat(result.players())
+                    .extracting(LowestProbabilityWinnerResponse.PlayerInfo::nickname)
+                    .containsExactlyInAnyOrder("영희", "민수");
         }
 
         @Test
@@ -270,7 +276,7 @@ class DashboardServiceTest extends ServiceTest {
 
             // then
             assertThat(result.probability()).isEqualTo(0.01);
-            assertThat(result.playerNames()).hasSize(5);
+            assertThat(result.players()).hasSize(5);
         }
 
         @Test
@@ -302,7 +308,9 @@ class DashboardServiceTest extends ServiceTest {
 
             // then
             assertThat(result.probability()).isEqualTo(0.03);
-            assertThat(result.playerNames()).containsExactly("민수");
+            assertThat(result.players())
+                    .extracting(LowestProbabilityWinnerResponse.PlayerInfo::nickname)
+                    .containsExactly("민수");
         }
 
         @Test
@@ -327,17 +335,22 @@ class DashboardServiceTest extends ServiceTest {
             // then: 게스트(확률 1)는 제외되고, 로그인 사용자(확률 30)만 집계됨
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.probability()).isEqualTo(0.30);
-                softly.assertThat(result.playerNames()).containsExactly("철수");
+                softly.assertThat(result.players())
+                        .extracting(LowestProbabilityWinnerResponse.PlayerInfo::nickname)
+                        .containsExactly("철수");
             });
         }
 
         @Test
-        void 이번달_당첨_기록이_없으면_null을_반환한다() {
+        void 이번달_당첨_기록이_없으면_빈_구조체를_반환한다() {
             // when
             final LowestProbabilityWinnerResponse result = dashboardService.getLowestProbabilityWinner();
 
             // then
-            assertThat(result).isNull();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.probability()).isEqualTo(0.0);
+                softly.assertThat(result.players()).isEmpty();
+            });
         }
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1248

# 🚀 작업 내용

- PlayerInfo 클래스 추가로 사용자 닉네임 및 유저코드 관리
- 최소 확률 당첨 조회 시 PlayerInfo 활용으로 데이터 구조 개선
- 게스트 플레이어 제외 처리 및 빈 응답 반환 로직 추가
- 관련 서비스 및 테스트 코드 수정으로 신뢰성과 유지보수성 강화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 최저 확률 우승자가 없을 때 null 대신 빈 응답을 반환하도록 개선

* **New Features**
  * 우승자 정보에 사용자 코드가 추가되어 더 상세한 플레이어 데이터 제공
  * 우승자 목록이 닉네임 순서로 정렬되어 일관된 순서 보장

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-zzol/pull/1249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->