### PR TITLE
[chore] 랭킹 탭 문구·항목 정리, 스타일 컨벤션 적용, PWA 설치 컨텍스트 개선

### DIFF
--- a/frontend/docs/adr/20260515-ranking-api-separate-endpoints.md
+++ b/frontend/docs/adr/20260515-ranking-api-separate-endpoints.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-05-15
-status: decided
+status: amended
+amended: 2026-05-23
 ---
 
 # 랭킹 대시보드 API를 통합하지 않고 별도 엔드포인트 유지
@@ -27,3 +28,17 @@ status: decided
 - 프론트엔드에서 탭별로 독립 요청을 보내므로 일부 탭 응답이 느려도 다른 탭에 영향을 주지 않는다.
 - 향후 통합이 필요해질 경우 `src/features/home/config/rankingConfigs.ts` 의 각 항목 `endpoint` 필드만 교체하면 된다. 컴포넌트 변경 없음.
 - 새로운 랭킹 카테고리는 `rankingConfigs.ts`에 항목을 추가하는 방식으로 확장한다.
+
+## 갱신 이력 (2026-05-23)
+
+랭킹 탭에서 `top-winners`, `lowest-probability-winner`, `game-play-counts` 세 카테고리를 제거했다. 다른 대시보드 슬라이드(`TopWinnersSlide`, `LowestProbabilitySlide`)와 내용이 중복되어 UX 관점에서 불필요하다고 판단했기 때문이다.
+
+**현재 `rankingConfigs.ts`에 남은 카테고리:**
+- `blockstacking-top-players` — `GET /dashboard/block-stacking-top-players`
+- `racing-game-top-players` — `GET /dashboard/racing-game-top-players`
+
+**제거된 세 엔드포인트의 현재 소비처:**
+- `top-winners`, `lowest-probability-winner` → `src/features/home/hooks/useDashboardData.ts` (DashBoard 슬라이드)
+- `game-play-counts` → 현재 미사용. 백엔드 엔드포인트는 유지 중.
+
+별도 엔드포인트 유지 결정 자체는 유효하다. `rankingConfigs.ts` 확장 패턴도 동일하게 적용된다.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { PlayerTypeProvider } from './contexts/PlayerType/PlayerTypeProvider';
 import ProbabilityHistoryProvider from './contexts/ProbabilityHistory/ProbabilityHistoryProvider';
 import { theme } from './styles/theme';
 import UpdateBanner from './components/@common/UpdateBanner/UpdateBanner';
+import InstallPromptProvider from './contexts/InstallPrompt/InstallPromptProvider';
 import { DevToolsWrapper } from './devtools/common/components/DevToolsWrapper/DevToolsWrapper';
 
 const App = () => {
@@ -23,34 +24,36 @@ const App = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      {process.env.ENABLE_DEVTOOLS && <DevToolsWrapper />}
-      <UpdateBanner />
+      <InstallPromptProvider>
+        {process.env.ENABLE_DEVTOOLS && <DevToolsWrapper />}
+        <UpdateBanner />
 
-      <AuthProvider>
-        <UserSocketProvider>
-          <IdentifierProvider>
-            <ParticipantsProvider>
-              <WebSocketProvider>
-                <PlayerTypeProvider>
-                  <ProbabilityHistoryProvider>
-                    <GlobalErrorBoundary>
-                      <ToastProvider>
-                        <ModalProvider>
-                          <FriendsProvider>
-                            <Suspense fallback={<div>Loading...</div>}>
-                              <Outlet />
-                            </Suspense>
-                          </FriendsProvider>
-                        </ModalProvider>
-                      </ToastProvider>
-                    </GlobalErrorBoundary>
-                  </ProbabilityHistoryProvider>
-                </PlayerTypeProvider>
-              </WebSocketProvider>
-            </ParticipantsProvider>
-          </IdentifierProvider>
-        </UserSocketProvider>
-      </AuthProvider>
+        <AuthProvider>
+          <UserSocketProvider>
+            <IdentifierProvider>
+              <ParticipantsProvider>
+                <WebSocketProvider>
+                  <PlayerTypeProvider>
+                    <ProbabilityHistoryProvider>
+                      <GlobalErrorBoundary>
+                        <ToastProvider>
+                          <ModalProvider>
+                            <FriendsProvider>
+                              <Suspense fallback={<div>Loading...</div>}>
+                                <Outlet />
+                              </Suspense>
+                            </FriendsProvider>
+                          </ModalProvider>
+                        </ToastProvider>
+                      </GlobalErrorBoundary>
+                    </ProbabilityHistoryProvider>
+                  </PlayerTypeProvider>
+                </WebSocketProvider>
+              </ParticipantsProvider>
+            </IdentifierProvider>
+          </UserSocketProvider>
+        </AuthProvider>
+      </InstallPromptProvider>
     </ThemeProvider>
   );
 };

