### PR TITLE
[chore] CI 파이프라인 강화 — Node.js 24 opt-in, 타임아웃, 보안 스캔, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "npm"
+    directory: "/tools/ws-mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ws-mcp"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -23,6 +23,9 @@ concurrency:
   group: backend-deploy-${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # 1. 공통 빌드/테스트 워크플로우 호출 (backend-ci.yml 재사용)
   ci-and-build:
@@ -34,6 +37,7 @@ jobs:
   deploy:
     needs: ci-and-build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # 빌드 단계에서 결정된 환경 사용
     environment: ${{ needs.ci-and-build.outputs.environment }}
     permissions:
@@ -57,10 +61,10 @@ jobs:
           name: build-artifacts
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -77,6 +81,15 @@ jobs:
             ghcr.io/${{ env.REPO_OWNER }}/zzol-backend:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ env.REPO_OWNER }}/zzol-backend:${{ env.IMAGE_TAG }}
+          format: table
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
 
       - name: Cleanup old GHCR images (keep 5)
         uses: actions/delete-package-versions@v5

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -37,7 +37,7 @@ jobs:
   deploy:
     needs: ci-and-build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     # 빌드 단계에서 결정된 환경 사용
     environment: ${{ needs.ci-and-build.outputs.environment }}
     permissions:
@@ -60,6 +60,15 @@ jobs:
         with:
           name: build-artifacts
 
+      - name: Scan artifacts for vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: backend/build/libs
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -81,15 +90,6 @@ jobs:
             ghcr.io/${{ env.REPO_OWNER }}/zzol-backend:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ghcr.io/${{ env.REPO_OWNER }}/zzol-backend:${{ env.IMAGE_TAG }}
