### PR TITLE
[be/fix] IpBlockFilter 내부 IP 화이트리스트로 인프라 IP 차단 방지

### DIFF
--- a/backend/app/src/main/resources/config/security.yml
+++ b/backend/app/src/main/resources/config/security.yml
@@ -41,6 +41,8 @@ security:
     exempt-paths:
       - /admin
       - /reports
+    not-found-exempt-paths:
+      - /ws
 
 admin:
   username: ${ADMIN_USERNAME}

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
@@ -177,18 +177,49 @@ public class IpBlockFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 사설(RFC1918)·루프백·링크로컬 IP 여부. isValidIp 통과 후 호출되므로 DNS 조회는 발생하지 않는다.
+     * 사설(RFC1918)·루프백·링크로컬·CGNAT(RFC6598)·IPv6 ULA(RFC4193) IP 여부.
+     * isValidIp 통과 후 호출되므로 DNS 조회는 발생하지 않는다.
      */
     private boolean isInternalIp(String ip) {
         try {
-            final InetAddress address = InetAddress.getByName(ip);
-            return address.isLoopbackAddress()
-                    || address.isSiteLocalAddress()
-                    || address.isLinkLocalAddress()
-                    || address.isAnyLocalAddress();
+            return isInternalAddress(InetAddress.getByName(ip));
         } catch (UnknownHostException e) {
             return false;
         }
+    }
+
+    private boolean isInternalAddress(InetAddress address) {
+        return address.isLoopbackAddress()
+                || address.isSiteLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isAnyLocalAddress()
+                || isCarrierGradeNat(address)
+                || isUniqueLocalIpv6(address);
+    }
+
+    /**
+     * 100.64.0.0/10 (RFC 6598 CGNAT). 클라우드·k8s 프록시가 사용할 수 있으나
+     * {@link InetAddress#isSiteLocalAddress()}는 포함하지 않으므로 직접 판정한다.
+     */
+    private boolean isCarrierGradeNat(InetAddress address) {
+        final byte[] bytes = address.getAddress();
+        if (bytes.length != 4) {
+            return false;
+        }
+        final int first = bytes[0] & 0xFF;
+        final int second = bytes[1] & 0xFF;
+        return first == 100 && second >= 64 && second <= 127;
+    }
+
+    /**
+     * fc00::/7 (RFC 4193 IPv6 Unique Local Address). 첫 바이트가 0xFC 또는 0xFD.
+     */
+    private boolean isUniqueLocalIpv6(InetAddress address) {
+        final byte[] bytes = address.getAddress();
+        if (bytes.length != 16) {
+            return false;
+        }
+        return (bytes[0] & 0xFE) == 0xFC;
     }
 
     private String getClientIp(HttpServletRequest request) {

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +72,17 @@ public class IpBlockFilter extends OncePerRequestFilter {
             return;
         }
 
+        // 사설/내부 IP(프록시·헬스체크·내부 서비스)는 클라이언트가 아니므로 차단·카운트 대상에서 제외한다.
+        // XFF가 깨지면 모든 트래픽이 프록시 IP로 보이는데, 이를 차단하면 전체 장애로 번진다.
+        // 악성 경로 접근은 XFF 설정 이상 신호이므로 경고만 남기고 통과시킨다.
+        if (isInternalIp(ip)) {
+            if (maliciousPathMatcher.isMalicious(uri)) {
+                ipBlockStore.recordInternalIpSuspicious(ip, uri);
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // 악성 경로는 예외 경로여도 항상 차단 (/admin.php 등 스캐너 패턴)
         if (maliciousPathMatcher.isMalicious(uri)) {
             log.warn("악성 경로 접근 감지 → IP 즉시 차단: ip={} uri={}", ip, uri);
@@ -93,7 +106,8 @@ public class IpBlockFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
 
         if (response.getStatus() == HttpStatus.NOT_FOUND.value()
-                && !Boolean.TRUE.equals(request.getAttribute(IpBlockAttributes.BUSINESS_NOT_FOUND))) {
+                && !Boolean.TRUE.equals(request.getAttribute(IpBlockAttributes.BUSINESS_NOT_FOUND))
+                && !isNotFoundExemptPath(uri)) {
             ipBlockStore.incrementNotFoundAndBlockIfExceeded(ip);
         }
     }
@@ -146,6 +160,35 @@ public class IpBlockFilter extends OncePerRequestFilter {
             }
         }
         return false;
+    }
+
+    /**
+     * 404 누적 카운트에서 제외할 경로인지 판단한다.
+     * WebSocket(SockJS) 엔드포인트는 재연결·전송 폴백 과정에서 정상적으로 4xx를 유발하므로
+     * 차단 카운트에 반영하면 정상 사용자가 차단될 수 있다.
+     */
+    private boolean isNotFoundExemptPath(String uri) {
+        for (final String prefix : properties.notFoundExemptPaths()) {
+            if (uri.equals(prefix) || uri.startsWith(prefix + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 사설(RFC1918)·루프백·링크로컬 IP 여부. isValidIp 통과 후 호출되므로 DNS 조회는 발생하지 않는다.
+     */
+    private boolean isInternalIp(String ip) {
+        try {
+            final InetAddress address = InetAddress.getByName(ip);
+            return address.isLoopbackAddress()
+                    || address.isSiteLocalAddress()
+                    || address.isLinkLocalAddress()
+                    || address.isAnyLocalAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
     }
 
     private String getClientIp(HttpServletRequest request) {

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockProperties.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockProperties.java
@@ -15,6 +15,7 @@ public record IpBlockProperties(
         @Min(value = 1, message = "Not Found 누적 임계값은 1 이상이어야 합니다") @DefaultValue("5") int notFoundThreshold,
         @DurationMin(nanos = 1, message = "Not Found 누적 윈도우는 0보다 커야 합니다") @DefaultValue("1h") Duration notFoundWindow,
         @DurationMin(nanos = 1, message = "차단 TTL은 0보다 커야 합니다") @DefaultValue("24h") Duration blockTtl,
-        @NotEmpty @DefaultValue({"/admin", "/reports"}) List<String> exemptPaths
+        @NotEmpty @DefaultValue({"/admin", "/reports"}) List<String> exemptPaths,
+        @DefaultValue("/ws") List<String> notFoundExemptPaths
 ) {
 }

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockStore.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockStore.java
@@ -61,6 +61,7 @@ public class IpBlockStore {
 
     private Counter blockedRequestCounter;
     private Counter newIpBlockCounter;
+    private Counter internalSuspiciousCounter;
 
     @PostConstruct
     private void initMetrics() {
@@ -70,6 +71,19 @@ public class IpBlockStore {
         newIpBlockCounter = Counter.builder("ip.block.new.total")
                 .description("새로 차단된 IP 수")
                 .register(meterRegistry);
+        internalSuspiciousCounter = Counter.builder("ip.block.internal.suspicious.total")
+                .description("사설/내부 IP가 차단 트리거 경로에 접근한 횟수 (XFF/프록시 설정 의심)")
+                .register(meterRegistry);
+    }
+
+    /**
+     * 사설/내부 IP가 악성 경로 등 차단 트리거 경로에 접근했을 때 호출한다.
+     * 내부 IP는 차단하지 않되, XFF/프록시 설정 이상으로 클라이언트 트래픽이 내부 IP로
+     * 보이는 상황을 조기에 감지하기 위해 경고 로그와 메트릭을 남긴다.
+     */
+    public void recordInternalIpSuspicious(String ip, String uri) {
+        internalSuspiciousCounter.increment();
+        log.warn("사설/내부 IP가 악성 경로에 접근 — XFF/프록시 설정 점검 필요: ip={} uri={}", ip, uri);
     }
 
     @CircuitBreaker(name = "redisBlockStore", fallbackMethod = "isBlockedFallback")

--- a/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockFilterTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockFilterTest.java
@@ -51,6 +51,7 @@ class IpBlockFilterTest {
     void setUp() {
         // lenient: 악성 경로 테스트에서는 isMalicious 체크 직후 return되어 exemptPaths에 도달하지 않음
         lenient().when(properties.exemptPaths()).thenReturn(List.of("/admin", "/reports"));
+        lenient().when(properties.notFoundExemptPaths()).thenReturn(List.of("/ws"));
         final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         filter = new IpBlockFilter(ipBlockStore, maliciousPathMatcher, properties, objectMapper);
     }
@@ -205,6 +206,18 @@ class IpBlockFilterTest {
 
             then(ipBlockStore).should(never()).incrementNotFoundAndBlockIfExceeded(any());
         }
+
+        @Test
+        void WS_엔드포인트의_404_응답은_카운터를_증가시키지_않는다() throws Exception {
+            doAnswer(invocation -> {
+                ((HttpServletResponse) invocation.getArgument(1)).setStatus(404);
+                return null;
+            }).when(filterChain).doFilter(any(), any());
+
+            filter.doFilter(요청(REMOTE_IP, "/ws/abc/123/websocket"), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should(never()).incrementNotFoundAndBlockIfExceeded(any());
+        }
     }
 
     @Nested
@@ -249,6 +262,51 @@ class IpBlockFilterTest {
             filter.doFilter(요청(REMOTE_IP, NORMAL_PATH), new MockHttpServletResponse(), filterChain);
 
             then(ipBlockStore).should().isBlocked(REMOTE_IP);
+        }
+    }
+
+    @Nested
+    class 사설_내부_IP {
+
+        private static final String INTERNAL_IP = "172.20.0.5";
+
+        @Test
+        void 차단_등록된_사설_IP도_filterChain을_통과한다() throws Exception {
+            lenient().when(maliciousPathMatcher.isMalicious(anyString())).thenReturn(false);
+            lenient().when(ipBlockStore.isBlocked(INTERNAL_IP)).thenReturn(true);
+
+            final MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(요청(INTERNAL_IP, NORMAL_PATH), response, filterChain);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.getStatus()).isNotEqualTo(403);
+            });
+            then(filterChain).should().doFilter(any(), any());
+        }
+
+        @Test
+        void 사설_IP의_404_응답은_카운터를_증가시키지_않는다() throws Exception {
+            lenient().when(maliciousPathMatcher.isMalicious(anyString())).thenReturn(false);
+            lenient().when(ipBlockStore.isBlocked(anyString())).thenReturn(false);
+            doAnswer(invocation -> {
+                ((HttpServletResponse) invocation.getArgument(1)).setStatus(404);
+                return null;
+            }).when(filterChain).doFilter(any(), any());
+
+            filter.doFilter(요청(INTERNAL_IP, "/not-found"), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should(never()).incrementNotFoundAndBlockIfExceeded(any());
+        }
+
+        @Test
+        void 사설_IP가_악성_경로_접근_시_차단하지_않고_경고만_기록한다() throws Exception {
+            given(maliciousPathMatcher.isMalicious(MALICIOUS_PATH)).willReturn(true);
+
+            filter.doFilter(요청(INTERNAL_IP, MALICIOUS_PATH), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should(never()).blockImmediately(any());
+            then(ipBlockStore).should().recordInternalIpSuspicious(INTERNAL_IP, MALICIOUS_PATH);
+            then(filterChain).should().doFilter(any(), any());
         }
     }
 

--- a/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockFilterTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockFilterTest.java
@@ -308,6 +308,40 @@ class IpBlockFilterTest {
             then(ipBlockStore).should().recordInternalIpSuspicious(INTERNAL_IP, MALICIOUS_PATH);
             then(filterChain).should().doFilter(any(), any());
         }
+
+        @Test
+        void CGNAT_대역_IP도_차단하지_않고_filterChain을_통과한다() throws Exception {
+            lenient().when(maliciousPathMatcher.isMalicious(anyString())).thenReturn(false);
+            lenient().when(ipBlockStore.isBlocked("100.64.0.1")).thenReturn(true);
+
+            final MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(요청("100.64.0.1", NORMAL_PATH), response, filterChain);
+
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(response.getStatus()).isNotEqualTo(403));
+            then(filterChain).should().doFilter(any(), any());
+        }
+
+        @Test
+        void IPv6_ULA_대역_IP도_차단하지_않고_filterChain을_통과한다() throws Exception {
+            lenient().when(maliciousPathMatcher.isMalicious(anyString())).thenReturn(false);
+            lenient().when(ipBlockStore.isBlocked("fd00::1")).thenReturn(true);
+
+            final MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(요청("fd00::1", NORMAL_PATH), response, filterChain);
+
+            SoftAssertions.assertSoftly(softly -> softly.assertThat(response.getStatus()).isNotEqualTo(403));
+            then(filterChain).should().doFilter(any(), any());
+        }
+
+        @Test
+        void 공인_IP는_CGNAT_경계_밖이면_정상_차단_검사를_수행한다() throws Exception {
+            lenient().when(maliciousPathMatcher.isMalicious(anyString())).thenReturn(false);
+            given(ipBlockStore.isBlocked("100.128.0.1")).willReturn(true);
+
+            filter.doFilter(요청("100.128.0.1", NORMAL_PATH), new MockHttpServletResponse(), filterChain);
+
+            then(ipBlockStore).should().isBlocked("100.128.0.1");
+        }
     }
 
     @Nested

--- a/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockStoreTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/ipblock/IpBlockStoreTest.java
@@ -251,5 +251,15 @@ class IpBlockStoreTest extends InfraModuleIntegrationTest {
             assertThat(meterRegistry.find("ip.block.new.total").counter().count() - before)
                     .isEqualTo(1.0);
         }
+
+        @Test
+        void 사설_IP_의심_접근_기록_시_internalSuspicious_카운터가_증가한다() {
+            double before = meterRegistry.find("ip.block.internal.suspicious.total").counter().count();
+
+            ipBlockStore.recordInternalIpSuspicious("172.20.0.5", "/.env");
+
+            assertThat(meterRegistry.find("ip.block.internal.suspicious.total").counter().count() - before)
+                    .isEqualTo(1.0);
+        }
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/fix/ip-block-admin-bypass 스택 — #1353 머지 후 be/dev로 재타깃)

# 🔥 연관 이슈

- close #1352

# 🚀 작업 내용

> ⚠️ 이 PR은 #1353(be/fix/ip-block-admin-bypass) 위에 스택되어 있습니다. **#1353을 먼저 머지**한 뒤 이 PR의 base를 be/dev로 재타깃해 주세요.

prod에서 `proxy-ws.inc`가 비어 Upgrade/XFF 헤더가 누락 → 모든 트래픽이 nginx IP로 보이고 → 그 내부 IP가 404 누적으로 차단 → WS 전면 장애가 발생했다. 프록시 설정 하나가 깨지면 전체 장애로 번지는 구조를 방어한다.

1. **내부 IP 화이트리스트**: `IpBlockFilter`가 사설(RFC1918)·루프백·링크로컬 IP를 차단·404 카운트에서 제외 (`InetAddress.isSiteLocalAddress` 등)
2. **XFF 이상 조기 감지**: 내부 IP가 악성 경로 접근 시 차단 대신 `recordInternalIpSuspicious` → WARN 로그 + `ip.block.internal.suspicious.total` 메트릭
3. **WS 404 제외**: `/ws` 엔드포인트 404는 누적 카운트에서 제외 (`not-found-exempt-paths` 설정, 기본 `/ws`)

# 💬 리뷰 중점사항

- `isInternalIp` 판정 정확성 (IPv6, 빈 IP 엣지케이스 — isValidIp 통과 후 호출이라 DNS 미발생)
- 내부 IP 전체 신뢰가 우회 경로를 만들지 않는지 (XFF 정상 시 앱은 실 클라 IP를 보므로 내부 IP = 인프라/설정이상으로 한정)
- WS 404 제외 범위가 과하지 않은지

> 별도 추적: 레포의 `proxy-ws.inc`는 정상이므로 배포본만 비어 있던 **설정 드리프트**는 인프라 이슈로 분리 예정