### PR TITLE
[chore] CI에서 Testcontainers reuse 활성화 (main 워크플로우 동기화)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -93,6 +93,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # 모듈별 test JVM이 같은 MySQL/Valkey 컨테이너를 재사용하도록 활성화 (ADR-0013)
+      # 모듈별 독립 DB(zzol_test_<module>)·Redis DB 인덱스 격리로 병렬 실행 시에도 안전하다
+      - name: Enable Testcontainers reuse
+        run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
+
       - name: Run Tests
         run: ./gradlew test --build-cache --no-daemon
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (GitHub Actions 워크플로우 파일은 main 전용)

# 🔥 연관 이슈

- 없음 (CI 빌드 시간 개선 — #1363 과 동일 변경의 main 반영)

# 🚀 작업 내용

1. `backend-ci.yml`에 `testcontainers.reuse.enable=true` 설정 스텝 추가 (main의 최신 복사본 기준)
   - 병렬 모듈 테스트 JVM들이 MySQL/Valkey 컨테이너 1세트를 공유하도록 전환

# 💬 리뷰 중점사항

- 상세 배경·안전성 근거는 #1363 (be/dev 타깃) 참조. ADR-0013 문서 갱신도 해당 PR에 포함되어 있습니다.
- `pull_request` 이벤트는 PR 머지 ref의 워크플로우를 실행하므로 실제 PR CI 가속은 be/dev 복사본(#1363)이 담당하고, 이 PR은 워크플로우 파일의 단일 진실 원천인 main을 동기화하는 목적입니다.
- 참고: main과 be/dev의 `backend-ci.yml`이 이미 갈라져 있습니다 (main: setup-java@v5·gradle/actions@v6·jacoco 스텝 없음 / be/dev: setup-java@v4·jacoco 포함). 이번 변경 범위 밖이라 손대지 않았지만 별도 동기화가 필요해 보입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
