### PR TITLE
[chore] CD deploy job을 ARM 네이티브 러너로 전환 (QEMU 에뮬레이션 제거)

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -34,9 +34,11 @@ jobs:
       environment: ${{ inputs.environment }}
 
   # 2. Deploy Job
+  # ARM 네이티브 러너 사용: linux/arm64 이미지 빌드 시 QEMU 에뮬레이션 제거
+  # (Dockerfile의 RUN java -Djarmode=tools ... 가 네이티브로 실행됨)
   deploy:
     needs: ci-and-build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     # 빌드 단계에서 결정된 환경 사용
     environment: ${{ needs.ci-and-build.outputs.environment }}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음 (main 타깃 #1367과 동일 변경)

# 🚀 작업 내용

1. CD `deploy` job의 러너를 `ubuntu-latest`(x86_64) → `ubuntu-24.04-arm`(ARM 네이티브)으로 전환

## 배경

- 배포 이미지는 `platforms: linux/arm64`로 빌드되는데, x86 러너에서는 Dockerfile의 `RUN` 단계(`java -Djarmode=tools -jar app.jar extract`, `adduser` 등)가 **QEMU 에뮬레이션**으로 실행됨
- ARM 네이티브 러너로 전환하면 QEMU 구간이 사라지고 전부 네이티브 실행
- GitHub ARM 러너는 2025년 1월부터 **퍼블릭 레포 무료**

## be/dev에도 별도 PR이 필요한 이유

push 트리거 워크플로우는 **푸시된 브랜치의 워크플로우 파일**로 실행됩니다. CD는 `push: [be/dev, be/prod]` 트리거이므로 main(#1367)만 머지하면 실제 배포에는 적용되지 않습니다. `be/prod`는 dev→prod 머지 시 함께 전파됩니다.

## 영향 범위

- Gradle 빌드/테스트(`ci-and-build` job, backend-ci.yml)는 변경 없음 — x86 그대로
- `deploy` job 내 스텝 호환성:
  - JAR 아티팩트: 플랫폼 무관 (바이트코드)
  - `appleboy/scp-action`, `ssh-action`: 멀티아치 이미지(drone-scp/drone-ssh) 제공
  - Trivy, buildx, gha 캐시: arm64 지원
- 기존 gha 빌드 캐시는 첫 빌드에서 미스 후 재적재됨 (1회성)

# 💬 리뷰 중점사항

첫 배포 1회는 캐시 미스 + ARM 러너 가용성(수요 몰릴 때 큐 대기 가능)으로 평소보다 느릴 수 있습니다. 머지 후 deploy job 로그에서 러너 아키텍처와 빌드 정상 여부 확인 부탁드립니다.
