### PR TITLE
[refactor] 탭 전환 후 복귀 시 방 삭제 감지 및 로비 리다이렉트

### DIFF
--- a/frontend/src/hooks/useRoomAccessGuard.ts
+++ b/frontend/src/hooks/useRoomAccessGuard.ts
@@ -1,16 +1,27 @@
 import useLazyFetch from '@/apis/rest/useLazyFetch';
 import { getIsRecovering } from '@/apis/websocket/contexts/WebSocketProvider';
+import useToast from '@/components/@common/Toast/useToast';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useParticipants } from '@/contexts/Participants/ParticipantsContext';
 import { usePlayerType } from '@/contexts/PlayerType/PlayerTypeContext';
 import { useReplaceNavigate } from '@/hooks/useReplaceNavigate';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export const useRoomAccessGuard = () => {
   const { myName, joinCode } = useIdentifier();
   const { participants } = useParticipants();
   const { playerType } = usePlayerType();
   const navigate = useReplaceNavigate();
+  const { showToast } = useToast();
+  const isCheckingRef = useRef(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const { execute: checkRoomExists } = useLazyFetch<{ exist: boolean }>({
     endpoint: `/rooms/check-joinCode?joinCode=${joinCode}`,
@@ -69,6 +80,32 @@ export const useRoomAccessGuard = () => {
     }
   }, [joinCode, playerType, myName, participants, navigateToHome, checkRoomExists]);
 
+  const handleVisibilityChange = useCallback(async () => {
+    if (document.hidden) return;
+    if (getIsRecovering()) return;
+    if (!joinCode) return;
+    if (isCheckingRef.current) return;
+
+    isCheckingRef.current = true;
+    try {
+      const response = await checkRoomExists();
+      if (!isMountedRef.current) return;
+      if (!response) return;
+      if (!response.exist) {
+        showToast({
+          message: '방이 종료되었습니다. 로비로 이동합니다.',
+          type: 'warning',
+          duration: 2000,
+        });
+        setTimeout(() => {
+          if (isMountedRef.current) navigate('/');
+        }, 800);
+      }
+    } finally {
+      isCheckingRef.current = false;
+    }
+  }, [joinCode, checkRoomExists, showToast, navigate]);
+
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       validateUserExistsAndRedirect();
@@ -76,4 +113,9 @@ export const useRoomAccessGuard = () => {
 
     return () => clearTimeout(timeoutId);
   }, [validateUserExistsAndRedirect]);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [handleVisibilityChange]);
 };


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1238

# 🚀 작업 내용

1. `useRoomAccessGuard`에 Page Visibility API(`visibilitychange`) 리스너 추가 — 탭이 다시 활성화될 때만 `/rooms/check-joinCode` 1회 호출
2. 방이 삭제된 경우 warning 토스트("방이 종료되었습니다. 로비로 이동합니다.") 표시 후 800ms 딜레이로 홈 이동
3. `isCheckingRef`로 탭 전환 직후 중복 API 호출 방지
4. `isMountedRef`로 언마운트 이후 `navigate` 호출 차단

# 💬 리뷰 중점사항

- `handleVisibilityChange`는 `validateUserExistsAndRedirect`(초기 마운트 검증)와 별도 경로로 분리해 경쟁 조건을 최소화했습니다. `isCheckingRef`로 visibility 중복 호출만 막고, 초기 검증과의 동시 실행은 replace navigate 특성상 시각적 부작용이 없어 허용했습니다.
- navigate 전 800ms 딜레이는 스크린 리더 사용자가 토스트 안내를 들을 수 있도록 한 접근성 배려입니다.
- `getIsRecovering()` 체크는 WebSocket 복구 시작 직전 타이밍에 false를 반환할 수 있는 한계가 있습니다. 방이 실제로 삭제된 상황에서는 오탐 없이 동작하므로 이번 PR에서는 현 구조를 유지했습니다.