### PR TITLE
[feat] 내 정보·더보기·친구 탭 프로필 UI 개선

### DIFF
--- a/frontend/src/components/icons/CopyIcon.tsx
+++ b/frontend/src/components/icons/CopyIcon.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  size?: number;
+};
+
+const CopyIcon = ({ size = 12 }: Props) => (
+  <svg viewBox="0 0 13 13" fill="none" width={size} height={size} aria-hidden="true">
+    <rect
+      x="3.5"
+      y="0.65"
+      width="8.85"
+      height="8.85"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.3"
+    />
+    <rect
+      x="0.65"
+      y="3.5"
+      width="8.85"
+      height="8.85"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.3"
+    />
+  </svg>
+);
+
+export default CopyIcon;

--- a/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
+++ b/frontend/src/features/home/components/FriendsTab/FriendsTab.tsx
@@ -5,6 +5,7 @@ import { useFriends } from '@/features/friends/hooks/useFriends';
 import useToast from '@/components/@common/Toast/useToast';
 import { useFriendSearch } from '@/features/home/hooks/useFriendSearch';
 import { theme } from '@/styles/theme';
+import CopyIcon from '@/components/icons/CopyIcon';
 import FriendsList from './FriendsList';
 import LoginRequiredView from './LoginRequiredView';
 import ReceivedRequestsList from './ReceivedRequestsList';
