### PR TITLE
[fix] UserPrincipal·sessionId Principal을 룸 세션으로 오파싱하는 버그 수정

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -28,6 +28,13 @@ grep "^startRound	" tags                 # 메서드 정의
 결과 형식: `심볼명\t파일경로\t패턴\t필드(line:N)` → 해당 파일을 line:N 기준으로 Read한다.
 `tags`가 없거나 오래됐으면 `./gradlew generateCtags` 또는 `./gradlew compileJava`로 재생성한다.
 
+## 브랜치 전략
+
+- 작업 브랜치는 **`be/dev`에서 체크아웃**한다
+- PR 타깃은 `be/dev`이다
+- `main`은 GitHub Actions 워크플로우·CodeRabbit 설정 등 GitHub 관련 파일 전용이다. 백엔드 코드 작업에 사용하지 않는다
+- 브랜치 네이밍: `be/feat/...`, `be/fix/...`, `be/chore/...`, `be/refactor/...`
+
 ## 작업 규칙
 
 - 요구사항이 모호하거나 여러 해석이 가능하면 구현 전에 먼저 질문한다. 추측으로 구현하지 않는다

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
@@ -4,11 +4,11 @@ import coffeeshout.global.metric.WebSocketMetricService;
 import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.redis.stream.StreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.global.exception.custom.BusinessException;
 import coffeeshout.global.websocket.PlayerKey;
-import coffeeshout.global.websocket.StompSessionManager;
+import coffeeshout.global.websocket.UserPrincipal;
 import coffeeshout.global.websocket.event.session.SessionRegisteredEvent;
 import coffeeshout.room.domain.JoinCode;
