### PR TITLE
[chore] CRITICAL 보안 취약점 의존성 패치 (Tomcat / Spring Security / Thymeleaf)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,6 +27,13 @@ subprojects {
     // Spring Boot BOM이 testcontainers 코어를 1.x로 다운그레이드하지 못하도록 오버라이드
     extra["testcontainers.version"] = testcontainersVersion
 
+    // CVE-2026-41293 / CVE-2026-43512 / CVE-2026-43515
+    extra["tomcat.version"] = "10.1.55"
+    // CVE-2026-***732
+    extra["spring-security.version"] = "6.5.9"
+    // CVE-2026-40477 / CVE-2026-40478 / CVE-2026-41901
+    extra["thymeleaf.version"] = "3.1.5.RELEASE"
+
     // Spring Boot bootJar 기본 비활성화 (라이브러리 모듈은 jar만, :app이 override)
     tasks.named("bootJar") { enabled = false }
     tasks.named("jar") { enabled = true }


### PR DESCRIPTION
## Summary
- `build.gradle.kts` 루트 `subprojects` 블록에 Spring BOM 버전 오버라이드 3개 추가
- 기존 `extra["testcontainers.version"]` 패턴과 동일한 방식으로 적용

| 라이브러리 | 변경 전 | 변경 후 | CVE |
|---|---|---|---|
| tomcat-embed-core | 10.1.42 | 10.1.55 | CVE-2026-41293 / CVE-2026-43512 / CVE-2026-43515 |
| spring-security-web | 6.5.1 | 6.5.9 | CVE-2026-***732 |
| thymeleaf + thymeleaf-spring6 | 3.1.3.RELEASE | 3.1.5.RELEASE | CVE-2026-40477 / CVE-2026-40478 / CVE-2026-41901 |

Closes #1347

## Test plan
- [ ] `./gradlew :app:dependencies | grep -E "tomcat|thymeleaf|spring-security"` 으로 패치 버전 확인
- [ ] Trivy 재스캔 시 6개 CVE 미검출
- [ ] CI 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 중요 의존성(Tomcat, Spring Security, Thymeleaf)의 버전이 고정되어 빌드 환경의 일관성이 강화되고 애플리케이션의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->