@@ -54,14 +55,17 @@ const FriendsTab = () => {
       </S.Header>
 
       {user && (
-        <S.MyCodeCard>
-          <S.MyCodeLabel>내 친구 코드</S.MyCodeLabel>
-          <S.MyCodeRow>
-            <S.MyCode># {user.userCode}</S.MyCode>
-            <S.MyCodeCopy type="button" onClick={handleCopyCode}>
-              복사
-            </S.MyCodeCopy>
-          </S.MyCodeRow>
+        <S.MyCodeCard type="button" onClick={handleCopyCode} aria-label="친구 코드 복사">
+          <S.MyCodeHeader>
+            <S.MyCodeLabel>내 친구 코드</S.MyCodeLabel>
+            <S.MyCodeCopyIcon>
+              <CopyIcon size={14} />
+            </S.MyCodeCopyIcon>
+          </S.MyCodeHeader>
+          <S.MyCodeBody>
+            <S.MyNickname>{user.nickname}</S.MyNickname>
+            <S.MyCode>#{user.userCode}</S.MyCode>
+          </S.MyCodeBody>
         </S.MyCodeCard>
       )}
 
@@ -130,51 +134,66 @@ const S = {
     letter-spacing: -0.02em;
   `,
 
-  MyCodeCard: styled.div`
+  MyCodeCard: styled.button`
     margin: 0 16px 4px;
-    padding: 14px 16px;
+    width: calc(100% - 32px);
+    padding: 16px 18px;
     background: ${theme.color.point[50]};
-    border: 1px solid ${theme.color.point[100]};
-    border-radius: 14px;
+    border: 1.5px solid ${theme.color.point[100]};
+    border-radius: 18px;
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s;
+
+    &:active {
+      background: ${theme.color.point[100]};
+    }
   `,
 
-  MyCodeLabel: styled.span`
-    font-size: 11px;
-    font-weight: 600;
-    color: ${theme.color.point[400]};
-    letter-spacing: 0.02em;
-  `,
-
-  MyCodeRow: styled.div`
+  MyCodeHeader: styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
   `,
 
-  MyCode: styled.span`
-    font-size: 18px;
-    font-weight: 800;
-    color: ${theme.color.gray[900]};
-    letter-spacing: 0.06em;
+  MyCodeLabel: styled.span`
+    font-size: ${theme.typography.caption.fontSize};
+    font-weight: ${theme.typography.h4.fontWeight};
+    color: ${theme.color.point[300]};
+    letter-spacing: 0.02em;
   `,
 
-  MyCodeCopy: styled.button`
-    padding: 4px 12px;
-    border: 1.5px solid ${theme.color.point[300]};
-    border-radius: 8px;
-    background: ${theme.color.white};
-    color: ${theme.color.point[500]};
-    font-size: 12px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: background 0.12s;
+  MyCodeCopyIcon: styled.span`
+    display: flex;
+    align-items: center;
+    color: ${theme.color.point[300]};
 
-    &:active {
-      background: ${theme.color.point[50]};
+    svg rect:last-of-type {
+      fill: ${theme.color.point[50]};
     }
+  `,
+
+  MyCodeBody: styled.div`
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    flex-wrap: wrap;
+  `,
+
+  MyNickname: styled.span`
+    font-size: ${theme.typography.h2.fontSize};
+    font-weight: ${theme.typography.h2.fontWeight};
+    color: ${theme.color.gray[900]};
+  `,
+
+  MyCode: styled.span`
+    font-size: ${theme.typography.paragraph.fontSize};
+    font-weight: ${theme.typography.h4.fontWeight};
+    color: ${theme.color.gray[500]};
+    letter-spacing: 0.08em;
   `,
 
   SearchArea: styled.div`

--- a/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
@@ -28,16 +28,14 @@ export const ProfileInfo = styled.div`
 `;
 
 export const WelcomeMessage = styled.span`
-  font-size: 17px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.h3}
   color: ${({ theme }) => theme.color.white};
   letter-spacing: -0.02em;
 `;
 
 export const UserStatus = styled.span`
-  font-size: 12px;
-  font-weight: 400;
-  color: rgba(255, 255, 255, 0.72);
+  ${({ theme }) => theme.typography.caption}
+  color: ${({ theme }) => theme.color.white}B8;
 `;
 
 export const StatGrid = styled.div`
@@ -58,8 +56,8 @@ export const StatCard = styled.div`
 `;
 
 export const StatLabel = styled.span`
-  font-size: 12px;
-  font-weight: 500;
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-weight: ${({ theme }) => theme.typography.paragraph.fontWeight};
   color: ${({ theme }) => theme.color.gray[400]};
   letter-spacing: -0.01em;
 `;
@@ -71,16 +69,14 @@ export const StatValueRow = styled.div`
 `;
 
 export const StatNumber = styled.span`
-  font-size: 30px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h1}
   color: ${({ theme }) => theme.color.gray[900]};
   letter-spacing: -0.04em;
   line-height: 1;
 `;
 
 export const StatUnit = styled.span`
-  font-size: 14px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.gray[500]};
   letter-spacing: -0.02em;
 `;
@@ -93,8 +89,8 @@ export const InfoSection = styled.div`
 `;
 
 export const SectionTitle = styled.h4`
-  font-size: 11px;
-  font-weight: 600;
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
   color: ${({ theme }) => theme.color.gray[400]};
   padding-left: 4px;
   letter-spacing: 0.06em;
@@ -110,7 +106,7 @@ export const TooltipCard = styled.div`
 `;
 
 export const TooltipList = styled.ul`
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.typography.small.fontSize};
   color: ${({ theme }) => theme.color.gray[500]};
   line-height: 1.7;
   list-style: none;
@@ -150,13 +146,13 @@ export const DangerRow = styled.button`
 `;
 
 export const DangerLabel = styled.span`
-  font-size: 13px;
-  font-weight: 600;
+  font-size: ${({ theme }) => theme.typography.small.fontSize};
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
   color: ${({ theme }) => theme.color.point[500]};
 `;
 
 export const DangerIcon = styled.span`
-  font-size: 16px;
+  font-size: ${({ theme }) => theme.typography.paragraph.fontSize};
   font-weight: 300;
   color: ${({ theme }) => theme.color.point[200]};
 `;

