### PR TITLE
[fix] Graceful Shutdown 중 HEALTHCHECK가 unhealthy로 오판하는 문제 수정

### DIFF
--- a/backend/app/src/main/resources/config/monitoring.yml
+++ b/backend/app/src/main/resources/config/monitoring.yml
@@ -3,6 +3,14 @@ management:
   endpoint:
     health:
       show-details: always
+      # OUT_OF_SERVICE(Graceful Shutdown 중)를 200으로 매핑한다.
+      # 기본값(503)이면 busybox wget이 본문 없이 exit 1 → Docker HEALTHCHECK가
+      # 종료 중인 컨테이너를 unhealthy로 오판한다. DOWN은 기본값(503)을 유지해
+      # 진짜 장애만 unhealthy로 판정한다. (LB가 이 엔드포인트를 액티브 헬스체크에
+      # 쓰게 된다면 이 매핑은 재검토 필요 — 503은 "트래픽 차단" 신호이기도 하다)
+      status:
+        http-mapping:
+          out-of-service: 200
       group:
         liveness:
           include: "ping"

--- a/backend/docker/app/Dockerfile
+++ b/backend/docker/app/Dockerfile
@@ -39,8 +39,13 @@ EXPOSE 8080
 
 # Health check 설정
 # DOWN만 unhealthy로 판정. OUT_OF_SERVICE(Graceful Shutdown)는 healthy로 통과시킴.
-# 1) wget 실패(앱 죽음, 타임아웃) → 즉시 unhealthy
-# 2) wget 성공 → 응답 본문에 "DOWN"이 있으면 unhealthy, 없으면(UP/OUT_OF_SERVICE) healthy
+# 1) wget 실패 → 즉시 unhealthy
+#    - 앱 죽음, 타임아웃
+#    - HTTP 503: busybox wget은 비2xx에서 본문 없이 exit 1. DOWN은 503이므로 여기서 걸러진다.
+#      OUT_OF_SERVICE는 config/monitoring.yml의 http-mapping(out-of-service: 200)으로 통과한다.
+# 2) wget 성공(2xx) → 본문에 "DOWN"이 있으면 unhealthy (http-mapping 변경에 대비한 이중 방어)
+# 주의: docker-compose(dev/prod)의 healthcheck가 이 설정을 덮어쓴다 (--spider, 상태 코드만 판정).
+#       해당 healthcheck도 위 http-mapping 덕분에 동일한 3분류 의미를 갖는다.
 HEALTHCHECK --interval=30s \
     --timeout=3s \
     --start-period=40s \

--- a/backend/infra/src/main/java/coffeeshout/global/health/RedisStreamContainerRecovery.java
+++ b/backend/infra/src/main/java/coffeeshout/global/health/RedisStreamContainerRecovery.java
@@ -26,7 +26,9 @@ import org.springframework.stereotype.Component;
  * 2. 멈춘 container 발견 시 start()를 호출하여 복구 시도
  * 3. 복구 실패 시 failedRecoveryStreams에 기록
  * 4. HealthIndicator는 이 정보를 읽어서, 복구 실패한 container가 있으면 DOWN 반환
- * 5. DOWN이 되면 Docker HEALTHCHECK에 의해 컨테이너 재시작 (last resort)
+ * 5. DOWN이 되면 모니터링 알림으로 운영자가 개입 (last resort)
+ *    — 순수 Docker는 unhealthy 컨테이너를 재시작하지 않는다 (상태 표시만 함).
+ *      자동 재시작이 필요해지면 재시작 판단 전용 health group 분리 후 autoheal 도입을 검토한다.
  * <p>
  * 스트림 키 목록은 RedisStreamProperties에서 동적으로 로드한다.
  * application.yml에 스트림을 추가/제거하면 자동으로 반영된다.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. **`config/monitoring.yml`** — `management.endpoint.health.status.http-mapping.out-of-service: 200` 추가
   - Spring 기본 매핑은 OUT_OF_SERVICE → HTTP 503인데, busybox wget(alpine)은 비2xx에서 본문 없이 exit 1로 실패한다
   - 이 때문에 "DOWN만 unhealthy, OUT_OF_SERVICE(Graceful Shutdown)는 healthy 통과"라는 HEALTHCHECK 설계 의도가 무력화되어, 종료 중인 컨테이너가 약 90초 후 unhealthy로 찍히고 있었다
   - DOWN은 기본값(503)을 유지해 진짜 장애만 unhealthy로 판정한다
2. **`docker/app/Dockerfile`** — HEALTHCHECK 주석을 실제 동작에 맞게 보정
   - 503 시 wget이 grep 분기 도달 전에 즉시 실패하는 동작, dev/prod compose가 `--spider` healthcheck로 Dockerfile HEALTHCHECK를 덮어쓰는 사실을 명시
3. **`RedisStreamContainerRecovery.java`** — 복구 흐름 주석 보정 (주석만 변경)
   - "DOWN이 되면 Docker HEALTHCHECK에 의해 컨테이너 재시작"은 순수 Docker에서 동작하지 않는 희망사항이었다 (Docker는 unhealthy 시 상태 표시만 함)
   - 실제 last resort는 모니터링 알림 → 운영자 개입임을 명시하고, 자동 재시작 도입 시 전제 조건(재시작 판단 전용 health group 분리)을 기록

# 💬 리뷰 중점사항

- **OUT_OF_SERVICE → 200 매핑의 트레이드오프**: 503은 LB에게 "트래픽 차단" 신호이기도 하다. 현재 구조는 배포 스크립트가 readiness 확인 후 nginx upstream을 직접 전환하므로 안전하지만, 이후 LB 액티브 헬스체크를 이 엔드포인트에 붙이게 되면 이 매핑은 재검토가 필요하다 (monitoring.yml 주석에도 기록)
- **autoheal / `depends_on: service_healthy`는 의도적으로 추가하지 않음**: readiness 그룹에 `db`, `redis` 등 외부 의존성이 포함돼 있어, 현 구성에 autoheal을 붙이면 DB 장애 시 재시작으로 고칠 수 없는 장애에 app 재시작 루프가 돌며 WebSocket 세션만 끊긴다. 자동 재시작이 필요해지면 재시작 판단 전용 health group 분리가 선행되어야 한다
- compose(dev/prod)의 `--spider` healthcheck는 상태 코드만 판정하므로, 이번 매핑 하나로 Dockerfile·compose 양쪽 healthcheck가 동일한 3분류(UP/OUT_OF_SERVICE → healthy, DOWN → unhealthy) 의미를 갖게 된다

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Graceful shutdown 중 헬스체크 응답 코드를 HTTP 200으로 변경되도록 설정 업데이트
  * 헬스체크 동작 및 모니터링 알림 관련 문서 주석 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->