### PR TITLE
[fix] 방 퇴장 시 lastStreamId 스토리지 누적 해결 및 WebSocket 복구 로직 리팩터링

### DIFF
--- a/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/WebSocketProvider.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback, useRef, useSyncExternalStore } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   fetchRecoveryMessages,
@@ -16,10 +16,18 @@ import { WebSocketContext, WebSocketContextType } from './WebSocketContext';
 
 const TOPIC_PREFIX = '/topic';
 
-const SCREEN_TRANSITION_PATTERNS = ['/roulette', '/winner', '/round'] as const;
+const RECOVERY_INITIAL_DELAY_MS = 500;
+const RECOVERY_RETRY_DELAY_MS = 300;
+const RECOVERY_COMPLETE_DELAY_MS = 2000;
+
+const SCREEN_TRANSITION_PATTERNS = {
+  WINNER: '/winner',
+  ROULETTE: '/roulette',
+  ROUND: '/round',
+} as const;
 
 const isScreenTransitionMessage = (destination: string): boolean => {
-  return SCREEN_TRANSITION_PATTERNS.some((pattern) => destination.includes(pattern));
+  return Object.values(SCREEN_TRANSITION_PATTERNS).some((pattern) => destination.includes(pattern));
 };
 
 const extractSubscriptionPath = (destination: string): string => {
@@ -56,25 +64,30 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
 
   const { client, isConnected, startSocket, stopSocket, connectedFrame } = useWebSocketConnection();
   const { sessionId } = useStompSessionWatcher(client, connectedFrame);
-  const { subscribe, send } = useWebSocketMessaging({ client, isConnected, playerName: myName });
+  const { subscribe, send } = useWebSocketMessaging({
+    client,
+    isConnected,
+    playerName: myName,
+    joinCode,
+  });
 
   const routeRecoveryMessage = useCallback(
     (destination: string) => {
       const navOptions = { replace: true, state: { fromInternal: true } };
 
-      if (destination.includes('/roulette') && !destination.includes('/winner')) {
-        console.log('🔄 복구: 룰렛 화면으로 이동');
-        navigate(`/room/${joinCode}/roulette/play`, navOptions);
-        return true;
-      }
-
-      if (destination.includes('/winner')) {
+      if (destination.includes(SCREEN_TRANSITION_PATTERNS.WINNER)) {
         console.log('🔄 복구: 당첨자 화면으로 이동');
         navigate(`/room/${joinCode}/roulette/result`, navOptions);
         return true;
       }
 
-      if (destination.includes('/round')) {
+      if (destination.includes(SCREEN_TRANSITION_PATTERNS.ROULETTE)) {
+        console.log('🔄 복구: 룰렛 화면으로 이동');
+        navigate(`/room/${joinCode}/roulette/play`, navOptions);
+        return true;
+      }
+
+      if (destination.includes(SCREEN_TRANSITION_PATTERNS.ROUND)) {
         console.log('🔄 복구: 게임 시작 - 핸들러에게 위임');
         return false;
       }
@@ -113,7 +126,9 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
     // 동기적으로 설정
     setIsRecoveringGlobal(true);
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, RECOVERY_INITIAL_DELAY_MS));
+
+    if (!joinCode) return;
 
     console.log('🔄 메시지 복구 시작:', { joinCode, myName, lastStreamId });
 
@@ -128,7 +143,8 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
       }
 
       console.log(`🔄 복구 재시도 ${attempt + 1}/${MAX_RETRY}`);
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, RECOVERY_RETRY_DELAY_MS));
+      if (!joinCode) return;
     }
 
     if (messages.length === 0) {
@@ -170,8 +186,18 @@ export const WebSocketProvider = ({ children }: PropsWithChildren) => {
 
     recoveryTimeoutRef.current = setTimeout(() => {
       setIsRecoveringGlobal(false);
-    }, 2000);
+    }, RECOVERY_COMPLETE_DELAY_MS);
   }, [joinCode, myName, routeRecoveryMessage, dispatchToSubscribers]);
