### PR TITLE
[chore] CI 브랜치 삭제 시 GitHub 500 에러로 워크플로우 실패 수정

### DIFF
--- a/.github/workflows/be-delete-merged-branch.yml
+++ b/.github/workflows/be-delete-merged-branch.yml
@@ -11,13 +11,16 @@ jobs:
   delete-branch:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Get branch name
         id: branch-name
@@ -27,24 +30,31 @@ jobs:
           echo "Merged branch: $BRANCH_NAME"
 
       - name: Delete merged branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH_NAME="${{ steps.branch-name.outputs.branch }}"
-          
-          # 보호된 브랜치들은 삭제하지 않음 (main, master, develop, be/dev 등)
+
           PROTECTED_BRANCHES=("main" "fe/dev" "fe/prod" "be/dev" "be/prod")
-          
+
           for protected in "${PROTECTED_BRANCHES[@]}"; do
             if [[ "$BRANCH_NAME" == "$protected" ]]; then
               echo "⚠️  Protected branch '$BRANCH_NAME' will not be deleted"
               exit 0
             fi
           done
-          
-          # 브랜치가 존재하는지 확인
-          if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+
+          if [ -n "$(git ls-remote --heads origin "refs/heads/$BRANCH_NAME")" ]; then
             echo "🗑️  Deleting branch: $BRANCH_NAME"
-            git push origin --delete "$BRANCH_NAME"
-            echo "✅ Branch '$BRANCH_NAME' has been deleted successfully"
+            for i in 1 2 3; do
+              if gh api --method DELETE "repos/${{ github.repository }}/git/refs/heads/$BRANCH_NAME"; then
+                echo "✅ Branch '$BRANCH_NAME' has been deleted successfully (attempt $i)"
+                exit 0
+              fi
+              echo "⚠️  Attempt $i failed, retrying in $((i * 3))s..."
+              sleep $((i * 3))
+            done
+            echo "::warning::Failed to delete branch $BRANCH_NAME after 3 attempts"
           else
             echo "ℹ️  Branch '$BRANCH_NAME' does not exist or already deleted"
           fi
@@ -54,10 +64,8 @@ jobs:
         with:
           script: |
             const branchName = '${{ steps.branch-name.outputs.branch }}';
-            
-            // 보호된 브랜치 체크
-            const protectedBranches = ['main', 'fe/prod', 'fe/dev', 'be/dev', 'be/prod'];
-            
+            const protectedBranches = ['main', 'fe/dev', 'fe/prod', 'be/dev', 'be/prod'];
+
             if (protectedBranches.includes(branchName)) {
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
@@ -74,7 +82,6 @@ jobs:
               });
             }
 
-  # 선택사항: 삭제된 브랜치들을 추적하는 잡
   log-deleted-branch:
     if: github.event.pull_request.merged == true
     needs: delete-branch
@@ -89,4 +96,3 @@ jobs:
           echo "- Merged branch: ${{ github.head_ref }}"
           echo "- Target branch: ${{ github.base_ref }}"
           echo "- Merge time: $(date -u)"
-          


### PR DESCRIPTION
## Summary
- `git push --delete` → `gh api --method DELETE` + 3회 retry(backoff)로 교체해 GitHub 500 에러 대응
- `git ls-remote | grep` 정규식 오탐 제거 → `refs/heads/$BRANCH_NAME` 직접 판정
- `permissions: contents/pull-requests: write` 명시 (미선언 시 조직 기본 설정에 따라 403 무음 실패 가능)
- 보호 브랜치 목록 shell/JS 불일치 수정, `fetch-depth: 0 → 1` 최적화
- 최종 실패 시 `::warning::` annotation으로 Actions UI 가시성 확보

## Test plan
- [ ] `be/dev`로 PR 머지 후 워크플로우 실행 확인
- [ ] 브랜치 삭제 완료 로그 및 PR 코멘트 정상 출력 확인

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 병합된 브랜치 자동 삭제 워크플로우의 안정성 및 신뢰성 향상
* 브랜치 삭제 실패 시 최대 3회 자동 재시도 메커니즘 구현
* 삭제 전 브랜치 존재 여부 확인 프로세스 추가
* 브랜치 삭제 처리 절차 및 권한 설정 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-zzol/pull/1294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->