--- a/frontend/src/contexts/InstallPrompt/InstallPromptContext.ts
+++ b/frontend/src/contexts/InstallPrompt/InstallPromptContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export type InstallPromptContextValue = {
+  isInstallable: boolean;
+  isInstalled: boolean;
+  install: () => Promise<void>;
+};
+
+export const InstallPromptContext = createContext<InstallPromptContextValue | null>(null);
+
+export const useInstallPromptContext = () => {
+  const ctx = useContext(InstallPromptContext);
+  if (ctx === null) {
+    throw new Error('useInstallPromptContext must be used within an InstallPromptProvider');
+  }
+  return ctx;
+};

--- a/frontend/src/contexts/InstallPrompt/InstallPromptProvider.tsx
+++ b/frontend/src/contexts/InstallPrompt/InstallPromptProvider.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
+import { InstallPromptContext } from './InstallPromptContext';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+const InstallPromptProvider = ({ children }: PropsWithChildren) => {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches
+  );
+
+  useEffect(() => {
+    const handleBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+    };
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      setDeferredPrompt(null);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstall);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstall);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, []);
+
+  const install = useCallback(async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') setDeferredPrompt(null);
+  }, [deferredPrompt]);
+
+  const value = useMemo(
+    () => ({ isInstallable: deferredPrompt !== null, isInstalled, install }),
+    [deferredPrompt, isInstalled, install]
+  );
+
+  return <InstallPromptContext.Provider value={value}>{children}</InstallPromptContext.Provider>;
+};
+
+export default InstallPromptProvider;

