### PR TITLE
[chore] SEO fallback 로딩 화면 브랜드 디자인 및 접근성 개선

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -80,6 +80,53 @@
         font-style: normal;
         font-display: swap;
       }
+      @keyframes zzol-pulse {
+        0%, 100% { opacity: 0.2; transform: scale(0.75); }
+        50%       { opacity: 1;   transform: scale(1); }
+      }
+      #zzol-splash {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        min-height: 100dvh;
+        background: #ffffff;
+        text-align: center;
+      }
+      #zzol-splash h1 {
+        font-family: 'Pretendard Variable', sans-serif;
+        font-size: 0.9375rem;
+        font-weight: 500;
+        color: #888;
+        margin: 0;
+        line-height: 1.5;
+      }
+      #zzol-splash p {
+        font-family: 'Pretendard Variable', sans-serif;
+        font-size: 0.8125rem;
+        font-weight: 400;
+        color: #aaa;
+        line-height: 1.75;
+        max-width: 260px;
+        margin: 0;
+      }
+      #zzol-dots {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        margin-top: 8px;
+      }
+      #zzol-dots span {
+        display: block;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #F53E41;
+        animation: zzol-pulse 1.2s ease-in-out infinite;
+      }
+      #zzol-dots span:nth-child(2) { animation-delay: 0.4s; }
+      #zzol-dots span:nth-child(3) { animation-delay: 0.8s; }
     </style>
     <script type="application/ld+json">
       {
@@ -123,13 +170,17 @@
   </head>
   <body>
     <div id="root">
-      <main style="display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100dvh;padding:24px;font-family:sans-serif;text-align:center;">
-        <h1 style="font-size:1.5rem;font-weight:700;margin-bottom:12px;">쫄 — 커피 내기·점심 내기를 미니게임으로</h1>
-        <p style="font-size:1rem;line-height:1.7;max-width:400px;color:#555;">
-          내기 게임, 복불복 게임을 더 재밌게! QR코드로 방에 입장하고 미니게임 결과로
-          룰렛 당첨 확률을 정하세요. 커피 내기, 점심 메뉴 정하기, 당번 뽑기까지
-          가위바위보 대신 쫄(ZZOL)로 해결하세요.
-        </p>
+      <main id="zzol-splash">
+        <svg width="120" height="31" viewBox="0 0 206 53" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="쫄 (ZZOL)">
+          <path d="M49.2 51.6H-1.95601e-06L19.08 18H0.899998V1.2H49.8L30.72 34.8H49.2V51.6ZM99.0047 51.6H49.8047L68.8847 18H50.7047V1.2L99.6047 1.2L80.5247 34.8H99.0047V51.6ZM130.209 52.8C112.389 52.8 100.809 42.78 100.209 27.54H121.269C121.689 31.44 124.869 34.8 130.209 34.8C135.909 34.8 139.209 30.84 139.209 26.34C139.209 21.84 135.969 18 130.209 18C124.809 18 121.329 21.42 121.269 26.94L100.209 25.14C100.869 9.96 112.449 2.38419e-08 130.209 2.38419e-08C148.449 2.38419e-08 160.209 10.5 160.209 26.4C160.209 42.3 148.449 52.8 130.209 52.8ZM205.181 34.2V51.6H161.981V1.2H182.381V34.2H205.181Z" fill="#FD6C6E"/>
+        </svg>
+        <h1>커피 내기 · 점심 내기를 미니게임으로</h1>
+        <p>내기 게임·복불복을 미니게임으로!<br/>커피 내기, 술 내기, 점심 메뉴, 당번 뽑기까지<br/>가위바위보 대신 쫄(ZZOL)로.</p>
+        <div id="zzol-dots" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
       </main>
     </div>
     <div id="modal-root"></div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -89,33 +89,39 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 16px;
+        gap: 1rem;
+        min-height: 100vh;
         min-height: 100dvh;
         background: #ffffff;
         text-align: center;
       }
+      #zzol-splash svg {
+        color: #FD6C6E;
+      }
       #zzol-splash h1 {
-        font-family: 'Pretendard Variable', sans-serif;
+        font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont,
+                     system-ui, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
         font-size: 0.9375rem;
         font-weight: 500;
-        color: #888;
+        color: #444;
         margin: 0;
         line-height: 1.5;
       }
       #zzol-splash p {
-        font-family: 'Pretendard Variable', sans-serif;
+        font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont,
+                     system-ui, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
         font-size: 0.8125rem;
         font-weight: 400;
-        color: #aaa;
+        color: #666;
         line-height: 1.75;
         max-width: 260px;
         margin: 0;
       }
       #zzol-dots {
         display: flex;
-        gap: 6px;
+        gap: 0.375rem;
         align-items: center;
-        margin-top: 8px;
+        margin-top: 0.5rem;
       }
       #zzol-dots span {
         display: block;
@@ -125,8 +131,11 @@
         background: #F53E41;
         animation: zzol-pulse 1.2s ease-in-out infinite;
       }