--- a/frontend/src/features/home/components/MenuTab/views/MyInfoView.tsx
+++ b/frontend/src/features/home/components/MenuTab/views/MyInfoView.tsx
@@ -9,7 +9,9 @@ import * as S from './MyInfoView.styled';
 const MyInfoView = () => {
   const { myName } = useIdentifier();
   const { winCount, streak } = useMyStats();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
+
+  const displayName = user?.nickname?.trim() || myName || '익명의 사용자';
   const { openModal } = useModal();
 
   const handleDeleteAccount = () => {
@@ -25,7 +27,7 @@ const MyInfoView = () => {
       <S.ProfileHeader>
         <PlayerIcon color="#FF6B6B" />
         <S.ProfileInfo>
-          <S.WelcomeMessage>{myName || '익명의 사용자'}님</S.WelcomeMessage>
+          <S.WelcomeMessage>{displayName}님</S.WelcomeMessage>
           <S.UserStatus>오늘도 쫄깃한 승부를 즐겨보세요!</S.UserStatus>
         </S.ProfileInfo>
       </S.ProfileHeader>

--- a/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.styled.ts
+++ b/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.styled.ts
@@ -48,12 +48,12 @@ export const UserInfo = styled.div`
 
 export const NicknameRow = styled.div`
   display: flex;
-  align-items: center;
-  gap: 8px;
+  align-items: baseline;
+  gap: 6px;
 `;
 
 export const Nickname = styled.span`
-  ${({ theme }) => theme.typography.h4};
+  ${({ theme }) => theme.typography.h2}
   color: ${({ theme }) => theme.color.gray[900]};
   white-space: nowrap;
   overflow: hidden;
@@ -61,13 +61,13 @@ export const Nickname = styled.span`
 `;
 
 export const EditButton = styled.button`
-  padding: 2px 8px;
+  padding: 3px 10px;
   border: 1px solid ${({ theme }) => theme.color.gray[200]};
   border-radius: 6px;
   background: transparent;
   color: ${({ theme }) => theme.color.gray[500]};
-  font-size: 11px;
-  font-weight: 600;
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
   cursor: pointer;
   flex-shrink: 0;
   transition: all 0.15s ease;
@@ -144,49 +144,55 @@ export const CancelButton = styled.button`
   }
 `;
 
-export const Provider = styled.span`
-  font-size: 12px;
-  color: ${({ theme }) => theme.color.gray[400]};
-`;
-
-export const UserCodeRow = styled.div`
+export const InfoRow = styled.div`
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 4px;
+  margin-top: 2px;
 `;
 
-export const UserCode = styled.span`
-  font-size: 12px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.color.gray[500]};
-  letter-spacing: 0.04em;
-`;
-
-export const CopyButton = styled.button`
-  padding: 1px 7px;
-  border: 1px solid ${({ theme }) => theme.color.gray[200]};
-  border-radius: 5px;
-  background: transparent;
+export const Provider = styled.span`
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
   color: ${({ theme }) => theme.color.gray[400]};
-  font-size: 10px;
-  font-weight: 600;
+  flex: 1;
+`;
+
+export const UserCode = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
+  color: ${({ theme }) => theme.color.gray[400]};
+  letter-spacing: 0.04em;
   cursor: pointer;
-  transition: all 0.12s;
+  transition: opacity 0.12s;
+
+  svg {
+    margin-bottom: 1px;
+    flex-shrink: 0;
+
+    rect:last-of-type {
+      fill: ${({ theme }) => theme.color.white};
+    }
+  }
 
   &:active {
-    background: ${({ theme }) => theme.color.gray[50]};
+    opacity: 0.6;
   }
 `;
 
 export const LogoutButton = styled.button`
-  padding: 7px 14px;
+  padding: 3px 10px;
   border: 1px solid ${({ theme }) => theme.color.gray[200]};
-  border-radius: 8px;
+  border-radius: 6px;
   background: ${({ theme }) => theme.color.white};
   color: ${({ theme }) => theme.color.gray[600]};
-  font-size: 13px;
-  font-weight: 600;
+  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
   cursor: pointer;
   flex-shrink: 0;
   transition: background-color 0.15s ease;

--- a/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.tsx
+++ b/frontend/src/features/home/components/tabs/MenuTab/AccountSection/AccountSection.tsx
@@ -4,6 +4,7 @@ import useToast from '@/components/@common/Toast/useToast';
 import { ApiError } from '@/apis/rest/error';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import LoginSheet from '@/features/auth/components/LoginSheet/LoginSheet';
+import CopyIcon from '@/components/icons/CopyIcon';
 import * as S from './AccountSection.styled';
 
 const PROVIDER_LABEL: Record<string, string> = {
@@ -96,31 +97,31 @@ const AccountSection = () => {
               ) : (
                 <S.NicknameRow>
                   <S.Nickname>{user.nickname}</S.Nickname>
-                  <S.EditButton type="button" onClick={handleEditStart} aria-label="닉네임 수정">
-                    수정
-                  </S.EditButton>
+                  <S.UserCode
+                    type="button"
+                    onClick={() => {
+                      navigator.clipboard.writeText(user.userCode);
+                      showToast({ message: '유저코드가 복사되었습니다', type: 'success' });
+                    }}
+                    aria-label="유저코드 복사"
+                  >
+                    #{user.userCode}
+                    <CopyIcon size={12} />
+                  </S.UserCode>
                 </S.NicknameRow>
               )}
-              <S.Provider>{PROVIDER_LABEL[user.provider] ?? user.provider}</S.Provider>
-              <S.UserCodeRow>
-                <S.UserCode># {user.userCode}</S.UserCode>
-                <S.CopyButton
-                  type="button"
-                  onClick={() => {
-                    navigator.clipboard.writeText(user.userCode);
-                    showToast({ message: '유저코드가 복사되었습니다', type: 'success' });
-                  }}
-                  aria-label="유저코드 복사"
-                >
-                  복사
-                </S.CopyButton>
-              </S.UserCodeRow>
+              {!isEditing && (
+                <S.InfoRow>
+                  <S.Provider>{PROVIDER_LABEL[user.provider] ?? user.provider}</S.Provider>
+                  <S.EditButton type="button" onClick={handleEditStart} aria-label="닉네임 변경">
+                    닉네임 변경
+                  </S.EditButton>
+                  <S.LogoutButton type="button" onClick={() => logout()}>
+                    로그아웃
+                  </S.LogoutButton>
+                </S.InfoRow>
+              )}
             </S.UserInfo>
-            {!isEditing && (
-              <S.LogoutButton type="button" onClick={() => logout()}>
-                로그아웃
-              </S.LogoutButton>
-            )}
           </S.UserRow>
         </S.Card>
       </S.Section>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. **내 정보 탭** — 로그인 사용자 닉네임 우선 표시 (`user.nickname.trim() || myName || '익명의 사용자'`)
2. **더보기 탭 AccountSection** — 닉네임(h2) + 유저코드 한 줄 배치, 유저코드 탭 시 클립보드 복사, "수정" → "닉네임 변경" 명시, 닉네임 변경·로그아웃 버튼을 하단 InfoRow로 이동
3. **친구 탭 MyCodeCard** — 닉네임 + 유저코드 함께 표시, 카드 전체 탭으로 복사, point[50] 연한 핑크 배경
4. **CopyIcon 공용 컴포넌트 추출** — `src/components/icons/CopyIcon.tsx`, AccountSection·FriendsTab에서 재사용
5. **MyInfoView.styled.ts** — 하드코딩된 font-size/font-weight/rgba 색상을 typography 토큰·hex opacity로 교체
<img width="906" height="406" alt="image" src="https://github.com/user-attachments/assets/a50a0e2e-a15a-40fe-b3a3-5794bf211002" />

<img width="448" height="213" alt="image" src="https://github.com/user-attachments/assets/35e8af29-b69c-4c0b-9069-2cdb3a5a8987" />



# 💬 리뷰 중점사항

- `AccountSection`의 `UserCode` styled.button에서 `svg rect:last-of-type { fill: white }`로 CopyIcon overlap을 마스킹하는 방식 — FriendsTab도 카드 배경색(`point[50]`)으로 동일하게 처리
- `displayName` 파생 로직(`user?.nickname?.trim() || myName || '익명의 사용자'`)이 컴포넌트 내부에 인라인 — 추후 재사용 시 `useDisplayName` 훅 분리 고려- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 