### PR TITLE
[chore] Dependabot 전 블록을 실제 작업 브랜치(be/dev·fe/dev)로 리타겟

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,17 @@
 version: 2
 updates:
+  # 백엔드 코드는 be/dev가 실제 작업 브랜치 — main의 backend는 멀티모듈 전환 이전
+  # 화석이라 main 스캔은 무의미하다. be/dev의 libs.versions.toml을 스캔해 be/dev로 PR을 보낸다.
   - package-ecosystem: "gradle"
     directory: "/backend"
+    target-branch: "be/dev"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - "BE"
       - "backend"
 
   - package-ecosystem: "npm"
@@ -30,6 +34,7 @@ updates:
       - "dependencies"
       - "ws-mcp"
 
+  # main의 워크플로우 파일용 + 보안 업데이트(Dependabot 보안 업데이트는 default 브랜치만 타깃)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -38,4 +43,18 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - "github-actions"
+
+  # 실행 브랜치 be/dev의 워크플로우 버전업 — main에만 bump가 와서 be/dev가 영원히
+  # 구버전으로 남는 문제(setup-gradle v4 잔존) 방지를 위해 be/dev 타깃 블록을 별도로 둔다.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "be/dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "BE"
       - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,24 +14,31 @@ updates:
       - "BE"
       - "backend"
 
+  # 프론트엔드 실제 작업 브랜치는 fe/dev (main 대비 수백 커밋 앞섬) — fe/dev를 스캔·타깃한다.
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "fe/dev"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+      - "FE"
       - "frontend"
 
+  # tools/ws-mcp는 main에 존재하지 않아(be/dev·fe/dev에만 있음) main 스캔은 no-op이었다.
+  # ws-mcp-ci 트리거가 be/dev·be/prod이므로 be/dev를 타깃한다.
   - package-ecosystem: "npm"
     directory: "/tools/ws-mcp"
+    target-branch: "be/dev"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+      - "BE"
       - "ws-mcp"
 
   # main의 워크플로우 파일용 + 보안 업데이트(Dependabot 보안 업데이트는 default 브랜치만 타깃)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # minor·patch는 PR 1개로 묶어 알림 폭주 방지. major(예: Spring Boot 메이저)만 개별 PR.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "BE"
@@ -22,6 +28,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "FE"
@@ -36,6 +47,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "BE"
@@ -48,6 +64,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # 액션 버전업은 대부분 저위험이라 major 포함 전부 PR 1개로 묶는다.
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"
@@ -61,6 +82,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "BE"


### PR DESCRIPTION
## 배경

Dependabot은 설정·스캔 모두 default 브랜치(main) 기준으로 동작하는데, 이 repo는 실제 작업이 be/dev(백엔드)·fe/dev(프론트엔드)에서 이뤄져 모든 블록이 헛돌고 있었다.

| 블록 | main 스캔의 실태 |
|---|---|
| gradle (/backend) | main의 backend는 멀티모듈 전환 이전 화석 — 존재하지 않는 옛 build.gradle 기준 bump |
| npm (/frontend) | fe/dev가 main 대비 326커밋 앞섬 — stale package.json 기준 bump |
| npm (/tools/ws-mcp) | **main에 디렉토리 자체가 없음** — 지금까지 no-op |
| github-actions | bump가 main에만 도착, 실행 브랜치 be/dev는 구버전 방치 (setup-gradle v4 잔존 원인, #1370에서 수동 반영) |

## 변경 사항

### 1. 실제 작업 브랜치로 리타겟

- **gradle** → `target-branch: be/dev` + BE 라벨
- **npm (/frontend)** → `target-branch: fe/dev` + FE 라벨
- **npm (/tools/ws-mcp)** → `target-branch: be/dev` + BE 라벨 (소스·ws-mcp-ci 트리거 모두 be/dev)
- **github-actions** → main 블록 유지(보안 업데이트는 default 브랜치만 타깃) + `target-branch: be/dev` 블록 추가

### 2. groups로 PR 폭주 방지

- **gradle·npm**: minor/patch를 `minor-and-patch` 그룹 PR 1개로 통합, major만 개별 PR
- **github-actions**: 저위험이라 major 포함 전부 `actions` 그룹 1개
- 효과: 최악의 주 PR 15개+ → 평소 주당 2~4개

## 참고

- `dependabot.yml`은 default 브랜치에서만 읽히므로 이 변경은 main 타깃이 맞다
- 같은 ecosystem+directory라도 `target-branch`가 다르면 중복 블록 허용 (공식 문서의 멀티 브랜치 유지 패턴)
- fe/prod·be/prod는 dev→prod 머지로 전파되므로 별도 타깃 불필요
- 보안 업데이트는 그루핑·주기와 무관하게 발견 즉시 개별 PR로 옴
- ⚠️ FE팀에 dependabot PR 수신 위치가 fe/dev로 바뀐다는 점 공유 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