--- a/frontend/src/features/home/components/DashBoard/LowestProbabilitySlide/LowestProbabilitySlide.tsx
+++ b/frontend/src/features/home/components/DashBoard/LowestProbabilitySlide/LowestProbabilitySlide.tsx
@@ -70,7 +70,7 @@ const LowestProbabilitySlide = ({ players, probability }: Props) => {
     <S.Card>
       <S.Header>
         <S.CardTitle>최저 확률 당첨</S.CardTitle>
-        <S.Sub>이번달 가장 짜릿한 역전</S.Sub>
+        <S.Sub>이번 달 가장 행복한 당첨자~</S.Sub>
       </S.Header>
       {players.length === 0 ? (
         <S.Empty>아직 당첨자가 없어요</S.Empty>

--- a/frontend/src/features/home/components/MenuTab/views/AppInstallView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/AppInstallView.styled.ts
@@ -27,28 +27,26 @@ export const HeroIconWrap = styled.div`
   width: 60px;
   height: 60px;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.2);
+  background: ${({ theme }) => theme.color.white}33;
   display: flex;
   align-items: center;
   justify-content: center;
 `;
 
 export const HeroTitle = styled.span`
-  font-size: 18px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h3}
   color: ${({ theme }) => theme.color.white};
   letter-spacing: -0.02em;
 `;
 
 export const HeroSub = styled.span`
-  font-size: 13px;
-  color: rgba(255, 255, 255, 0.72);
+  ${({ theme }) => theme.typography.small}
+  color: ${({ theme }) => theme.color.white}B8;
   text-align: center;
 `;
 
 export const SectionLabel = styled.span`
-  font-size: 11px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -78,7 +76,7 @@ export const BenefitRow = styled.div`
 `;
 
 export const BenefitEmoji = styled.span`
-  font-size: 22px;
+  font-size: ${({ theme }) => theme.typography.h2.fontSize};
   width: 36px;
   height: 36px;
   display: flex;
@@ -96,14 +94,13 @@ export const BenefitInfo = styled.div`
 `;
 
 export const BenefitTitle = styled.span`
-  font-size: 14px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.gray[800]};
   letter-spacing: -0.01em;
 `;
 
 export const BenefitDesc = styled.span`
-  font-size: 12px;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
 `;
 
@@ -115,8 +112,7 @@ export const InstallButton = styled.button`
   border-radius: 14px;
   background: ${({ theme }) => theme.color.point[500]};
   color: ${({ theme }) => theme.color.white};
-  font-size: 15px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.h4}
   letter-spacing: -0.01em;
   cursor: pointer;
   transition:
@@ -141,15 +137,13 @@ export const StatusBanner = styled.div<{ $type: 'installed' }>`
 `;
 
 export const StatusEmoji = styled.span`
-  font-size: 16px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.point[500]};
   flex-shrink: 0;
 `;
 
 export const StatusText = styled.span`
-  font-size: 14px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.point[500]};
 `;
 
@@ -165,8 +159,7 @@ export const GuideRow = styled.div`
 `;
 
 export const GuideBadge = styled.span`
-  font-size: 11px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.point[500]};
   background: ${({ theme }) => theme.color.point[50]};
   border: 1px solid ${({ theme }) => theme.color.point[100]};
@@ -178,6 +171,6 @@ export const GuideBadge = styled.span`
 `;
 
 export const GuideDesc = styled.span`
-  font-size: 13px;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[600]};
 `;

--- a/frontend/src/features/home/components/MenuTab/views/GameManualView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/GameManualView.styled.ts
@@ -18,8 +18,7 @@ export const HintBanner = styled.div`
 `;
 
 export const Subtitle = styled.p`
-  font-size: 13px;
-  font-weight: 500;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.point[500]};
   margin: 0;
   line-height: 1.5;

--- a/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/MyInfoView.styled.ts
@@ -56,8 +56,7 @@ export const StatCard = styled.div`
 `;
 
 export const StatLabel = styled.span`
-  font-size: ${({ theme }) => theme.typography.caption.fontSize};
-  font-weight: ${({ theme }) => theme.typography.paragraph.fontWeight};
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
   letter-spacing: -0.01em;
 `;
@@ -89,8 +88,7 @@ export const InfoSection = styled.div`
 `;
 
 export const SectionTitle = styled.h4`
-  font-size: ${({ theme }) => theme.typography.caption.fontSize};
-  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
   padding-left: 4px;
   letter-spacing: 0.06em;
@@ -106,7 +104,7 @@ export const TooltipCard = styled.div`
 `;
 
 export const TooltipList = styled.ul`
-  font-size: ${({ theme }) => theme.typography.small.fontSize};
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[500]};
   line-height: 1.7;
   list-style: none;
@@ -146,13 +144,11 @@ export const DangerRow = styled.button`
 `;
 
 export const DangerLabel = styled.span`
-  font-size: ${({ theme }) => theme.typography.small.fontSize};
-  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.point[500]};
 `;
 
 export const DangerIcon = styled.span`
