### PR TITLE
[fix] 블록 쌓기 게임 속도 밸런스 조정 및 코드 리팩터링

### DIFF
--- a/frontend/src/contexts/BlockStackingGame/BlockStackingGameProvider.tsx
+++ b/frontend/src/contexts/BlockStackingGame/BlockStackingGameProvider.tsx
@@ -1,9 +1,9 @@
 import { useWebSocketSubscription } from '@/apis/websocket/hooks/useWebSocketSubscription';
 import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { BlockStackingGameState } from '@/types/miniGame/blockStackingGame';
-import { PropsWithChildren, useCallback, useState } from 'react';
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 import { BlockStackingGameContext } from './BlockStackingGameContext';
-import { GAME_DURATION } from '@/features/miniGame/blockStackingGame/constants/blockStackingConstants';
+import { GAME_DURATION } from '@/features/miniGame/blockStackingGame/constants/blockStackingBalance';
 
 type BlockStackingRanking = { name: string; floor: number };
 
@@ -43,19 +43,20 @@ const BlockStackingGameProvider = ({ children }: PropsWithChildren) => {
     }, [])
   );
 
+  const value = useMemo(
+    () => ({
+      gameState,
+      rankings,
+      isLocalGameOver,
+      setLocalGameOver,
+      endTimeEpochMs,
+      totalTimeSeconds,
+    }),
+    [gameState, rankings, isLocalGameOver, setLocalGameOver, endTimeEpochMs, totalTimeSeconds]
+  );
+
   return (
-    <BlockStackingGameContext.Provider
-      value={{
-        gameState,
-        rankings,
-        isLocalGameOver,
-        setLocalGameOver,
-        endTimeEpochMs,
-        totalTimeSeconds,
-      }}
-    >
-      {children}
-    </BlockStackingGameContext.Provider>
+    <BlockStackingGameContext.Provider value={value}>{children}</BlockStackingGameContext.Provider>
   );
 };
 

--- a/frontend/src/features/miniGame/blockStackingGame/constants/blockStackingBalance.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/constants/blockStackingBalance.ts
@@ -1,0 +1,8 @@
+export const INITIAL_SPEED = 3.2;
+export const SPEED_INCREMENT = 1.05; // 5% per floor
+export const MAX_SPEED = 8.0;
+export const GAME_DURATION = 20;
+export const PERFECT_THRESHOLD = 3;
+
+export const getBlockSpeed = (floor: number): number =>
+  Math.min(INITIAL_SPEED * Math.pow(SPEED_INCREMENT, floor), MAX_SPEED);

--- a/frontend/src/features/miniGame/blockStackingGame/constants/blockStackingConstants.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/constants/blockStackingConstants.ts
@@ -5,19 +5,8 @@ export const BLOCK_GAP = 2;
 export const INITIAL_BLOCK_WIDTH = 150;
 export const INITIAL_BLOCK_X = (CANVAS_WIDTH - INITIAL_BLOCK_WIDTH) / 2; // 60
 export const CURRENT_BLOCK_Y = 155; // default Y, but we will make it dynamic
-export const PERFECT_THRESHOLD = 3; // px — tolerance for "perfect" alignment
-
-export const GAME_DURATION = 20; // 20 seconds limit
 export const GRAVITY = 0.4;
 export const OPACITY_DECAY = 0.025;
-
-export const INITIAL_SPEED = 3.3;
-export const SPEED_INCREMENT = 1.06; // 6% per floor
-
-export const getBlockSpeed = (floor: number): number => {
-  const speed = INITIAL_SPEED * Math.pow(SPEED_INCREMENT, floor);
-  return Math.min(speed, 18.0); // Safety cap at 18.0
-};
 
 export const BLOCK_COLORS = [
   '#FF6B6B',

--- a/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingActions.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingActions.ts
@@ -15,9 +15,7 @@ export const useBlockStackingActions = () => {
 
   const publishProgress = useCallback(
     (payload: BlockStackingProgressPayload) => {
-      send(`/room/${joinCode}/block-stacking/progress`, {
-        ...payload,
-      });
+      send(`/room/${joinCode}/block-stacking/progress`, payload);
     },
     [joinCode, send]
   );

--- a/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
@@ -13,10 +13,12 @@ import {
   GRAVITY,
   INITIAL_BLOCK_WIDTH,
   OPACITY_DECAY,
-  PERFECT_THRESHOLD,
+} from '@/features/miniGame/blockStackingGame/constants/blockStackingConstants';
+import {
   GAME_DURATION,
+  PERFECT_THRESHOLD,
   getBlockSpeed,
-} from '../constants/blockStackingConstants';
+} from '@/features/miniGame/blockStackingGame/constants/blockStackingBalance';
 import { BlockStackingProgressPayload } from './useBlockStackingActions';
 import { useBlockStackingSounds } from './useBlockStackingSounds';
 
@@ -99,6 +101,55 @@ const updateFallingPieces = (pieces: FallingPiece[], H: number, dt60: number) =>
     .filter((p) => p.opacity > 0 && p.y < H + 100);
 };
 