-import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.service.RoomQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,6 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 public class SessionConnectEventListener {
 
     private final WebSocketMetricService webSocketMetricService;
-    private final StompSessionManager sessionManager;
     private final StreamPublisher streamPublisher;
     private final RoomQueryService roomQueryService;
 
@@ -37,10 +36,19 @@ public class SessionConnectEventListener {
     @EventListener
     public void handleSessionConnected(SessionConnectedEvent event) {
         final String sessionId = event.getMessage().getHeaders().get("simpSessionId", String.class);
-        final String playerKey = event.getUser().getName();
-        final PlayerKey parsed = PlayerKey.parse(playerKey);
-        log.info("웹소켓 연결 완료: sessionId={}, joinCode={}, playerName={}", sessionId, parsed.joinCode(), parsed.playerName());
+        if (event.getUser() == null) {
+            webSocketMetricService.completeConnection(sessionId);
+            return;
+        }
+        final String principalName = event.getUser().getName();
 
+        if (principalName.startsWith(UserPrincipal.PREFIX) || !PlayerKey.isValid(principalName)) {
+            webSocketMetricService.completeConnection(sessionId);
+            return;
+        }
+
+        final PlayerKey parsed = PlayerKey.parse(principalName);
+        log.info("웹소켓 연결 완료: sessionId={}, joinCode={}, playerName={}", sessionId, parsed.joinCode(), parsed.playerName());
         processPlayerConnection(sessionId, parsed.joinCode(), parsed.playerName());
         webSocketMetricService.completeConnection(sessionId);
     }
@@ -49,8 +57,7 @@ public class SessionConnectEventListener {
         try {
             roomQueryService.getByJoinCode(new JoinCode(joinCode));
             publishSessionRegisteredEvent(sessionId, joinCode, playerName);
-
-        } catch (Exception e) {
+        } catch (BusinessException e) {
             log.warn("플레이어 연결 실패: joinCode={}, playerName={}, error={}", joinCode, playerName, e.getMessage());
         }
     }

--- a/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
+++ b/backend/src/main/java/coffeeshout/global/websocket/event/SessionConnectEventListener.java
@@ -49,8 +49,11 @@ public class SessionConnectEventListener {
 
         final PlayerKey parsed = PlayerKey.parse(principalName);
         log.info("웹소켓 연결 완료: sessionId={}, joinCode={}, playerName={}", sessionId, parsed.joinCode(), parsed.playerName());
-        processPlayerConnection(sessionId, parsed.joinCode(), parsed.playerName());
-        webSocketMetricService.completeConnection(sessionId);
+        try {
+            processPlayerConnection(sessionId, parsed.joinCode(), parsed.playerName());
+        } finally {
+            webSocketMetricService.completeConnection(sessionId);
+        }
     }
 
     private void processPlayerConnection(String sessionId, String joinCode, String playerName) {

--- a/backend/src/test/java/coffeeshout/global/websocket/event/SessionConnectEventListenerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/event/SessionConnectEventListenerTest.java
@@ -1,0 +1,125 @@
+package coffeeshout.global.websocket.event;
+
+import coffeeshout.global.exception.custom.BusinessException;
+import coffeeshout.global.metric.WebSocketMetricService;
+import coffeeshout.global.redis.BaseEvent;
+import coffeeshout.global.redis.stream.StreamKey;
+import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.room.domain.RoomErrorCode;
+import coffeeshout.room.domain.service.RoomQueryService;
+import java.security.Principal;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionConnectEventListenerTest {
+
+    @Mock
+    private WebSocketMetricService webSocketMetricService;
+    @Mock
+    private StreamPublisher streamPublisher;
+    @Mock
+    private RoomQueryService roomQueryService;
+
+    private SessionConnectEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new SessionConnectEventListener(webSocketMetricService, streamPublisher, roomQueryService);
+    }
+
+    private SessionConnectedEvent eventWith(String principalName) {
+        final MessageHeaders headers = new MessageHeaders(Map.of("simpSessionId", "session-1"));
+        final Message<byte[]> message = new GenericMessage<>(new byte[0], headers);
+        return new SessionConnectedEvent(this, message, () -> principalName);
+    }
+
+    @Nested
+    class 룸_세션_토큰으로_연결한_경우 {
+
+        @Test
+        void 유효한_PlayerKey_형식이면_룸_조회와_세션_등록_이벤트를_발행한다() {
+            final SessionConnectedEvent event = eventWith("ABCD:홍길동");
+
+            listener.handleSessionConnected(event);
+
+            verify(roomQueryService).getByJoinCode(any());
+            verify(streamPublisher).publish(eq(StreamKey.ROOM_BROADCAST), any(BaseEvent.class));
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+    }
+
+    @Nested
+    class Bearer_토큰으로_연결한_경우 {
+
+        @Test
+        void user_userId_형식_Principal이면_룸_처리를_건너뛴다() {
+            final SessionConnectedEvent event = eventWith("user:4");
+
+            listener.handleSessionConnected(event);
+
+            verify(roomQueryService, never()).getByJoinCode(any());
+            verify(streamPublisher, never()).publish(any(), any());
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+    }
+
+    @Nested
+    class Principal_형식이_올바르지_않은_경우 {
+
+        @Test
+        void PlayerKey_형식이_아니면_룸_처리를_건너뛴다() {
+            final SessionConnectedEvent event = eventWith("b1c2d3e4-f5a6-7890-abcd-ef1234567890");
+
+            listener.handleSessionConnected(event);
+
+            verify(roomQueryService, never()).getByJoinCode(any());
+            verify(streamPublisher, never()).publish(any(), any());
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+
+        @Test
+        void Principal이_null이면_룸_처리를_건너뛴다() {
+            final MessageHeaders headers = new MessageHeaders(Map.of("simpSessionId", "session-1"));
+            final Message<byte[]> message = new GenericMessage<>(new byte[0], headers);
+            final SessionConnectedEvent event = new SessionConnectedEvent(this, message, null);
+
+            listener.handleSessionConnected(event);
+
+            verify(roomQueryService, never()).getByJoinCode(any());
+            verify(streamPublisher, never()).publish(any(), any());
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+    }
+
+    @Nested
+    class 룸_조회가_실패한_경우 {
+
+        @Test
+        void 세션_등록_이벤트를_발행하지_않고_메트릭만_완료한다() {
+            given(roomQueryService.getByJoinCode(any()))
+                    .willThrow(new BusinessException(RoomErrorCode.ROOM_NOT_FOUND, "방을 찾을 수 없습니다."));
+            final SessionConnectedEvent event = eventWith("ABCD:홍길동");
+
+            listener.handleSessionConnected(event);
+
+            verify(streamPublisher, never()).publish(any(), any());
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+    }
+}

--- a/backend/src/test/java/coffeeshout/global/websocket/event/SessionConnectEventListenerTest.java
+++ b/backend/src/test/java/coffeeshout/global/websocket/event/SessionConnectEventListenerTest.java
@@ -7,7 +7,6 @@ import coffeeshout.global.redis.stream.StreamKey;
 import coffeeshout.global.redis.stream.StreamPublisher;
 import coffeeshout.room.domain.RoomErrorCode;
 import coffeeshout.room.domain.service.RoomQueryService;
-import java.security.Principal;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -23,6 +22,7 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -119,6 +119,22 @@ class SessionConnectEventListenerTest {
             listener.handleSessionConnected(event);
 
             verify(streamPublisher, never()).publish(any(), any());
+            verify(webSocketMetricService).completeConnection("session-1");
+        }
+    }
+
+    @Nested
+    class 인프라_예외가_발생한_경우 {
+
+        @Test
+        void 예외가_전파되더라도_메트릭_완료는_반드시_호출된다() {
+            willThrow(new RuntimeException("Redis publish 실패"))
+                    .given(streamPublisher).publish(any(), any());
+            final SessionConnectedEvent event = eventWith("ABCD:홍길동");
+
+            org.assertj.core.api.Assertions.assertThatThrownBy(() -> listener.handleSessionConnected(event))
+                    .isInstanceOf(RuntimeException.class);
+
             verify(webSocketMetricService).completeConnection("session-1");
         }
     }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

<img width="2402" height="170" alt="image" src="https://github.com/user-attachments/assets/84e1afce-e01c-41f6-a733-83f5bca5c105" />

1. `SessionConnectEventListener.handleSessionConnected`에서 `event.getUser()` null 가드 추가
2. `UserPrincipal.PREFIX`(`user:`) 또는 유효하지 않은 `PlayerKey` 형식의 Principal은 룸 연결 처리를 건너뛰도록 분기 추가
3. `processPlayerConnection`의 `catch (Exception)` → `catch (BusinessException)`으로 범위 좁혀 인프라 예외가 묻히지 않도록 수정
4. `SessionConnectEventListenerTest` 단위 테스트 추가 (5개 케이스)

# 💬 리뷰 중점사항

- `principalName.startsWith(UserPrincipal.PREFIX) || !PlayerKey.isValid(principalName)` 분기 순서: `user:4`는 `PlayerKey.isValid`가 `true`를 반환하므로 `UserPrincipal.PREFIX` 체크가 앞에 있어야 함
- `catch (BusinessException)`으로 좁힌 이유: 기존 `catch (Exception)`은 Redis 다운 등 인프라 예외까지 warn으로 묻어버려 실제 장애 감지가 어려웠음