-  font-size: ${({ theme }) => theme.typography.paragraph.fontSize};
-  font-weight: 300;
+  ${({ theme }) => theme.typography.paragraph}
   color: ${({ theme }) => theme.color.point[200]};
 `;

--- a/frontend/src/features/home/components/MenuTab/views/PatchNotesView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/PatchNotesView.styled.ts
@@ -18,8 +18,7 @@ export const ListSummary = styled.div`
 `;
 
 export const SummaryText = styled.p`
-  font-size: 13px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[500]};
   letter-spacing: -0.01em;
 `;
@@ -58,8 +57,7 @@ export const CategoryChip = styled.span<{ $category: PatchNoteCategory }>`
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  font-size: 11px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.caption}
   padding: 3px 8px;
   border-radius: 20px;
   letter-spacing: 0.01em;
@@ -76,8 +74,7 @@ export const CategoryChip = styled.span<{ $category: PatchNoteCategory }>`
 `;
 
 export const NewBadge = styled.span`
-  font-size: 10px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.caption}
   padding: 2px 6px;
   border-radius: 20px;
   background: ${({ theme }) => theme.color.point[400]};
@@ -86,15 +83,14 @@ export const NewBadge = styled.span`
 `;
 
 export const MetaDate = styled.span`
-  font-size: 11px;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
   margin-left: auto;
   letter-spacing: -0.01em;
 `;
 
 export const CardTitle = styled.h3`
-  font-size: 16px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.gray[900]};
   letter-spacing: -0.03em;
   line-height: 1.35;
@@ -102,7 +98,7 @@ export const CardTitle = styled.h3`
 `;
 
 export const CardPreview = styled.p`
-  font-size: 13px;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[500]};
   line-height: 1.7;
   margin: 0;
@@ -119,8 +115,7 @@ export const CardFooter = styled.div`
 `;
 
 export const CardReadMore = styled.span`
-  font-size: 12px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.point[400]};
   letter-spacing: -0.01em;
 `;
@@ -140,7 +135,7 @@ export const DetailMeta = styled.div`
 `;
 
 export const DetailBody = styled.p`
-  font-size: 15px;
+  ${({ theme }) => theme.typography.paragraph}
   color: ${({ theme }) => theme.color.gray[700]};
   line-height: 1.8;
   margin: 0;
@@ -166,20 +161,19 @@ export const EmptyIconWrap = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 36px;
+  font-size: ${({ theme }) => theme.typography.h1.fontSize};
   margin-bottom: 8px;
 `;
 
 export const EmptyTitle = styled.h3`
-  font-size: 20px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h2}
   color: ${({ theme }) => theme.color.gray[900]};
   letter-spacing: -0.03em;
   margin: 0;
 `;
 
 export const EmptyDesc = styled.p`
-  font-size: 14px;
+  ${({ theme }) => theme.typography.paragraph}
   color: ${({ theme }) => theme.color.gray[400]};
   text-align: center;
   line-height: 1.6;

--- a/frontend/src/features/home/components/MenuTab/views/ServiceInfoView.styled.ts
+++ b/frontend/src/features/home/components/MenuTab/views/ServiceInfoView.styled.ts
@@ -25,7 +25,7 @@ export const AppIcon = styled.div`
   width: 52px;
   height: 52px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.22);
+  background: ${({ theme }) => theme.color.white}38;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -46,15 +46,14 @@ export const AppMeta = styled.div`
 `;
 
 export const AppName = styled.span`
-  font-size: 17px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h3}
   color: ${({ theme }) => theme.color.white};
   letter-spacing: -0.02em;
 `;
 
 export const AppTagline = styled.span`
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.72);
+  ${({ theme }) => theme.typography.caption}
+  color: ${({ theme }) => theme.color.white}B8;
 `;
 
 export const InfoCard = styled.div`
@@ -79,13 +78,13 @@ export const InfoRow = styled.div`
 `;
 
 export const InfoLabel = styled.span`
-  font-size: 13px;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[500]};
 `;
 
 export const InfoValue = styled.span`
-  font-size: 13px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.small}
+  font-weight: ${({ theme }) => theme.typography.h4.fontWeight};
   color: ${({ theme }) => theme.color.gray[800]};
 `;
 