+
+  useEffect(() => {
+    if (!joinCode) {
+      setIsRecoveringGlobal(false);
+      if (recoveryTimeoutRef.current) {
+        clearTimeout(recoveryTimeoutRef.current);
+        recoveryTimeoutRef.current = null;
+      }
+    }
+  }, [joinCode]);
 
   useWebSocketReconnection({
     isConnected,

--- a/frontend/src/apis/websocket/hooks/useWebSocketMessaging.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketMessaging.ts
@@ -8,14 +8,10 @@ type Props = {
   client: Client | null;
   isConnected: boolean;
   playerName: string | null;
+  joinCode: string;
 };
 
-const extractJoinCodeFromDestination = (destination: string): string | null => {
-  const match = destination.match(/\/room\/([^/]+)/);
-  return match ? match[1] : null;
-};
-
-export const useWebSocketMessaging = ({ client, isConnected, playerName }: Props) => {
+export const useWebSocketMessaging = ({ client, isConnected, playerName, joinCode }: Props) => {
   const subscribe = useCallback(
     <T>(url: string, onData: (data: T) => void, onError?: (error: Error) => void) => {
       if (!client || !isConnected) {
@@ -45,11 +41,8 @@ export const useWebSocketMessaging = ({ client, isConnected, playerName }: Props
             return;
           }
 
-          if (parsedMessage.id && playerName) {
-            const joinCode = extractJoinCodeFromDestination(url);
-            if (joinCode) {
-              saveLastStreamId(joinCode, playerName, parsedMessage.id);
-            }
+          if (parsedMessage.id && joinCode && playerName) {
+            saveLastStreamId(joinCode, playerName, parsedMessage.id);
           }
 
           onData(parsedMessage.data);
@@ -63,7 +56,7 @@ export const useWebSocketMessaging = ({ client, isConnected, playerName }: Props
         }
       });
     },
-    [client, isConnected, playerName]
+    [client, isConnected, playerName, joinCode]
   );
 
   const send = useCallback(

--- a/frontend/src/contexts/Identifier/IdentifierProvider.tsx
+++ b/frontend/src/contexts/Identifier/IdentifierProvider.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react';
+import { clearLastStreamId } from '@/apis/rest/recovery';
 import { storageManager, STORAGE_KEYS } from '@/utils/StorageManager';
 import { IdentifierContext } from './IdentifierContext';
 
@@ -76,8 +77,12 @@ export const IdentifierProvider = ({ children }: PropsWithChildren) => {
 
   const clearIdentifier = useCallback(() => {
     const currentJoinCode = joinCodeRef.current;
+    const currentMyName = myNameRef.current;
     if (currentJoinCode) {
       storageManager.setItem(STORAGE_KEYS.LAST_JOIN_CODE, currentJoinCode, 'localStorage');
+      if (currentMyName) {
+        clearLastStreamId(currentJoinCode, currentMyName);
+      }
     }
     clearJoinCode();
     clearMyName();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1298

# 🚀 작업 내용

1. **`IdentifierProvider` — 방 퇴장 시 lastStreamId 자동 정리**
   - `clearIdentifier` 내 `if (currentJoinCode && currentMyName)` 조건 하에 `clearLastStreamId` 호출
   - 퇴장 경로(직접 나가기, 방 삭제 감지, kick 등) 모두 `clearIdentifier`를 거치므로 분산 처리 불필요

2. **`WebSocketProvider` — joinCode 초기화 시 복구 상태 리셋 (race condition 방어)**
   - `joinCode`가 빈 문자열이 되는 시점에 `setIsRecoveringGlobal(false)` + `recoveryTimeoutRef` clear
   - `handleReconnected` 내 각 `await` 이후 `joinCode` 유효성 재확인 — 퇴장 후 이전 방으로 `navigate` 오작동 방지

3. **`useWebSocketMessaging` — joinCode regex 파싱 제거**
   - `extractJoinCodeFromDestination` (destination에서 regex로 joinCode 역추출) 삭제
   - `joinCode`를 prop으로 직접 수신하도록 변경 (`string` 타입, IdentifierContext 실제 타입과 일치)

4. **`WebSocketProvider` — SCREEN_TRANSITION_PATTERNS 통일**
   - 배열 → 객체(`{ WINNER, ROULETTE, ROUND }`)로 변환
   - `routeRecoveryMessage` 내 문자열 리터럴을 상수로 교체해 중복 제거
   - winner → roulette 체크 순서 변경으로 `&& !includes('/winner')` 보호 조건 단순화 (동등성 증명 완료)

5. **`WebSocketProvider` — 복구 딜레이 상수 추출**
   - `500` → `RECOVERY_INITIAL_DELAY_MS`
   - `300` → `RECOVERY_RETRY_DELAY_MS`
   - `2000` → `RECOVERY_COMPLETE_DELAY_MS`

# 💬 리뷰 중점사항

- **`clearIdentifier` 호출 타이밍**: `clearJoinCode()` 이전에 `clearLastStreamId`를 호출해 ref가 유효한 시점에 키를 정확히 제거합니다. `lastStreamId:{joinCode}:{playerName}` 키 포맷이 `recovery.ts`와 일치하는지 확인 부탁드립니다.
- **race condition 처리 범위**: `isRecoveringGlobal` 플래그 리셋과 타이머 정리는 추가했으나, `handleReconnected`의 async 클로저가 캡처한 `joinCode`는 클로저 시점 값입니다. 각 `await` 이후 `if (!joinCode) return` 가드로 방어했지만, 클로저 내 `joinCode`는 stale할 수 있어 이 가드가 항상 최신 값을 반영하지 않을 수 있습니다. 이 구조적 한계는 모듈 레벨 상태(`isRecoveringGlobal`) + async 클로저 조합에서 기인하며, 근본 해결은 별도 이슈로 분리하는 것이 적절하다고 판단했습니다.
- **`joinCode: string` 타입**: 기존 `string | null`에서 변경. IdentifierContext의 실제 타입(`string`, 빈 문자열로 "없음" 표현)과 맞췄으며, `''`은 falsy 가드에서 자연스럽게 처리됩니다.