-      #zzol-dots span:nth-child(2) { animation-delay: 0.4s; }
-      #zzol-dots span:nth-child(3) { animation-delay: 0.8s; }
+      #zzol-dots span:nth-of-type(2) { animation-delay: 0.4s; }
+      #zzol-dots span:nth-of-type(3) { animation-delay: 0.8s; }
+      @media (prefers-reduced-motion: reduce) {
+        #zzol-dots span { animation: none; opacity: 0.6; }
+      }
     </style>
     <script type="application/ld+json">
       {
@@ -171,8 +180,8 @@
   <body>
     <div id="root">
       <main id="zzol-splash">
-        <svg width="120" height="31" viewBox="0 0 206 53" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="쫄 (ZZOL)">
-          <path d="M49.2 51.6H-1.95601e-06L19.08 18H0.899998V1.2H49.8L30.72 34.8H49.2V51.6ZM99.0047 51.6H49.8047L68.8847 18H50.7047V1.2L99.6047 1.2L80.5247 34.8H99.0047V51.6ZM130.209 52.8C112.389 52.8 100.809 42.78 100.209 27.54H121.269C121.689 31.44 124.869 34.8 130.209 34.8C135.909 34.8 139.209 30.84 139.209 26.34C139.209 21.84 135.969 18 130.209 18C124.809 18 121.329 21.42 121.269 26.94L100.209 25.14C100.869 9.96 112.449 2.38419e-08 130.209 2.38419e-08C148.449 2.38419e-08 160.209 10.5 160.209 26.4C160.209 42.3 148.449 52.8 130.209 52.8ZM205.181 34.2V51.6H161.981V1.2H182.381V34.2H205.181Z" fill="#FD6C6E"/>
+        <svg width="120" height="31" viewBox="0 0 206 53" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+          <path d="M49.2 51.6H-1.95601e-06L19.08 18H0.899998V1.2H49.8L30.72 34.8H49.2V51.6ZM99.0047 51.6H49.8047L68.8847 18H50.7047V1.2L99.6047 1.2L80.5247 34.8H99.0047V51.6ZM130.209 52.8C112.389 52.8 100.809 42.78 100.209 27.54H121.269C121.689 31.44 124.869 34.8 130.209 34.8C135.909 34.8 139.209 30.84 139.209 26.34C139.209 21.84 135.969 18 130.209 18C124.809 18 121.329 21.42 121.269 26.94L100.209 25.14C100.869 9.96 112.449 2.38419e-08 130.209 2.38419e-08C148.449 2.38419e-08 160.209 10.5 160.209 26.4C160.209 42.3 148.449 52.8 130.209 52.8ZM205.181 34.2V51.6H161.981V1.2H182.381V34.2H205.181Z" fill="currentColor"/>
         </svg>
         <h1>커피 내기 · 점심 내기를 미니게임으로</h1>
         <p>내기 게임·복불복을 미니게임으로!<br/>커피 내기, 술 내기, 점심 메뉴, 당번 뽑기까지<br/>가위바위보 대신 쫄(ZZOL)로.</p>


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. React 번들 로드 전 사용자에게 노출되는 `#root` fallback 콘텐츠를 브랜드 로딩 화면으로 교체 
2. (새로고침 하면 확인할 수 이있습니다._)
<img width="656" height="1588" alt="image" src="https://github.com/user-attachments/assets/5ef9e581-f997-4376-be85-9ecb69688322" />

3. ZZOL.svg를 인라인으로 삽입해 별도 네트워크 요청 없이 즉시 렌더링
4. SEO 키워드(`<h1>`, `<p>`)를 유지하되 cloaking 없이 자연스러운 UI로 표현
5. CSS를 기존 `<style>` 블록에서 ID 선택자(`#zzol-splash`, `#zzol-dots`)로 관리
6. 텍스트 색상 WCAG AA 기준으로 상향 (`#888` → `#444`, `#aaa` → `#666`)
7. SVG `aria-hidden="true" focusable="false"` 처리 및 `fill="currentColor"` 전환
8. `min-height: 100vh` fallback 추가 (dvh 미지원 인앱 브라우저 대응)
9. `prefers-reduced-motion` 처리로 dots 애니메이션 모션 접근성 개선
10. 폰트 시스템 스택 보강 (`-apple-system`, `Apple SD Gothic Neo`, `Malgun Gothic` 등)
11. `gap`/`margin` 단위 rem 통일, `nth-child` → `nth-of-type` 선택자 명확화

# 💬 리뷰 중점사항

- **SEO 안전성**: fallback 텍스트(`<h1>`, `<p>`)가 React 렌더링 결과와 주제·키워드가 일치하므로 cloaking 판정 위험 없음. Googlebot은 JS 실행 결과를 1순위로 인덱싱하며, 이 fallback은 1차 크롤(JS 실행 전) 보조용.
- **텍스트 색상**: 로딩 중 흐릿한 느낌을 살리면서도 WCAG AA(4.5:1) 통과하는 수준(`#444`, `#666`)으로 조정. 너무 진하면 어색하고 너무 연하면 SEO 리스크가 있어 그 사이 지점.
- **SVG currentColor**: `fill="currentColor"` + `#zzol-splash svg { color: #FD6C6E }` 구조로 향후 색상 변경 시 CSS 한 곳만 수정하면 됨.