+/** cur 를 in-place 로 변이한다 (RAF 루프 alloc 회피). */
+const updateCurrentBlock = (cur: CurrentBlock, speed: number, dt60: number, W: number) => {
+  let nx = cur.x + speed * dt60 * cur.direction;
+  let nd = cur.direction;
+  if (nx <= 0) {
+    nx = 0;
+    nd = 1;
+  } else if (nx + cur.width >= W) {
+    nx = W - cur.width;
+    nd = -1;
+  }
+  cur.x = nx;
+  cur.direction = nd;
+};
+
+const toFallingPiece = (x: number, y: number, width: number, color: string): FallingPiece => ({
+  x,
+  y,
+  width,
+  vy: 1,
+  opacity: 1,
+  color,
+});
+
+const createOverhangPieces = ({
+  blockX,
+  blockWidth,
+  leftEdge,
+  rightEdge,
+  y,
+  color,
+}: {
+  blockX: number;
+  blockWidth: number;
+  leftEdge: number;
+  rightEdge: number;
+  y: number;
+  color: string;
+}): FallingPiece[] => {
+  const pieces: FallingPiece[] = [];
+  if (blockX < leftEdge) {
+    pieces.push(toFallingPiece(blockX, y, leftEdge - blockX, color));
+  }
+  if (blockX + blockWidth > rightEdge) {
+    pieces.push(toFallingPiece(rightEdge, y, blockX + blockWidth - rightEdge, color));
+  }
+  return pieces;
+};
+
 /**
  * 블록 쌓기 게임의 핵심 로직을 담당하는 커스텀 훅
  * 캔버스 렌더링, 물리 연산, 게임 상태 관리, 타이머 동기화 등을 수행합니다.
@@ -178,14 +229,9 @@ export const useBlockStackingGame = (
 
     // [Case A] 완전히 빗나간 경우: 게임 오버 처리
     if (overlap <= 0) {
-      fallingPiecesRef.current.push({
-        x: cur.x,
-        y: cameraYRef.current,
-        width: cur.width,
-        vy: 1,
-        opacity: 1,
-        color: currentColor,
-      });
+      fallingPiecesRef.current.push(
+        toFallingPiece(cur.x, cameraYRef.current, cur.width, currentColor)
+      );
 
       shakeRef.current = { intensity: 12, startTime: performance.now(), duration: 500 };
       soundsRef.current.playGameOver();
@@ -201,28 +247,14 @@ export const useBlockStackingGame = (
 
     // 퍼펙트가 아닐 경우 잘려나가는 조각들 생성
     if (!isPerfect) {
-      const newPieces: FallingPiece[] = [];
-      const currentY = cameraYRef.current;
-      if (cur.x < leftEdge) {
-        newPieces.push({
-          x: cur.x,
-          y: currentY,
-          width: leftEdge - cur.x,
-          vy: 1,
-          opacity: 1,
-          color: currentColor,
-        });
-      }
-      if (cur.x + cur.width > rightEdge) {
-        newPieces.push({
-          x: rightEdge,
-          y: currentY,
-          width: cur.x + cur.width - rightEdge,
-          vy: 1,
-          opacity: 1,
-          color: currentColor,
-        });
-      }
+      const newPieces = createOverhangPieces({
+        blockX: cur.x,
+        blockWidth: cur.width,
+        leftEdge,
+        rightEdge,
+        y: cameraYRef.current,
+        color: currentColor,
+      });
       fallingPiecesRef.current = [...fallingPiecesRef.current, ...newPieces];
     }
 
@@ -365,19 +397,7 @@ export const useBlockStackingGame = (
 
       // [Update Logic] 게임 중일 때만 블록 이동
       if (!isGameOver) {
-        const cur = currentBlockRef.current;
-        const speed = getBlockSpeed(scoreRef.current);
-        let nx = cur.x + speed * dt60 * cur.direction;
-        let nd = cur.direction;
-        if (nx <= 0) {
-          nx = 0;
-          nd = 1;
-        } else if (nx + cur.width >= W) {
-          nx = W - cur.width;
-          nd = -1;
-        }
-        currentBlockRef.current.x = nx;
-        currentBlockRef.current.direction = nd;
+        updateCurrentBlock(currentBlockRef.current, getBlockSpeed(scoreRef.current), dt60, W);
       }
 
       // [Camera Logic] 카메라 팔로우 부드럽게 이동


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1291

# 🚀 작업 내용

1. **속도 밸런스 조정** — 19층 이후 속도 고정으로 고층 구간 플레이 개선
   - `INITIAL_SPEED` 3.3 → 3.2, `SPEED_INCREMENT` 1.06 → 1.05 (5%/층), `MAX_SPEED` 18.0 → 8.0
2. **`blockStackingBalance.ts` 신규 생성** — 밸런스 튜닝 상수(`INITIAL_SPEED`, `SPEED_INCREMENT`, `MAX_SPEED`, `GAME_DURATION`, `PERFECT_THRESHOLD`, `getBlockSpeed`)를 렌더링 상수와 분리해 단일 파일에서 관리
3. **모듈 레벨 함수 추출** (`useBlockStackingGame.ts`)
   - `updateCurrentBlock` — RAF 루프 내 블록 이동 로직 추출 (in-place 변이, alloc 회피)
   - `toFallingPiece` — FallingPiece 생성 팩토리 (Case A·B 공유)
   - `createOverhangPieces` — 오버행 조각 생성 로직 추출, 객체 인자로 파라미터 가독성 개선
4. **`BlockStackingGameProvider` context value `useMemo` 안정화** — 매 렌더마다 새 객체 생성으로 인한 불필요한 소비 컴포넌트 리렌더 방지
5. **`publishProgress` 불필요한 spread 제거** (`useBlockStackingActions.ts`)
6. **import 경로 `@/` 절대경로 통일** (`useBlockStackingGame.ts`)

# 💬 리뷰 중점사항

- `updateCurrentBlock`이 `cur`(ref 객체)를 **in-place 변이**하는 패턴 — RAF 루프에서 객체 할당을 피하려는 의도이며, ref 내부값은 React 렌더 사이클 밖이라 불변성 규칙 적용 대상 아님
- `MAX_SPEED = 8.0` 기준 19층부터 속도 고정 — 체감 테스트 후 수치 조정이 필요하다면 `blockStackingBalance.ts` 한 곳만 수정