### PR TITLE
[test] 테스트 컨텍스트 캐시 위반 정리로 모듈별 컨텍스트 기동 축소

### DIFF
--- a/backend/admin/src/test/java/coffeeshout/AdminModuleIntegrationTest.java
+++ b/backend/admin/src/test/java/coffeeshout/AdminModuleIntegrationTest.java
@@ -1,12 +1,23 @@
 package coffeeshout;
 
 import coffeeshout.config.ServiceTestConfig;
+import coffeeshout.report.ratelimit.ReportRateLimitStore;
 import coffeeshout.support.IntegrationTestSupport;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(classes = AdminModuleTestApplication.class, webEnvironment = WebEnvironment.MOCK)
+@AutoConfigureMockMvc
 @Import(ServiceTestConfig.class)
 public abstract class AdminModuleIntegrationTest extends IntegrationTestSupport {
+
+    /**
+     * 컨텍스트 캐시 공유를 위해 베이스에서 mock으로 고정한다. 개별 테스트 클래스에 @MockitoBean을 선언하면
+     * 클래스마다 새 컨텍스트가 생성된다. 실제 ReportRateLimitStore 동작은 ReportRateLimitStoreTest(ServiceTest 컨텍스트)가 검증한다.
+     */
+    @MockitoBean
+    protected ReportRateLimitStore rateLimitStore;
 }