@@ -107,14 +106,12 @@ export const LinkRow = styled.a`
 `;
 
 export const LinkLabel = styled.span`
-  font-size: 13px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[800]};
 `;
 
 export const LinkIcon = styled.span`
-  font-size: 16px;
-  font-weight: 300;
+  ${({ theme }) => theme.typography.paragraph}
   color: ${({ theme }) => theme.color.gray[300]};
 `;
 

--- a/frontend/src/features/home/components/MenuTab/views/ServiceInfoView.tsx
+++ b/frontend/src/features/home/components/MenuTab/views/ServiceInfoView.tsx
@@ -14,7 +14,7 @@ const ServiceInfoView = () => {
         </S.AppIcon>
         <S.AppMeta>
           <S.AppName>쫄 (ZZOL)</S.AppName>
-          <S.AppTagline>미니게임 기반 당첨자 추첨 서비스</S.AppTagline>
+          <S.AppTagline>미니게임 기반 내기 서비스</S.AppTagline>
         </S.AppMeta>
       </S.AppHeader>
 

--- a/frontend/src/features/home/components/tabs/HomeTab/NewsCarousel/NewsCarousel.styled.ts
+++ b/frontend/src/features/home/components/tabs/HomeTab/NewsCarousel/NewsCarousel.styled.ts
@@ -35,7 +35,7 @@ export const NavChevron = styled.button`
   border: 1px solid ${({ theme }) => theme.color.gray[200]};
   background: ${({ theme }) => theme.color.white};
   color: ${({ theme }) => theme.color.gray[400]};
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.typography.h4.fontSize};
   line-height: 1;
   cursor: pointer;
   flex-shrink: 0;
@@ -88,8 +88,7 @@ export const Tag = styled.span`
   align-items: center;
   padding: 3px 8px;
   border-radius: 20px;
-  font-size: ${({ theme }) => theme.typography.caption.fontSize};
-  font-weight: 700;
+  ${({ theme }) => theme.typography.caption}
   letter-spacing: 0.03em;
   width: fit-content;
   background: ${({ theme }) => theme.color.point[50]};
@@ -104,24 +103,21 @@ export const CardTop = styled.div`
 `;
 
 export const Title = styled.span`
-  font-size: 15px;
-  font-weight: 700;
+  ${({ theme }) => theme.typography.h4}
   color: ${({ theme }) => theme.color.gray[900]};
   line-height: 1.4;
   letter-spacing: -0.01em;
 `;
 
 export const Date = styled.span`
-  font-size: 12px;
-  font-weight: 400;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
   flex-shrink: 0;
   padding-top: 2px;
 `;
 
 export const Body = styled.p`
-  font-size: 13px;
-  font-weight: 400;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[500]};
   line-height: 1.7;
   margin: 0;
@@ -132,8 +128,7 @@ export const Body = styled.p`
 `;
 
 export const ReadMore = styled.span`
-  font-size: 12px;
-  font-weight: 600;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.point[400]};
   margin-top: 2px;
   align-self: flex-end;
@@ -193,28 +188,26 @@ export const MoreIconCircle = styled.div`
   border-radius: 10px;
   background: ${({ theme }) => theme.color.point[50]};
   color: ${({ theme }) => theme.color.point[500]};
-  font-size: 18px;
+  font-size: ${({ theme }) => theme.typography.h3.fontSize};
   margin-bottom: 6px;
   flex-shrink: 0;
 `;
 
 export const MoreTitle = styled.span`
-  font-size: 17px;
-  font-weight: 800;
+  ${({ theme }) => theme.typography.h3}
   color: ${({ theme }) => theme.color.gray[900]};
   letter-spacing: -0.03em;
   line-height: 1.2;
 `;
 
 export const MoreSub = styled.span`
-  font-size: 13px;
-  font-weight: 400;
+  ${({ theme }) => theme.typography.small}
   color: ${({ theme }) => theme.color.gray[400]};
 `;
 
 export const MoreArrow = styled.span`
   align-self: flex-end;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.typography.h2.fontSize};
   color: ${({ theme }) => theme.color.gray[300]};
 `;
 
