### PR TITLE
[chore] CI setup-gradle v6 업그레이드 및 PR 빌드 캐시 쓰기 허용

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -89,7 +89,9 @@ jobs:
         with:
           # PR 런도 캐시를 저장한다 — 같은 PR에 커밋을 거듭 푸시할 때
           # 직전 푸시에서 실행한 모듈 테스트 결과(FROM-CACHE)를 재사용하기 위함.
-          # PR 브랜치 캐시는 해당 PR 스코프에만 보이므로 다른 PR을 오염시키지 않는다.
+          # 캐시는 head 브랜치 스코프에 저장되고, 다른 브랜치는 base/default 브랜치
+          # 캐시를 단방향으로 읽기만 하므로 sibling PR이나 배포 빌드(be/dev·be/prod)로
+          # 역전파되지 않는다. 10GB LRU 압박은 v6 기본 cache-cleanup(on-success)이 완화.
           cache-read-only: false
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -79,15 +79,18 @@ jobs:
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'corretto'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/be/dev' && github.ref != 'refs/heads/be/prod' }}
+          # PR 런도 캐시를 저장한다 — 같은 PR에 커밋을 거듭 푸시할 때
+          # 직전 푸시에서 실행한 모듈 테스트 결과(FROM-CACHE)를 재사용하기 위함.
+          # PR 브랜치 캐시는 해당 PR 스코프에만 보이므로 다른 PR을 오염시키지 않는다.
+          cache-read-only: false
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## 배경

멀티 모듈 분리 후 CI 테스트 시간 분석 과정에서 두 가지를 발견했다.

1. Dependabot이 `gradle/actions/setup-gradle` v6, `actions/setup-java` v5 버전업을 **main에만** 머지함 (#1319, #1334). 워크플로우는 트리거된 ref의 파일로 실행되므로 백엔드 CI(PR·CD 모두 be/dev 기준)에는 한 번도 적용되지 않았다.
2. `cache-read-only`가 PR 런에서 true라, 같은 PR에 커밋을 거듭 푸시해도 비교 기준이 항상 "마지막 be/dev 머지 시점" 캐시였다. 1번째 푸시에서 이미 통과한 모듈 테스트가 2, 3번째 푸시에서도 매번 재실행됐다.

## 변경 사항

- `actions/setup-java` v4 → v5, `gradle/actions/setup-gradle` v4 → v6
  - v6 기본 캐시 제공자(enhanced)는 public repo에서 추가 동의 입력 없이 사용 가능, `cache-read-only` 시맨틱 동일 (문서 확인)
- `cache-read-only: false` — PR 런도 캐시를 저장해 직전 푸시 결과를 FROM-CACHE로 재사용
  - PR 브랜치 캐시는 해당 PR 스코프에만 보이므로 다른 PR 오염 없음
  - 트레이드오프: repo 캐시 용량(10GB, LRU 축출) 사용량 증가

## 검증

- 최근 PR 런(27099625752) 로그 실측: 변경 없는 모듈(web/profanity/websocket/zzolbot)은 이미 FROM-CACHE로 스킵 중 — 빌드 캐시 메커니즘 자체는 정상 동작 확인
- 이 PR 자체가 backend-ci paths에 걸려 변경된 워크플로우 파일로 CI가 실행됨 (v6 동작 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 빌드 파이프라인 인프라 업데이트: 관련 액션 버전 및 캐시 처리 방식을 개선하여 빌드 안정성과 성능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->