### PR TITLE
[fix] Consumer 미등록 이벤트 수신 시 서비스 정지 방지

### DIFF
--- a/backend/game/src/main/java/coffeeshout/blindtimer/domain/event/BlindTimerProgressEvent.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/domain/event/BlindTimerProgressEvent.java
@@ -3,14 +3,14 @@ package coffeeshout.blindtimer.domain.event;
 import coffeeshout.blindtimer.domain.BlindTimerGame;
 import java.util.List;
 
-public record BlindTimerProgressEvent(String joinCode, List<PlayerProgress> players) {
+public record BlindTimerProgressEvent(String joinCode, List<BlindTimerPlayerProgress> players) {
 
-    public record PlayerProgress(String playerName, boolean stopped, boolean timedOut) {
+    public record BlindTimerPlayerProgress(String playerName, boolean stopped, boolean timedOut) {
     }
 
     public static BlindTimerProgressEvent of(BlindTimerGame game, String joinCode) {
-        final List<PlayerProgress> progresses = game.getPlayers().stream()
-                .map(p -> new PlayerProgress(
+        final List<BlindTimerPlayerProgress> progresses = game.getPlayers().stream()
+                .map(p -> new BlindTimerPlayerProgress(
                         p.getPlayer().getName().value(),
                         p.isStopped(),
                         p.isTimedOut()

--- a/backend/game/src/main/java/coffeeshout/blindtimer/ui/response/BlindTimerProgressResponse.java
+++ b/backend/game/src/main/java/coffeeshout/blindtimer/ui/response/BlindTimerProgressResponse.java
@@ -1,10 +1,10 @@
 package coffeeshout.blindtimer.ui.response;
 
 import coffeeshout.blindtimer.domain.event.BlindTimerProgressEvent;
-import coffeeshout.blindtimer.domain.event.BlindTimerProgressEvent.PlayerProgress;
+import coffeeshout.blindtimer.domain.event.BlindTimerProgressEvent.BlindTimerPlayerProgress;
 import java.util.List;
 
-public record BlindTimerProgressResponse(List<PlayerProgress> players) {
+public record BlindTimerProgressResponse(List<BlindTimerPlayerProgress> players) {
 
     public static BlindTimerProgressResponse from(BlindTimerProgressEvent event) {
         return new BlindTimerProgressResponse(event.players());

--- a/backend/game/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchProgressEvent.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/domain/event/SpeedTouchProgressEvent.java
@@ -4,14 +4,14 @@ import coffeeshout.speedtouch.domain.SpeedTouchGame;
 import coffeeshout.speedtouch.domain.SpeedTouchPlayer;
 import java.util.List;
 
-public record SpeedTouchProgressEvent(String joinCode, List<PlayerProgress> players) {
+public record SpeedTouchProgressEvent(String joinCode, List<SpeedTouchPlayerProgress> players) {
 
-    public record PlayerProgress(String playerName, int currentNumber, boolean finished) {
+    public record SpeedTouchPlayerProgress(String playerName, int currentNumber, boolean finished) {
     }
 
     public static SpeedTouchProgressEvent of(SpeedTouchGame game, String joinCode) {
-        final List<PlayerProgress> progresses = game.getPlayers().stream()
-                .map(p -> new PlayerProgress(
+        final List<SpeedTouchPlayerProgress> progresses = game.getPlayers().stream()
+                .map(p -> new SpeedTouchPlayerProgress(
                         p.getPlayer().getName().value(),
                         p.getCurrentNumber(),
                         p.isFinished()

--- a/backend/game/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchProgressResponse.java
+++ b/backend/game/src/main/java/coffeeshout/speedtouch/ui/response/SpeedTouchProgressResponse.java
@@ -1,10 +1,10 @@
 package coffeeshout.speedtouch.ui.response;
 
 import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent;
-import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent.PlayerProgress;
+import coffeeshout.speedtouch.domain.event.SpeedTouchProgressEvent.SpeedTouchPlayerProgress;
 import java.util.List;
 
-public record SpeedTouchProgressResponse(List<PlayerProgress> players) {
+public record SpeedTouchProgressResponse(List<SpeedTouchPlayerProgress> players) {
 
     public static SpeedTouchProgressResponse from(SpeedTouchProgressEvent event) {
         return new SpeedTouchProgressResponse(event.players());

--- a/backend/infra/src/main/java/coffeeshout/global/redis/ConsumerStartupValidator.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/ConsumerStartupValidator.java
@@ -1,0 +1,54 @@
+package coffeeshout.global.redis;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConsumerStartupValidator implements SmartInitializingSingleton {
+
+    private static final String BASE_PACKAGE = "coffeeshout";
+
+    private final ApplicationContext applicationContext;
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        final Reflections reflections = new Reflections(BASE_PACKAGE);
+        final Set<Class<? extends BaseEvent>> eventTypes = reflections.getSubTypesOf(BaseEvent.class);
+
+        final List<String> missing = new ArrayList<>();
+        for (Class<? extends BaseEvent> eventType : eventTypes) {
+            if (isAbstractOrInterface(eventType)) {
+                continue;
+            }
+            final ResolvableType type = ResolvableType.forClassWithGenerics(Consumer.class, eventType);
+            if (applicationContext.getBeanProvider(type).getIfAvailable() == null) {
+                missing.add(eventType.getName());
+            }
+        }
+
+        if (missing.isEmpty()) {
+            log.info("모든 BaseEvent 타입에 Consumer가 등록되어 있습니다 ({}개)", eventTypes.size());
+            return;
+        }
+        missing.forEach(eventType -> log.error("Consumer 없음: {}", eventType));
+        throw new IllegalStateException(
+                "Consumer가 등록되지 않은 이벤트 타입 " + missing.size() + "개 — 위 로그를 확인하세요"
+        );
+    }
+
+    private boolean isAbstractOrInterface(Class<?> clazz) {
+        return clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers());
+    }
+}

--- a/backend/infra/src/main/java/coffeeshout/global/redis/ConsumerStartupValidator.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/ConsumerStartupValidator.java
@@ -10,11 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class ConsumerStartupValidator implements SmartInitializingSingleton {
 

--- a/backend/infra/src/main/java/coffeeshout/global/redis/EventDispatcher.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/EventDispatcher.java
@@ -25,7 +25,11 @@ public class EventDispatcher {
         try {
             recordLatency(event);
 
-            final Consumer<BaseEvent> consumer = (Consumer<BaseEvent>) getConsumer(event.getClass());
+            final Consumer<BaseEvent> consumer = (Consumer<BaseEvent>) findConsumer(event.getClass());
+            if (consumer == null) {
+                log.warn("등록된 Consumer 없음, 이벤트를 건너뜁니다: eventType={}", event.getClass().getSimpleName());
+                return;
+            }
             final Runnable handling = () -> consumer.accept(event);
 
             if (event instanceof Traceable traceable) {
@@ -47,9 +51,9 @@ public class EventDispatcher {
         }
     }
 
-    private <T extends BaseEvent> Consumer<T> getConsumer(Class<T> eventType) {
+    private <T extends BaseEvent> Consumer<T> findConsumer(Class<T> eventType) {
         final ResolvableType type = ResolvableType.forClassWithGenerics(Consumer.class, eventType);
         final ObjectProvider<Consumer<T>> provider = applicationContext.getBeanProvider(type);
-        return provider.getObject();
+        return provider.getIfAvailable();
     }
 }

--- a/backend/room/src/main/java/coffeeshout/room/domain/event/RouletteShownEvent.java
+++ b/backend/room/src/main/java/coffeeshout/room/domain/event/RouletteShownEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.room.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.trace.TraceInfo;
 import coffeeshout.global.trace.TraceInfoExtractor;
 import coffeeshout.global.trace.Traceable;
@@ -14,7 +13,7 @@ public record RouletteShownEvent(
         Instant timestamp,
         String joinCode,
         RoomState roomState
-) implements BaseEvent, Traceable {
+) implements Traceable {
 
     public RouletteShownEvent(String joinCode, RoomState roomState) {
         this(

--- a/backend/room/src/main/java/coffeeshout/room/domain/event/RouletteWinnerEvent.java
+++ b/backend/room/src/main/java/coffeeshout/room/domain/event/RouletteWinnerEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.room.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.global.trace.TraceInfo;
 import coffeeshout.global.trace.TraceInfoExtractor;
 import coffeeshout.global.trace.Traceable;
@@ -14,7 +13,7 @@ public record RouletteWinnerEvent(
         Instant timestamp,
         String joinCode,
         Winner winner
-) implements BaseEvent, Traceable {
+) implements Traceable {
 
     public RouletteWinnerEvent(String joinCode, Winner winner) {
         this(

--- a/backend/room/src/main/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumer.java
+++ b/backend/room/src/main/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumer.java
@@ -1,0 +1,19 @@
+package coffeeshout.room.infra.messaging.consumer;
+
+import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
+import coffeeshout.websocket.event.player.PlayerDisconnectedEvent;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerDisconnectedConsumer implements Consumer<PlayerDisconnectedEvent> {
+
+    private final DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @Override
+    public void accept(PlayerDisconnectedEvent event) {
+        delayedPlayerRemovalService.schedulePlayerRemoval(event.playerKey(), event.sessionId(), event.reason());
+    }
+}

--- a/backend/room/src/main/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumer.java
+++ b/backend/room/src/main/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumer.java
@@ -1,0 +1,19 @@
+package coffeeshout.room.infra.messaging.consumer;
+
+import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
+import coffeeshout.websocket.event.player.PlayerReconnectedEvent;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerReconnectedConsumer implements Consumer<PlayerReconnectedEvent> {
+
+    private final DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @Override
+    public void accept(PlayerReconnectedEvent event) {
+        delayedPlayerRemovalService.cancelScheduledRemoval(event.playerKey());
+    }
+}

--- a/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumerTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumerTest.java
@@ -1,0 +1,29 @@
+package coffeeshout.room.infra.messaging.consumer;
+
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
+import coffeeshout.support.ServiceTest;
+import coffeeshout.websocket.event.player.PlayerDisconnectedEvent;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class PlayerDisconnectedConsumerTest extends ServiceTest {
+
+    @Autowired
+    Consumer<PlayerDisconnectedEvent> playerDisconnectedEventConsumer;
+
+    @MockitoBean
+    DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @Test
+    void 플레이어_연결_해제_이벤트를_수신하면_지연_삭제가_스케줄링된다() {
+        PlayerDisconnectedEvent event = PlayerDisconnectedEvent.create("ABCD:닉네임", "session-1", "SESSION_DISCONNECT");
+
+        playerDisconnectedEventConsumer.accept(event);
+
+        verify(delayedPlayerRemovalService).schedulePlayerRemoval("ABCD:닉네임", "session-1", "SESSION_DISCONNECT");
+    }
+}

--- a/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumerTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumerTest.java
@@ -1,0 +1,29 @@
+package coffeeshout.room.infra.messaging.consumer;
+
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
+import coffeeshout.support.ServiceTest;
+import coffeeshout.websocket.event.player.PlayerReconnectedEvent;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+class PlayerReconnectedConsumerTest extends ServiceTest {
+
+    @Autowired
+    Consumer<PlayerReconnectedEvent> playerReconnectedEventConsumer;
+
+    @MockitoSpyBean
+    DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @Test
+    void 플레이어_재연결_이벤트를_수신하면_스케줄링된_삭제가_취소된다() {
+        PlayerReconnectedEvent event = PlayerReconnectedEvent.create("ABCD:닉네임", "session-1");
+
+        playerReconnectedEventConsumer.accept(event);
+
+        verify(delayedPlayerRemovalService).cancelScheduledRemoval("ABCD:닉네임");
+    }
+}

--- a/backend/user/src/main/java/coffeeshout/friend/application/PresenceTracker.java
+++ b/backend/user/src/main/java/coffeeshout/friend/application/PresenceTracker.java
@@ -4,14 +4,14 @@ import coffeeshout.friend.config.FriendPresenceProperties;
 import coffeeshout.friend.domain.event.PresenceChangedEvent;
 import coffeeshout.websocket.event.user.UserSessionConnectedEvent;
 import coffeeshout.websocket.event.user.UserSessionDisconnectedEvent;
-import jakarta.annotation.PreDestroy;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -22,20 +22,18 @@ public class PresenceTracker {
 
     private final Map<Long, AtomicInteger> sessionCounts = new ConcurrentHashMap<>();
     private final Map<Long, ScheduledFuture<?>> pendingOffline = new ConcurrentHashMap<>();
-    private final ScheduledThreadPoolExecutor scheduler;
+    private final ScheduledExecutorService scheduler;
     private final ApplicationEventPublisher eventPublisher;
     private final long gracePeriodSeconds;
 
-    public PresenceTracker(ApplicationEventPublisher eventPublisher, FriendPresenceProperties properties) {
+    public PresenceTracker(
+            @Qualifier("presenceScheduler") ScheduledExecutorService scheduler,
+            ApplicationEventPublisher eventPublisher,
+            FriendPresenceProperties properties
+    ) {
+        this.scheduler = scheduler;
         this.eventPublisher = eventPublisher;
         this.gracePeriodSeconds = properties.gracePeriodSeconds();
-        this.scheduler = new ScheduledThreadPoolExecutor(1);
-        this.scheduler.setRemoveOnCancelPolicy(true);
-    }
-
-    @PreDestroy
-    public void shutdown() {
-        scheduler.shutdown();
     }
 
     @EventListener

--- a/backend/user/src/main/java/coffeeshout/friend/config/PresenceSchedulerConfig.java
+++ b/backend/user/src/main/java/coffeeshout/friend/config/PresenceSchedulerConfig.java
@@ -1,0 +1,17 @@
+package coffeeshout.friend.config;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PresenceSchedulerConfig {
+
+    @Bean(name = "presenceScheduler", destroyMethod = "shutdown")
+    public ScheduledExecutorService presenceScheduler() {
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.setRemoveOnCancelPolicy(true);
+        return executor;
+    }
+}

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRemovedEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRemovedEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -9,7 +8,7 @@ public record FriendRemovedEvent(
         Instant timestamp,
         Long removedByUserId,
         Long targetUserId
-) implements BaseEvent {
+) {
 
     public FriendRemovedEvent(Long removedByUserId, Long targetUserId) {
         this(UUID.randomUUID().toString(), Instant.now(), removedByUserId, targetUserId);

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestAcceptedEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestAcceptedEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -14,7 +13,7 @@ public record FriendRequestAcceptedEvent(
         Long addresseeId,
         String addresseeUserCode,
         String addresseeNickname
-) implements BaseEvent {
+) {
 
     public FriendRequestAcceptedEvent(Long requestId,
                                       Long requesterId, String requesterUserCode, String requesterNickname,

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestCreatedEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestCreatedEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -12,7 +11,7 @@ public record FriendRequestCreatedEvent(
         String requesterUserCode,
         String requesterNickname,
         Long addresseeId
-) implements BaseEvent {
+) {
 
     public FriendRequestCreatedEvent(Long requestId, Long requesterId, String requesterUserCode,
                                      String requesterNickname, Long addresseeId) {

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestRejectedEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/FriendRequestRejectedEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -12,7 +11,7 @@ public record FriendRequestRejectedEvent(
         Long addresseeId,
         String addresseeUserCode,
         String addresseeNickname
-) implements BaseEvent {
+) {
 
     public FriendRequestRejectedEvent(Long requestId, Long requesterId, Long addresseeId,
                                       String addresseeUserCode, String addresseeNickname) {

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/PresenceChangedEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/PresenceChangedEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -9,7 +8,7 @@ public record PresenceChangedEvent(
         Instant timestamp,
         Long userId,
         boolean online
-) implements BaseEvent {
+) {
 
     public PresenceChangedEvent(Long userId, boolean online) {
         this(UUID.randomUUID().toString(), Instant.now(), userId, online);

--- a/backend/user/src/main/java/coffeeshout/friend/domain/event/RoomInvitationSentEvent.java
+++ b/backend/user/src/main/java/coffeeshout/friend/domain/event/RoomInvitationSentEvent.java
@@ -1,6 +1,5 @@
 package coffeeshout.friend.domain.event;
 
-import coffeeshout.global.redis.BaseEvent;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -11,7 +10,7 @@ public record RoomInvitationSentEvent(
         String inviterNickname,
         Long targetUserId,
         String joinCode
-) implements BaseEvent {
+) {
 
     public RoomInvitationSentEvent(Long inviterUserId, String inviterNickname, Long targetUserId, String joinCode) {
         this(UUID.randomUUID().toString(), Instant.now(), inviterUserId, inviterNickname, targetUserId, joinCode);

--- a/backend/user/src/test/java/coffeeshout/friend/application/PresenceTrackerTest.java
+++ b/backend/user/src/test/java/coffeeshout/friend/application/PresenceTrackerTest.java
@@ -1,0 +1,176 @@
+package coffeeshout.friend.application;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.friend.config.FriendPresenceProperties;
+import coffeeshout.friend.domain.event.PresenceChangedEvent;
+import coffeeshout.websocket.event.user.UserSessionConnectedEvent;
+import coffeeshout.websocket.event.user.UserSessionDisconnectedEvent;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+
+class PresenceTrackerTest {
+
+    ApplicationEventPublisher eventPublisher;
+    ScheduledExecutorService scheduler;
+
+    @BeforeEach
+    void setUp() {
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        scheduler = newScheduler();
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdownNow();
+    }
+
+    private ScheduledExecutorService newScheduler() {
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        executor.setRemoveOnCancelPolicy(true);
+        return executor;
+    }
+
+    private PresenceTracker trackerWithGrace(long gracePeriodSeconds) {
+        return new PresenceTracker(scheduler, eventPublisher, new FriendPresenceProperties(gracePeriodSeconds));
+    }
+
+    @Nested
+    class 세션_연결 {
+
+        @Test
+        void 첫_번째_연결_시_온라인_이벤트를_발행한다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+
+            tracker.onConnected(connected(1L));
+
+            final ArgumentCaptor<PresenceChangedEvent> captor = forClass(PresenceChangedEvent.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            assertThat(captor.getValue().online()).isTrue();
+        }
+
+        @Test
+        void 두_번째_연결_시_온라인_이벤트를_중복_발행하지_않는다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+
+            tracker.onConnected(connected(1L));
+            tracker.onConnected(connected(1L));
+
+            verify(eventPublisher, times(1)).publishEvent((Object) any());
+        }
+
+        @Test
+        void 연결_후_온라인_상태가_된다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+
+            tracker.onConnected(connected(1L));
+
+            assertThat(tracker.isOnline(1L)).isTrue();
+        }
+
+        @Test
+        void 연결_이력이_없으면_오프라인이다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+
+            assertThat(tracker.isOnline(999L)).isFalse();
+        }
+    }
+
+    @Nested
+    class 세션_종료 {
+
+        @Test
+        void 남은_세션이_있으면_오프라인_이벤트를_발행하지_않는다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+            tracker.onConnected(connected(1L));
+            tracker.onConnected(connected(1L));
+
+            tracker.onDisconnected(disconnected(1L));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(tracker.isOnline(1L)).isTrue();
+                softly.assertThatCode(() ->
+                        verify(eventPublisher, times(1)).publishEvent((Object) any())
+                ).doesNotThrowAnyException();
+            });
+        }
+
+        @Test
+        void 마지막_세션_종료_후_유예_시간이_지나면_오프라인_이벤트를_발행한다() {
+            final PresenceTracker tracker = trackerWithGrace(1);
+            tracker.onConnected(connected(1L));
+
+            tracker.onDisconnected(disconnected(1L));
+
+            final ArgumentCaptor<PresenceChangedEvent> captor = forClass(PresenceChangedEvent.class);
+            await().atMost(ofSeconds(3)).untilAsserted(() -> {
+                verify(eventPublisher, times(2)).publishEvent(captor.capture());
+                assertThat(captor.getAllValues())
+                        .filteredOn(e -> !e.online())
+                        .hasSize(1);
+            });
+        }
+
+        @Test
+        void 마지막_세션_종료_후_유예_시간이_지나면_오프라인_상태가_된다() {
+            final PresenceTracker tracker = trackerWithGrace(1);
+            tracker.onConnected(connected(1L));
+
+            tracker.onDisconnected(disconnected(1L));
+
+            await().atMost(ofSeconds(3)).until(() -> !tracker.isOnline(1L));
+        }
+    }
+
+    @Nested
+    class 유예_시간_내_재연결 {
+
+        @Test
+        void 재연결_시_오프라인_이벤트를_발행하지_않는다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+            tracker.onConnected(connected(1L));
+            tracker.onDisconnected(disconnected(1L));
+
+            tracker.onConnected(connected(1L));
+
+            verify(eventPublisher, never()).publishEvent(
+                    argThat((Object obj) -> obj instanceof PresenceChangedEvent p && !p.online())
+            );
+        }
+
+        @Test
+        void 재연결_후_온라인_상태를_유지한다() {
+            final PresenceTracker tracker = trackerWithGrace(10);
+            tracker.onConnected(connected(1L));
+            tracker.onDisconnected(disconnected(1L));
+
+            tracker.onConnected(connected(1L));
+
+            assertThat(tracker.isOnline(1L)).isTrue();
+        }
+    }
+
+    private static UserSessionConnectedEvent connected(Long userId) {
+        return new UserSessionConnectedEvent(userId, "session-" + userId);
+    }
+
+    private static UserSessionDisconnectedEvent disconnected(Long userId) {
+        return new UserSessionDisconnectedEvent(userId, "session-" + userId);
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close #1299

## 🚀 작업 내용

1. **PlayerDisconnectedEvent / PlayerReconnectedEvent Consumer 구현** (`room`)
   - WebSocket 세션 단절·재연결 시 PresenceTracker에 위임하는 Consumer 추가

2. **EventDispatcher: Consumer 없는 이벤트 수신 시 서비스 정지 방지** (`infra`)
   - `getObject()` → `getIfAvailable()`로 교체
   - Consumer가 없으면 `WARN` 로그 후 skip (기존: `NoSuchBeanDefinitionException` → 이벤트 처리 중단)

3. **ConsumerStartupValidator 추가** (`infra`)
   - `SmartInitializingSingleton` 구현 — 모든 싱글톤 빈 생성 완료 직후 실행
   - Reflections로 전체 `BaseEvent` 서브타입 스캔, Consumer 미등록 타입 있으면 클래스 전체명 로깅 후 `IllegalStateException`으로 startup fail (fail-fast)

4. **Spring 전용 이벤트 8개에서 불필요한 BaseEvent 구현 제거** (`user`, `room`)
   - `FriendRequestCreatedEvent`, `FriendRequestAcceptedEvent`, `FriendRequestRejectedEvent`, `FriendRemovedEvent`, `RoomInvitationSentEvent`, `PresenceChangedEvent`, `RouletteShownEvent`, `RouletteWinnerEvent`
   - 이 이벤트들은 `eventPublisher.publishEvent()` → `@EventListener`/`@TransactionalEventListener` 경로만 사용, Redis Stream을 거치지 않음

5. **PresenceTracker 스케줄러 빈 분리** (`user`)
   - 직접 생성하던 `ScheduledThreadPoolExecutor` + `@PreDestroy` 제거
   - `PresenceSchedulerConfig` 빈(`presenceScheduler`)을 주입받아 생명주기를 Spring이 관리하도록 위임
   - 단위 테스트 추가 (9개)

## 💬 리뷰 중점사항

**Friend 이벤트 BaseEvent 제거 배경**
Friend 관련 이벤트(친구 요청·수락·거절·삭제, 초대, Presence)는 단일 인스턴스 내에서 Spring 이벤트로만 처리되고 있어 `BaseEvent` 구현이 불필요했습니다. 다중 인스턴스 환경에서 인스턴스 간 브로드캐스트가 필요해진다면 Redis Stream 경유로 전환해야 하며, 이는 별도 PR에서 다뤄야 할 것 같습니다.

**BaseEvent 설계 방향에 대한 고민**
현재 `BaseEvent`는 Redis Stream 이벤트와 Spring 이벤트가 혼재해 있었습니다. 향후 `BaseEvent`를 모든 이벤트의 공통 인터페이스로 유지할지, 아니면 Redis Stream 전용 이벤트임을 명시하는 `RedisStreamEvent` 같은 하위 인터페이스로 분리할지 설계 결정이 필요해 보입니다.

## ✅ 체크리스트

- [x] PR 대상 브랜치가 `be/dev`인가요?
- [x] 셀프 코드리뷰를 완료했나요?