### PR TITLE
[hotfix] STOMP 인증 로직 분기 추가

### DIFF
--- a/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptor.java
@@ -2,9 +2,11 @@ package coffeeshout.global.websocket.interceptor;
 
 import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.global.websocket.PlayerKey;
+import coffeeshout.global.websocket.UserPrincipal;
 import coffeeshout.global.websocket.auth.RoomSessionClaim;
-import coffeeshout.global.websocket.auth.RoomSessionTokenErrorCode;
 import coffeeshout.global.websocket.auth.RoomSessionTokenService;
+import coffeeshout.user.application.service.AuthTokenService;
+import coffeeshout.user.domain.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -20,7 +22,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompPrincipalInterceptor implements ChannelInterceptor {
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
     private final RoomSessionTokenService roomSessionTokenService;
+    private final AuthTokenService authTokenService;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -31,16 +36,34 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
         }
 
         final String roomToken = accessor.getFirstNativeHeader("roomToken");
-        if (roomToken == null) {
-            throw new BusinessException(RoomSessionTokenErrorCode.ROOM_TOKEN_MISSING, "roomToken 헤더가 없습니다.");
+        if (roomToken != null) {
+            final RoomSessionClaim claim = roomSessionTokenService.verify(roomToken);
+            final String userName = PlayerKey.of(claim.joinCode(), claim.playerName()).toString();
+            accessor.setUser(() -> userName);
+            log.debug("STOMP Room Principal 설정: {}", userName);
+            return message;
         }
 
-        final RoomSessionClaim claim = roomSessionTokenService.verify(roomToken);
-        final String userName = PlayerKey.of(claim.joinCode(), claim.playerName()).toString();
-
+        final String userName = resolveUserPrincipal(accessor);
         accessor.setUser(() -> userName);
-        log.debug("STOMP Principal 설정: {}", userName);
-
+        log.debug("STOMP User Principal 설정: {}", userName);
         return message;
+    }
+
+    private String resolveUserPrincipal(StompHeaderAccessor accessor) {
+        final String authorization = accessor.getFirstNativeHeader("Authorization");
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            log.warn("STOMP CONNECT 헤더 누락으로 sessionId를 Principal로 사용: sessionId={}", accessor.getSessionId());
+            return accessor.getSessionId();
+        }
+        final String token = authorization.substring(BEARER_PREFIX.length());
+        try {
+            final AuthenticatedUser user = authTokenService.verify(token);
+            log.debug("STOMP 사용자 인증 성공: userId={}", user.userId());
+            return UserPrincipal.of(user.userId());
+        } catch (BusinessException e) {
+            log.warn("STOMP Access Token 검증 실패: {}", e.getMessage());
+            return accessor.getSessionId();
+        }
     }
 }

--- a/backend/src/test/java/coffeeshout/fixture/WebSocketIntegrationTestSupport.java
+++ b/backend/src/test/java/coffeeshout/fixture/WebSocketIntegrationTestSupport.java
@@ -79,6 +79,18 @@ public abstract class WebSocketIntegrationTestSupport extends IntegrationTestSup
 
     protected TestStompSession createSessionWithoutRoomToken()
             throws InterruptedException, ExecutionException, TimeoutException {
+        return createSessionWithConnectHeaders(new StompHeaders());
+    }
+
+    protected TestStompSession createSessionWithAuthorizationToken(String accessToken)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        final StompHeaders headers = new StompHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        return createSessionWithConnectHeaders(headers);
+    }
+
+    private TestStompSession createSessionWithConnectHeaders(StompHeaders connectHeaders)
+            throws InterruptedException, ExecutionException, TimeoutException {
         final SockJsClient sockJsClient = new SockJsClient(List.of(
                 new WebSocketTransport(new StandardWebSocketClient())
         ));
@@ -87,15 +99,23 @@ public abstract class WebSocketIntegrationTestSupport extends IntegrationTestSup
         messageConverter.setStrictContentTypeMatch(false);
         stompClient.setMessageConverter(messageConverter);
 
+        final String[] principalHolder = new String[1];
         final StompSession session = stompClient
                 .connectAsync(
                         String.format(WEBSOCKET_BASE_URL_FORMAT, port),
                         new WebSocketHttpHeaders(),
-                        new StompHeaders(),
-                        new StompSessionHandlerAdapter() {}
+                        connectHeaders,
+                        new StompSessionHandlerAdapter() {
+                            @Override
+                            public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+                                principalHolder[0] = connectedHeaders.getFirst("user-name");
+                            }
+                        }
                 )
                 .get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        return new TestStompSession(session, objectMapper);