-          format: table
-          severity: CRITICAL
-          exit-code: '1'
-          ignore-unfixed: true
 
       - name: Cleanup old GHCR images (keep 5)
         uses: actions/delete-package-versions@v5

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -66,7 +66,7 @@ jobs:
           scan-type: fs
           scan-ref: backend/build/libs
           severity: CRITICAL
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,9 +29,18 @@ on:
         description: "Docker image tag"
         value: ${{ jobs.ci-build.outputs.image_tag }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   ci-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # output을 상위 워크플로우로 전달
     outputs:
       environment: ${{ steps.set-env.outputs.environment }}

--- a/.github/workflows/backend-rollback.yml
+++ b/.github/workflows/backend-rollback.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      deployments: write
 
     env:
       ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/backend-rollback.yml
+++ b/.github/workflows/backend-rollback.yml
@@ -19,9 +19,13 @@ concurrency:
   group: backend-deploy-${{ inputs.environment }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   rollback:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: ${{ inputs.environment }}
 
     env:

--- a/.github/workflows/be-delete-merged-branch.yml
+++ b/.github/workflows/be-delete-merged-branch.yml
@@ -7,6 +7,9 @@ on:
     types:
       - closed
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   delete-branch:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -3,10 +3,17 @@ on:
   pull_request:
     types: [closed] # PR이 닫힐 때
     branches: [fe/dev, fe/prod, be/dev, be/prod]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   close_linked_issues:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
     steps:
       - name: Close linked issues in PR body
         uses: actions/github-script@v7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,12 +33,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: java
           build-mode: none
           queries: security-and-quality
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 2 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -26,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL Security Analysis
+
+on:
+  push:
+    branches: [be/dev, be/prod]
+    paths: ['backend/**']
+  pull_request:
+    branches: [be/dev, be/prod]
+    paths: ['backend/**']
+  schedule:
+    - cron: '0 2 * * 1'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Java
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: java
+          queries: security-and-quality
+
+      - name: Build for CodeQL
+        run: cd backend && ./gradlew compileJava compileTestJava --no-daemon
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,22 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'corretto'
-
-      - uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: true
-
       - uses: github/codeql-action/init@v3
         with:
           languages: java
+          build-mode: none
           queries: security-and-quality
-
-      - name: Build for CodeQL
-        run: cd backend && ./gradlew compileJava compileTestJava --no-daemon
 
       - uses: github/codeql-action/analyze@v3
         with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -13,9 +13,6 @@ on:
     paths:
       - "frontend/**"
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -13,9 +13,15 @@ on:
     paths:
       - "frontend/**"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
 
     # frontend 폴더를 기본 작업 디렉토리로 설정
     defaults:

--- a/.github/workflows/ws-mcp-ci.yml
+++ b/.github/workflows/ws-mcp-ci.yml
@@ -14,8 +14,9 @@ on:
       - 'backend/src/test/resources/__fixtures__/ws-catalog.json'
       - '.github/workflows/ws-mcp-ci.yml'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ws-mcp:
@@ -28,6 +29,8 @@ jobs:
         working-directory: tools/ws-mcp
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ws-mcp-ci.yml
+++ b/.github/workflows/ws-mcp-ci.yml
@@ -2,6 +2,7 @@ name: ws-mcp CI
 
 on:
   pull_request:
+    branches: [be/dev, be/prod]
     paths:
       - 'tools/ws-mcp/**'
       - 'backend/src/test/resources/__fixtures__/ws-catalog.json'

--- a/.github/workflows/ws-mcp-ci.yml
+++ b/.github/workflows/ws-mcp-ci.yml
@@ -1,0 +1,54 @@
+name: ws-mcp CI
+
+on:
+  pull_request:
+    paths:
+      - 'tools/ws-mcp/**'
+      - 'backend/src/test/resources/__fixtures__/ws-catalog.json'
+      - '.github/workflows/ws-mcp-ci.yml'
+  push:
+    branches:
+      - be/dev
+    paths:
+      - 'tools/ws-mcp/**'
+      - 'backend/src/test/resources/__fixtures__/ws-catalog.json'
+      - '.github/workflows/ws-mcp-ci.yml'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  ws-mcp:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: tools/ws-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: tools/ws-mcp/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Format check (Prettier)
+        run: npm run format:check
+
+      - name: Lint (ESLint + typescript-eslint)
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test (L1 단위 + L2 컨트랙트)
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- **Node.js 24 opt-in**: 백엔드 워크플로우에 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` 추가 (6/16 강제 전환 대비)
  - `frontend-ci`, `ws-mcp-ci`는 `actions/setup-node@v4`가 Node 24 런타임 비호환이라 제외
- **타임아웃**: 모든 job에 `timeout-minutes` 설정 (hung 빌드 방지)
  - 일반 CI job: 10분, deploy job: 30분
- **권한 최소화**: `backend-ci`, `frontend-ci`, `close-issue`, `backend-rollback` 등에 최소 권한 명시
- **Docker action 버전업**: `setup-buildx-action` / `login-action` v3 → v4
- **Trivy 취약점 스캔**: CD 파이프라인에 JAR 파일 대상 fs 스캔 추가 (Docker push 전 실행, arm64 플랫폼 이슈 회피)
  - 초기 단계라 `exit-code: 0`으로 리포팅 전용 운영, 이후 `exit-code: 1`로 전환 예정
- **ws-mcp CI** 추가: Node.js 22, format/lint/typecheck/test/build, `be/dev`·`be/prod` PR에서만 실행
- **CodeQL 보안 분석**: Java 코드 취약점 자동 탐지 (PR + 매주 월요일), concurrency 블록 포함
  - `build-mode: none`(buildless) 사용 — Gradle 빌드 캐시 복원 시 `compileJava`가 UP-TO-DATE로 스킵되어 추출기가 소스를 보지 못하는 "no source code seen during build" 오류 방지
  - **CodeQL Action v4** 사용 (v3는 2026년 12월 deprecation 예정)
- **Dependabot**: Gradle / npm (frontend, ws-mcp) / GitHub Actions 주 1회 자동 업데이트 PR

## 제외한 것

- **JaCoCo 커버리지 CI 연동** — `backend/build.gradle.kts` 변경이 `be/dev`에 머지된 후 별도 PR로 추가 예정

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend-ci.yml` | Node 24 opt-in, permissions, timeout |
| `backend-cd.yml` | Node 24 opt-in, timeout 30분, docker action v4, Trivy fs 스캔 |
| `backend-rollback.yml` | Node 24 opt-in, timeout, `deployments:write` 권한 |
| `be-delete-merged-branch.yml` | Node 24 opt-in |
| `close-issue.yml` | Node 24 opt-in, permissions, timeout |
| `frontend-ci.yml` | timeout, `contents:read` 권한 |
| `ws-mcp-ci.yml` | 신규 추가, Node 22, concurrency, `persist-credentials:false`, branches 필터 |
| `codeql.yml` | 신규 추가, `build-mode: none`(buildless), concurrency, `persist-credentials:false`, CodeQL Action v4 |
| `dependabot.yml` | 신규 추가 |

## Test plan

- [ ] `be/dev` 타깃 PR 생성 시 `backend-ci.yml` 트리거 확인
- [ ] `be/dev` 타깃 PR 생성 시 `ws-mcp-ci.yml` 트리거 확인 (main PR에서는 미실행)
- [ ] CodeQL 분석이 Security 탭에 표시되는지 확인
- [ ] Dependabot이 활성화되는지 확인 (Settings > Code security)
- [ ] CD 실행 시 Trivy 스캔 결과가 로그에 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)