--- a/backend/admin/src/test/java/coffeeshout/patchnote/ui/PatchNoteControllerTest.java
+++ b/backend/admin/src/test/java/coffeeshout/patchnote/ui/PatchNoteControllerTest.java
@@ -11,10 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
-@AutoConfigureMockMvc
 @DisplayName("PatchNoteController 통합 테스트")
 class PatchNoteControllerTest extends AdminModuleIntegrationTest {
 

--- a/backend/admin/src/test/java/coffeeshout/report/ui/ReportControllerTest.java
+++ b/backend/admin/src/test/java/coffeeshout/report/ui/ReportControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import coffeeshout.AdminModuleIntegrationTest;
-import coffeeshout.report.ratelimit.ReportRateLimitStore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,12 +13,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@AutoConfigureMockMvc
 @DisplayName("ReportController 통합 테스트")
 class ReportControllerTest extends AdminModuleIntegrationTest {
 
@@ -28,9 +24,6 @@ class ReportControllerTest extends AdminModuleIntegrationTest {
 
     @Autowired
     ObjectMapper objectMapper;
-
-    @MockitoBean
-    ReportRateLimitStore rateLimitStore;
 
     @BeforeEach
     void setUp() {

--- a/backend/app/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
+++ b/backend/app/src/test/java/coffeeshout/global/outbox/OutboxE2ETest.java
@@ -2,26 +2,15 @@ package coffeeshout.global.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coffeeshout.gamecommon.flow.FlowScheduler;
-import coffeeshout.support.TestContainerSupport;
 import coffeeshout.global.redis.BaseEvent;
 import coffeeshout.room.infra.messaging.RoomStreamKey;
 import coffeeshout.room.domain.event.PlayerListUpdateEvent;
+import coffeeshout.support.app.IntegrationTestSupport;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Outbox 패턴 E2E 테스트 (2단 콤보 Outbox).
@@ -32,65 +21,11 @@ import org.springframework.test.context.ActiveProfiles;
  * Worker가 500ms 후 재시도 (Fallback)
  * <p>
  * H2 대신 MySQL을 쓰는 이유: FOR UPDATE SKIP LOCKED가 H2에서 지원되지 않는다.
+ * <p>
+ * 백그라운드 @Scheduled(relay/recoverStaleEvents/cleanup)와 수동 호출의 경합 방지는
+ * 베이스의 CommonTestSchedulerConfig(no-op taskScheduler)가, 게임 스케줄러 대체는 IntegrationTestConfig가 담당한다.
  */
-
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(OutboxE2ETest.OutboxE2ETestConfig.class)
-class OutboxE2ETest extends TestContainerSupport {
-
-    @TestConfiguration
-    static class OutboxE2ETestConfig {
-
-        @Bean(name = "cardGameFlowScheduler")
-        @Primary
-        public FlowScheduler mockCardGameFlowScheduler() {
-            return Mockito.mock(FlowScheduler.class);
-        }
-
-        @Bean(name = "blockStackingFlowScheduler")
-        public FlowScheduler mockBlockStackingFlowScheduler() {
-            return Mockito.mock(FlowScheduler.class);
-        }
-
-        @Bean(name = "cardGameTaskScheduler")
-        public TaskScheduler cardGameTaskScheduler() {
-            return new coffeeshout.support.ShutDownTestScheduler();
-        }
-
-        @Bean(name = "delayRemovalScheduler")
-        public TaskScheduler delayRemovalScheduler() {
-            return new coffeeshout.support.ShutDownTestScheduler();
-        }
-
-        @Bean(name = "racingGameScheduler")
-        public TaskScheduler racingGameScheduler() {
-            return new coffeeshout.support.ShutDownTestScheduler();
-        }
-
-        @Bean(name = "speedTouchGameScheduler")
-        public TaskScheduler speedTouchGameScheduler() {
-            return new coffeeshout.support.ShutDownTestScheduler();
-        }
-
-        @Bean(name = "blindTimerGameScheduler")
-        public TaskScheduler blindTimerGameScheduler() {
-            return new coffeeshout.support.ShutDownTestScheduler();
-        }
-
-        /**
-         * 기본 taskScheduler를 no-op으로 덮어써서 @Scheduled 메서드 실행을 막는다.
-         * OutboxRelayWorker의 relay(), recoverStaleEvents(), cleanup()이
-         * 테스트 중에 백그라운드로 돌면서 수동 호출과 경합하는 걸 방지한다.
-         * ShutDownTestScheduler는 ThreadPoolTaskScheduler 상속이라 실제로 태스크를 실행하므로
-         * Mockito mock을 사용해 진짜 no-op으로 만든다.
-         */
-        @Bean(name = "taskScheduler")
-        @Primary
-        public TaskScheduler noOpTaskScheduler() {
-            return Mockito.mock(TaskScheduler.class, Answers.RETURNS_MOCKS);
-        }
-    }
+class OutboxE2ETest extends IntegrationTestSupport {
 
     @Autowired
     private OutboxEventRecorder outboxEventRecorder;
@@ -103,11 +38,6 @@ class OutboxE2ETest extends TestContainerSupport {
 
     @Autowired
     private OutboxEventRepository outboxEventRepository;
-
-    @BeforeEach
-    void setUp() {
-        cleanDatabase();
-    }
 
     @Nested
     class AFTER_COMMIT_즉시_발행_Happy_Path는 {

--- a/backend/app/src/test/java/coffeeshout/global/outbox/OutboxEventRecorderTest.java
+++ b/backend/app/src/test/java/coffeeshout/global/outbox/OutboxEventRecorderTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coffeeshout.support.app.StreamMockedServiceTest;
 import coffeeshout.global.redis.BaseEvent;
-import coffeeshout.global.redis.stream.StreamTracePropagator;
 import coffeeshout.room.infra.messaging.RoomStreamKey;
 import coffeeshout.room.domain.event.PlayerListUpdateEvent;
 import java.util.List;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 /**
  * OutboxEventRecorder 단위 테스트.
@@ -21,6 +19,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
  * ServiceTest가 @Transactional이므로 테스트 종료 시 롤백된다.
  * 따라서 @TransactionalEventListener(AFTER_COMMIT)은 실행되지 않는다.
  * AFTER_COMMIT 즉시 발행 동작은 OutboxAfterCommitRelayTest에서 별도 검증한다.
+ * streamTracePropagator spy는 베이스 클래스(StreamMockedServiceTest)가 제공한다.
  */
 class OutboxEventRecorderTest extends StreamMockedServiceTest {
 
@@ -29,9 +28,6 @@ class OutboxEventRecorderTest extends StreamMockedServiceTest {
 
     @Autowired
     private OutboxEventRepository outboxEventRepository;
-
-    @MockitoSpyBean
-    private StreamTracePropagator streamTracePropagator;
 
     @BeforeEach
     void setUp() {

--- a/backend/app/src/test/java/coffeeshout/support/app/StreamMockedServiceTest.java
+++ b/backend/app/src/test/java/coffeeshout/support/app/StreamMockedServiceTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.support.app;
 
 import coffeeshout.global.redis.stream.StreamPublisher;
+import coffeeshout.global.redis.stream.StreamTracePropagator;
 import coffeeshout.room.application.service.DelayedRoomRemovalService;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -12,4 +13,10 @@ public abstract class StreamMockedServiceTest extends ServiceTest {
 
     @MockitoSpyBean
     protected DelayedRoomRemovalService delayedRoomRemovalService;
+
+    /**
+     * 컨텍스트 캐시 공유를 위해 베이스에서 spy로 고정한다. 개별 테스트 클래스에 선언하면 클래스마다 새 컨텍스트가 생성된다.
+     */
+    @MockitoSpyBean
+    protected StreamTracePropagator streamTracePropagator;
 }

--- a/backend/infra/src/test/java/coffeeshout/InfraModuleIntegrationTest.java
+++ b/backend/infra/src/test/java/coffeeshout/InfraModuleIntegrationTest.java
@@ -1,12 +1,27 @@
 package coffeeshout;
 
 import coffeeshout.config.ServiceTestConfig;
+import coffeeshout.global.outbox.OutboxAfterCommitRelay;
+import coffeeshout.global.redis.config.RedisStreamResilienceTestConfig;
 import coffeeshout.support.IntegrationTestSupport;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
+/**
+ * RedisStreamResilienceTestConfig 임포트로 RecordingDummyEventConsumer가 minigame 스트림의
+ * 라이브 리스너로 모든 infra 통합 테스트 컨텍스트에 상주한다. 개별 테스트 클래스에 @Import를 선언하면
+ * 클래스마다 새 컨텍스트가 생성되므로 캐시 공유를 위해 베이스에서 임포트한다.
+ */
 @SpringBootTest(classes = InfraModuleTestApplication.class, webEnvironment = WebEnvironment.MOCK)
-@Import(ServiceTestConfig.class)
+@Import({ServiceTestConfig.class, RedisStreamResilienceTestConfig.class})
 public abstract class InfraModuleIntegrationTest extends IntegrationTestSupport {
+
+    /**
+     * 컨텍스트 캐시 공유를 위해 베이스에서 spy로 고정한다. 개별 테스트 클래스에 @MockitoSpyBean을 선언하면
+     * 클래스마다 새 컨텍스트가 생성된다. spy는 기본적으로 실제 동작을 위임하므로 다른 테스트에 영향이 없다.
+     */
+    @MockitoSpyBean
+    protected OutboxAfterCommitRelay outboxAfterCommitRelay;
 }

--- a/backend/infra/src/test/java/coffeeshout/global/outbox/OutboxAfterCommitRelayIntegrationTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/outbox/OutboxAfterCommitRelayIntegrationTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -19,11 +18,9 @@ import org.springframework.transaction.support.TransactionTemplate;
  * <p>
  * 단위 테스트로 검증 불가한 @TransactionalEventListener(phase=AFTER_COMMIT) 바인딩을 검증한다.
  * 트랜잭션이 실제로 커밋된 뒤에만 릴레이가 실행되는지 확인한다.
+ * outboxAfterCommitRelay spy는 베이스 클래스(InfraModuleIntegrationTest)가 제공한다.
  */
 class OutboxAfterCommitRelayIntegrationTest extends InfraModuleIntegrationTest {
-
-    @MockitoSpyBean
-    private OutboxAfterCommitRelay outboxAfterCommitRelay;
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;

--- a/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamSubscriptionResilienceTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamSubscriptionResilienceTest.java
@@ -11,15 +11,14 @@ import java.time.Duration;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
  * 처리에 실패하는 메시지가 끼어도 Redis Stream 구독이 유지되어
  * 후속 메시지를 계속 소비하는지 검증한다.
+ * RedisStreamResilienceTestConfig는 베이스 클래스(InfraModuleIntegrationTest)가 임포트한다.
  */
-@Import(RedisStreamResilienceTestConfig.class)
 class RedisStreamSubscriptionResilienceTest extends InfraModuleIntegrationTest {
 
     private static final String STREAM_KEY = "minigame";

--- a/backend/room/src/test/java/coffeeshout/room/infra/OracleObjectStorageIntegrationTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/OracleObjectStorageIntegrationTest.java
@@ -24,6 +24,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 /**
  * OracleObjectStorageService의 서킷 브레이커 및 리트라이 동작을 검증하는 통합 테스트. 실제 Spring 컨텍스트에서 Resilience4j 어노테이션(@CircuitBreaker,
  * @Retry)과 폴백(fallbackMethod) 로직이 정상적으로 작동하여 InfrastructureException을 던지는지 확인합니다.
+ *
+ * <p>OracleObjectStorageService는 {@code @Profile("!local & !test")}라 공유 테스트 컨텍스트에 존재하지 않으므로,
+ * {@code @Import} + {@code @MockitoBean}으로 별도 컨텍스트를 구성한다. 공유 컨텍스트에 합치면 LocalStorageService와
+ * StorageService 빈이 경합하므로 이 컨텍스트 분리는 의도된 비용이다.
+ *
+ * <p>circuit-breaker-test 프로파일은 oracleStorage resilience4j 설정의 유일한 소스인
+ * application-circuit-breaker-test.yml을 로드한다. 이 컨텍스트는 어차피 캐시를 공유하지 못하므로
+ * 프로파일 추가로 인한 캐시 분리 비용은 없다.
  */
 @ActiveProfiles({"test", "circuit-breaker-test"})
 @Import(OracleObjectStorageTestConfig.class)

--- a/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumerTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerDisconnectedConsumerTest.java
@@ -3,26 +3,27 @@ package coffeeshout.room.infra.messaging.consumer;
 import static org.mockito.Mockito.verify;
 
 import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
-import coffeeshout.RoomModuleServiceTest;
 import coffeeshout.websocket.event.player.PlayerDisconnectedEvent;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class PlayerDisconnectedConsumerTest extends RoomModuleServiceTest {
+@ExtendWith(MockitoExtension.class)
+class PlayerDisconnectedConsumerTest {
 
-    @Autowired
-    Consumer<PlayerDisconnectedEvent> playerDisconnectedEventConsumer;
-
-    @MockitoBean
+    @Mock
     DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @InjectMocks
+    PlayerDisconnectedConsumer playerDisconnectedConsumer;
 
     @Test
     void 플레이어_연결_해제_이벤트를_수신하면_지연_삭제가_스케줄링된다() {
         PlayerDisconnectedEvent event = PlayerDisconnectedEvent.create("ABCD:닉네임", "session-1", "SESSION_DISCONNECT");
 
-        playerDisconnectedEventConsumer.accept(event);
+        playerDisconnectedConsumer.accept(event);
 
         verify(delayedPlayerRemovalService).schedulePlayerRemoval("ABCD:닉네임", "session-1", "SESSION_DISCONNECT");
     }

--- a/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumerTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/PlayerReconnectedConsumerTest.java
@@ -3,26 +3,27 @@ package coffeeshout.room.infra.messaging.consumer;
 import static org.mockito.Mockito.verify;
 
 import coffeeshout.room.infra.websocket.DelayedPlayerRemovalService;
-import coffeeshout.RoomModuleServiceTest;
 import coffeeshout.websocket.event.player.PlayerReconnectedEvent;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class PlayerReconnectedConsumerTest extends RoomModuleServiceTest {
+@ExtendWith(MockitoExtension.class)
+class PlayerReconnectedConsumerTest {
 
-    @Autowired
-    Consumer<PlayerReconnectedEvent> playerReconnectedEventConsumer;
-
-    @MockitoSpyBean
+    @Mock
     DelayedPlayerRemovalService delayedPlayerRemovalService;
+
+    @InjectMocks
+    PlayerReconnectedConsumer playerReconnectedConsumer;
 
     @Test
     void 플레이어_재연결_이벤트를_수신하면_스케줄링된_삭제가_취소된다() {
         PlayerReconnectedEvent event = PlayerReconnectedEvent.create("ABCD:닉네임", "session-1");
 
-        playerReconnectedEventConsumer.accept(event);
+        playerReconnectedConsumer.accept(event);
 
         verify(delayedPlayerRemovalService).cancelScheduledRemoval("ABCD:닉네임");
     }

--- a/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/RoomCreateConsumerTest.java
+++ b/backend/room/src/test/java/coffeeshout/room/infra/messaging/consumer/RoomCreateConsumerTest.java
@@ -3,21 +3,19 @@ package coffeeshout.room.infra.messaging.consumer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
-import coffeeshout.room.application.service.DelayedRoomRemovalService;
+import coffeeshout.room.StreamMockedServiceTest;
 import coffeeshout.room.application.service.RoomQueryService;
 import coffeeshout.room.domain.JoinCode;
 import coffeeshout.room.domain.Room;
 import coffeeshout.room.domain.event.RoomCreateEvent;
 import coffeeshout.room.domain.service.JoinCodeGenerator;
-import coffeeshout.RoomModuleServiceTest;
 import java.util.function.Consumer;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
-class RoomCreateConsumerTest extends RoomModuleServiceTest {
+class RoomCreateConsumerTest extends StreamMockedServiceTest {
 
     @Autowired
     Consumer<RoomCreateEvent> roomCreateEventConsumer;
@@ -27,9 +25,6 @@ class RoomCreateConsumerTest extends RoomModuleServiceTest {
 
     @Autowired
     JoinCodeGenerator joinCodeGenerator;
-
-    @MockitoSpyBean
-    DelayedRoomRemovalService delayedRoomRemovalService;
 
     JoinCode joinCode;
 

--- a/backend/user/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTransactionTest.java
+++ b/backend/user/src/test/java/coffeeshout/user/application/service/UserWithdrawalServiceTransactionTest.java
@@ -2,10 +2,8 @@ package coffeeshout.user.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coffeeshout.config.ServiceTestConfig;
+import coffeeshout.UserModuleIntegrationTest;
 import coffeeshout.fixture.UserFixture;
-import coffeeshout.support.CommonTestSchedulerConfig;
-import coffeeshout.support.TestContainerSupport;
 import coffeeshout.user.domain.User;
 import coffeeshout.user.domain.repository.RefreshTokenRepository;
 import coffeeshout.user.domain.repository.UserRepository;
@@ -13,14 +11,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
-@Import({CommonTestSchedulerConfig.class, ServiceTestConfig.class})
-@ActiveProfiles("test")
-class UserWithdrawalServiceTransactionTest extends TestContainerSupport {
+/**
+ * 트랜잭션 커밋 후 동작(AFTER_COMMIT 리스너)을 검증하므로 실제 ApplicationEventPublisher가 필요하다.
+ * MockEventPublisherConfig를 임포트하는 ServiceTest 대신 통합 테스트 베이스를 사용한다.
+ */
+class UserWithdrawalServiceTransactionTest extends UserModuleIntegrationTest {
 
     @Autowired
     UserWithdrawalService userWithdrawalService;
@@ -36,7 +32,6 @@ class UserWithdrawalServiceTransactionTest extends TestContainerSupport {
 
     @BeforeEach
     void setUp() {
-        cleanDatabase();
         final User user = userRepository.save(UserFixture.회원_엠제이());
         userId = user.getId();
         userCode = user.getUserCode().value();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

<img width="2138" height="402" alt="image" src="https://github.com/user-attachments/assets/322f9952-2056-482c-a28a-3bb1603c0c66" />
8분 오버한 테스트 우선은 5분 대로 축소 작업...

Spring TestContext 캐시를 깨는 개별 테스트 클래스의 `@MockitoBean`/`@MockitoSpyBean`/`@AutoConfigureMockMvc`/`@Import` 선언을 모듈 베이스 클래스로 승격하거나 순수 유닛 테스트로 전환해, 모듈당 컨텍스트 기동 횟수를 줄였습니다.

1. **room** — `PlayerDisconnected/ReconnectedConsumerTest`를 순수 Mockito 유닛 테스트로 전환(한 줄 위임 검증에 풀 컨텍스트 불필요), `RoomCreateConsumerTest`는 동일 spy를 제공하는 `StreamMockedServiceTest` 상속으로 전환
2. **admin** — `@AutoConfigureMockMvc` + `@MockitoBean(ReportRateLimitStore)`를 `AdminModuleIntegrationTest` 베이스로 승격. 컨트롤러 테스트 2개가 베이스 컨텍스트 공유
3. **infra** — `@MockitoSpyBean(OutboxAfterCommitRelay)` + `@Import(RedisStreamResilienceTestConfig)`를 `InfraModuleIntegrationTest` 베이스로 승격. 통합 컨텍스트 3개 → 1개
4. **user** — `UserWithdrawalServiceTransactionTest`의 독자 `@SpringBootTest` 부트스트랩 제거, `UserModuleIntegrationTest` 상속으로 전환
5. **app** — `OutboxE2ETest`의 inner `@TestConfiguration` 제거(`CommonTestSchedulerConfig`/`IntegrationTestConfig`가 동등 보장 제공), `StreamTracePropagator` spy를 `StreamMockedServiceTest` 베이스로 승격

**실측 결과** (`Started ...` 배너 + HikariPool/EntityManagerFactory 카운트 교차 확인): infra 4회 → 2회, admin 4회 → 2회. 전 모듈 테스트 통과.

# 💬 리뷰 중점사항

- **베이스 승격 mock/spy의 공유 영향**: admin `ReportRateLimitStore` mock은 기본 false를 반환하지만 레이트리밋 경로를 타는 통합 테스트는 `ReportControllerTest`뿐이고 자체 `@BeforeEach`에서 스텁합니다. infra `RecordingDummyEventConsumer`는 모든 infra 통합 테스트에 minigame 스트림 라이브 리스너로 상주하게 됩니다(베이스 주석 명시) — 이 트레이드오프가 수용 가능한지 확인 부탁드립니다.
- **`OracleObjectStorageIntegrationTest`는 의도적으로 별도 컨텍스트 유지**: `circuit-breaker-test` 프로파일은 `oracleStorage` resilience4j 설정의 유일한 소스(`application-circuit-breaker-test.yml`은 파일명에만 프로파일명이 있어 grep에 안 걸림)라 제거하면 라이브러리 기본값으로 폴백됩니다. 주석으로 사유를 박아뒀습니다.
- **`OutboxE2ETest` MOCK→RANDOM_PORT 전환**: app `IntegrationTestSupport` 합류에 따른 변화로, HTTP 클라이언트를 쓰지 않아 기능 차이는 없습니다(ADR-0017 허용 범위).
- 부수 발견(이번 범위 제외): `QueryPerformanceTest`가 루트 `build.gradle.kts`의 `exclude`로 실행되지 않는 죽은 테스트 상태, ADR-0013의 선별 `scanBasePackages` 기술과 실제 코드(루트 스캔)의 드리프트.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

본 변경사항은 **내부 테스트 인프라 개선**으로, 최종 사용자에게 보이는 기능 변화는 없습니다.

* **Tests**
  * 테스트 베이스 클래스 및 컨텍스트 구성 통합
  * 테스트 환경의 안정성 및 재사용성 개선

* **Chores**
  * 테스트 설정 최적화 및 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->