@@ -232,13 +225,12 @@ export const DetailMeta = styled.div`
 `;
 
 export const DetailDate = styled.span`
-  font-size: 12px;
+  ${({ theme }) => theme.typography.caption}
   color: ${({ theme }) => theme.color.gray[400]};
 `;
 
 export const DetailBody = styled.p`
-  font-size: 15px;
-  font-weight: 400;
+  ${({ theme }) => theme.typography.paragraph}
   color: ${({ theme }) => theme.color.gray[700]};
   line-height: 1.8;
   white-space: pre-wrap;

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -1,26 +1,7 @@
 import type { ComponentType } from 'react';
-import type {
-  TopWinner,
-  GamePlayCount,
-  LowestProbabilityWinner,
-  BlockStackingTopPlayer,
-  RacingGameTopPlayer,
-} from '@/types/dashBoard';
-import { MINI_GAME_NAME_MAP, type MiniGameType } from '@/types/miniGame/common';
-import {
-  TrophyIcon,
-  SkullIcon,
-  BlocksIcon,
-  GamepadIcon,
-  RacingCarIcon,
-} from '../components/RankingTab/rankingIcons';
-import {
-  MOCK_TOP_WINNERS,
-  MOCK_LOWEST_PROBABILITY,
-  MOCK_GAME_PLAY_COUNTS,
-  MOCK_BLOCK_STACKING_TOP_PLAYERS,
-  MOCK_RACING_GAME_TOP_PLAYERS,
-} from './dashboardMock';
+import type { BlockStackingTopPlayer, RacingGameTopPlayer } from '@/types/dashBoard';
+import { BlocksIcon, RacingCarIcon } from '../components/RankingTab/rankingIcons';
+import { MOCK_BLOCK_STACKING_TOP_PLAYERS, MOCK_RACING_GAME_TOP_PLAYERS } from './dashboardMock';
 
 export type RankingItem = {
   rank: number;
@@ -39,37 +20,6 @@ export type RankingCategory = {
 };
 
 export const RANKING_CATEGORIES: RankingCategory[] = [
-  {
-    key: 'top-winners',
-    label: '이번 달 당첨 랭킹',
-    icon: TrophyIcon,
-    endpoint: '/dashboard/top-winners',
-    mockRaw: MOCK_TOP_WINNERS,
-    transformData: (raw) =>
-      (raw as TopWinner[]).map((w, i) => ({
-        rank: i + 1,
-        name: w.nickname,
-        count: w.winCount,
-      })),
-  },
-  {
-    key: 'lowest-probability',
-    label: '최저 확률 당첨자',
-    icon: SkullIcon,
-    endpoint: '/dashboard/lowest-probability-winner',
-    mockRaw: MOCK_LOWEST_PROBABILITY,
-    transformData: (raw) => {
-      const data = raw as LowestProbabilityWinner;
-      if (!data?.players?.length) return [];
-      const probability = Math.round(data.probability * 10) / 10;
-      return data.players.map((p, i) => ({
-        rank: i + 1,
-        name: `${p.nickname} (${p.userCode})`,
-        count: probability,
-        unit: '%',
-      }));
-    },
-  },
   {
     key: 'blockstacking-top-players',
     label: '블록쌓기 최고 기록',
@@ -96,19 +46,6 @@ export const RANKING_CATEGORIES: RankingCategory[] = [
         name: p.playerName,
         count: Math.round(p.bestTime / 10) / 100,
         unit: '초',
-      })),
-  },
-  {
-    key: 'game-play-counts',
-    label: '게임 인기 순위',
-    icon: GamepadIcon,
-    endpoint: '/dashboard/game-play-counts',
-    mockRaw: MOCK_GAME_PLAY_COUNTS,
-    transformData: (raw) =>
-      (raw as GamePlayCount[]).map((g, i) => ({
-        rank: i + 1,
-        name: MINI_GAME_NAME_MAP[g.gameType as MiniGameType] || g.gameType,
-        count: g.playCount,
       })),
   },
 ];

--- a/frontend/src/hooks/useInstallPrompt.ts
+++ b/frontend/src/hooks/useInstallPrompt.ts
@@ -1,47 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useInstallPromptContext } from '@/contexts/InstallPrompt/InstallPromptContext';
 
-interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>;
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-}
-
-const useInstallPrompt = () => {
-  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [isInstalled, setIsInstalled] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches
-  );
-
-  useEffect(() => {
-    const handleBeforeInstall = (e: Event) => {
-      e.preventDefault();
-      setDeferredPrompt(e as BeforeInstallPromptEvent);
-    };
-    const handleAppInstalled = () => {
-      setIsInstalled(true);
-      setDeferredPrompt(null);
-    };
-
-    window.addEventListener('beforeinstallprompt', handleBeforeInstall);
-    window.addEventListener('appinstalled', handleAppInstalled);
-
-    return () => {
-      window.removeEventListener('beforeinstallprompt', handleBeforeInstall);
-      window.removeEventListener('appinstalled', handleAppInstalled);
-    };
-  }, []);
-
-  const install = useCallback(async () => {
-    if (!deferredPrompt) return;
-    await deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
-    if (outcome === 'accepted') setDeferredPrompt(null);
-  }, [deferredPrompt]);
-
-  return {
-    isInstallable: deferredPrompt !== null,
-    isInstalled,
-    install,
-  };
-};
+const useInstallPrompt = () => useInstallPromptContext();
 
 export default useInstallPrompt;


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1279

# 🚀 작업 내용

1. **랭킹 탭 문구 변경** — "이번달 가장 짜릿한 역전" → "이번 달 가장 행복한 당첨자~"
2. **전체랭킹 중복 항목 제거** — `이번 달 당첨랭킹`, `최저 확률 당첨자`, `게임 인기 순위` 3개 카테고리 제거 (DashBoard 슬라이드와 중복)
3. **서비스 소개 문구 변경** — "미니게임 기반 당첨자 추첨 서비스" → "미니게임 기반 내기 서비스"
4. **스타일 컨벤션 적용** — 더보기 탭 전체(MenuTab views, NewsCarousel) `font-size`/`font-weight` 하드코딩 → `theme.typography.*` full spread 전환, `rgba(255,255,255,N)` → hex opacity 패턴 전환
5. **PWA 설치 프롬프트 컨텍스트 분리** — `useInstallPrompt` 훅 내 이벤트 리스너를 `InstallPromptProvider`로 앱 루트에 끌어올려 `beforeinstallprompt` 이벤트 유실 방지
6. **ADR 갱신** — `20260515-ranking-api-separate-endpoints.md` status를 `amended`로 변경, 제거된 카테고리 및 엔드포인트 소비처 명문화

# 💬 리뷰 중점사항

- **타이포그래피 시각 변화**: full spread 전환으로 일부 요소의 `font-weight`가 함께 변경됨 (예: `CategoryChip` 700→400, `CardTitle` 800→600, `LinkIcon` 300→500). 의도된 디자인 방향과 맞는지 확인 필요
- **`InstallPromptContext` null 패턴**: Provider 외부 호출 시 에러를 throw하도록 설계. 기존 다른 Context들과 동일한 패턴
- **`game-play-counts` 엔드포인트**: 랭킹 탭에서 제거 후 현재 FE 미사용 상태. 백엔드 엔드포인트는 유지 중