+        final TestStompSession testSession = new TestStompSession(session, objectMapper);
+        testSession.setPrincipalName(principalHolder[0]);
+        return testSession;
     }
 
     protected TestStompSession createSessionWithRoomToken(String roomToken)

--- a/backend/src/test/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptorTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/interceptor/StompPrincipalInterceptorTest.java
@@ -1,9 +1,16 @@
 package coffeeshout.global.websocket.interceptor;
 
 import coffeeshout.fixture.TestStompSession;
+import coffeeshout.fixture.UserFixture;
 import coffeeshout.fixture.WebSocketIntegrationTestSupport;
+import coffeeshout.global.websocket.UserPrincipal;
+import coffeeshout.user.application.service.AuthTokenService;
+import coffeeshout.user.domain.TokenPair;
+import coffeeshout.user.domain.User;
+import coffeeshout.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,6 +19,12 @@ import java.util.concurrent.ExecutionException;
 import org.springframework.messaging.simp.stomp.ConnectionLostException;
 
 class StompPrincipalInterceptorTest extends WebSocketIntegrationTestSupport {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthTokenService authTokenService;
 
     @Nested
     class 유효한_roomToken_헤더 {
@@ -31,17 +44,46 @@ class StompPrincipalInterceptorTest extends WebSocketIntegrationTestSupport {
     class 유효하지_않은_roomToken_헤더 {
 
         @Test
-        void roomToken_헤더가_없으면_연결이_거부된다() {
-            assertThatThrownBy(() -> createSessionWithoutRoomToken())
-                    .isInstanceOf(ExecutionException.class)
-                    .hasCauseInstanceOf(ConnectionLostException.class);
-        }
-
-        @Test
         void 위조된_토큰으로_연결하면_거부된다() {
             assertThatThrownBy(() -> createSessionWithRoomToken("invalid.token.value"))
                     .isInstanceOf(ExecutionException.class)
                     .hasCauseInstanceOf(ConnectionLostException.class);
+        }
+    }
+
+    @Nested
+    class Authorization_Bearer_헤더 {
+
+        @Test
+        void 유효한_액세스_토큰으로_연결하면_user_principal로_성공한다() throws Exception {
+            final User user = userRepository.save(UserFixture.회원_엠제이());
+            final TokenPair tokens = authTokenService.issue(user);
+
+            final TestStompSession session = createSessionWithAuthorizationToken(tokens.accessToken());
+
+            assertThat(session.isConnected()).isTrue();
+            assertThat(session.getPrincipalName()).isEqualTo(UserPrincipal.of(user.getId()));
+
+            session.disconnect();
+        }
+
+        @Test
+        void 유효하지_않은_액세스_토큰이면_sessionId로_연결된다() throws Exception {
+            final TestStompSession session = createSessionWithAuthorizationToken("invalid.token");
+
+            assertThat(session.isConnected()).isTrue();
+            assertThat(session.getPrincipalName()).isNotNull();
+
+            session.disconnect();
+        }
+
+        @Test
+        void Authorization_헤더_없으면_sessionId로_연결된다() throws Exception {
+            final TestStompSession session = createSessionWithoutRoomToken();
+
+            assertThat(session.isConnected()).isTrue();
+
+            session.disconnect();
         }
     }
 }

--- a/backend/src/test/java/coffeeshout/websocket/WebSocketConnectionTest.java
+++ b/backend/src/test/java/coffeeshout/websocket/WebSocketConnectionTest.java
@@ -21,8 +21,8 @@ class WebSocketConnectionTest extends WebSocketIntegrationTestSupport {
     }
 
     @Test
-    void RST_없이_연결하면_연결이_거부된다() {
-        assertThatThrownBy(() -> createSessionWithoutRoomToken())
+    void 위조된_RST로_연결하면_거부된다() {
+        assertThatThrownBy(() -> createSessionWithRoomToken("invalid.token.value"))
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(ConnectionLostException.class);
     }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용

- RoomToken 및 Authorization 헤더 기반으로 STOMP 사용자 인증 로직 개선
- 권한이 없는 경우 sessionId를 기본 Principal로 사용하도록 처리
- AuthTokenService 의존성 추가 및 UserPrincipal 변환 로직 구현
- WebSocket 통합 테스트에 Authorization 헤더 적용 테스트 케이스 추가
- TestStompSession 생성 유틸리티 메서드 확장 (roomToken 및 Authorization 지원)

# 💬 리뷰 중점사항

중점사항
