### PR TITLE
[refactor] QueryDSL을 openfeign fork 7.0으로 교체 (ADR-0020 Phase 1)

### DIFF
--- a/backend/admin/build.gradle.kts
+++ b/backend/admin/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation(libs.redisson)
-    implementation(variantOf(libs.querydsl.jpa) { classifier("jakarta") })
+    implementation(libs.querydsl.jpa)
 
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
     implementation(libs.resilience4j)
 
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/backend/game/build.gradle.kts
+++ b/backend/game/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core")
     implementation("io.micrometer:context-propagation")
 
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ spring-doc                   = "2.8.17"
 oci-sdk                      = "3.74.1"
 redisson                     = "4.4.0"
 zxing                        = "3.5.3"
-querydsl                     = "5.0.0"
+querydsl                     = "7.0"
 google-genai                 = "1.55.0"
 testcontainers               = "2.0.5"
 reflections                  = "0.10.2"
@@ -22,8 +22,8 @@ springdoc-openapi            = { module = "org.springdoc:springdoc-openapi-start
 
 redisson                     = { module = "org.redisson:redisson-spring-boot-starter",               version.ref = "redisson" }
 
-querydsl-jpa                 = { module = "com.querydsl:querydsl-jpa",                              version.ref = "querydsl" }
-querydsl-apt                 = { module = "com.querydsl:querydsl-apt",                              version.ref = "querydsl" }
+querydsl-jpa                 = { module = "io.github.openfeign.querydsl:querydsl-jpa",             version.ref = "querydsl" }
+querydsl-apt                 = { module = "io.github.openfeign.querydsl:querydsl-apt",             version.ref = "querydsl" }
 
 oci-sdk-bom                  = { module = "com.oracle.oci.sdk:oci-java-sdk-bom",                    version.ref = "oci-sdk" }
 

--- a/backend/infra/build.gradle.kts
+++ b/backend/infra/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
 
     implementation(libs.redisson)
 
-    implementation(variantOf(libs.querydsl.jpa) { classifier("jakarta") })
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    implementation(libs.querydsl.jpa)
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/backend/profanity/build.gradle.kts
+++ b/backend/profanity/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
-    implementation(variantOf(libs.querydsl.jpa) { classifier("jakarta") })
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    implementation(libs.querydsl.jpa)
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 }

--- a/backend/room/build.gradle.kts
+++ b/backend/room/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation("io.micrometer:context-propagation")
 
     implementation(libs.resilience4j)
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 

--- a/backend/user/build.gradle.kts
+++ b/backend/user/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)
 
-    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jakarta") })
+    annotationProcessor(variantOf(libs.querydsl.apt) { classifier("jpa") })
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev) → **be/dev**

# 🔥 연관 이슈

- part of #1358 (스프링 부트4 마이그레이션 — ADR-0020)

> ADR-0020의 **Phase 1**만 다루므로 이슈를 close 하지 않는다. Phase 2(Boot 4.0.x)·Phase 3(Jackson 3) 완료 시 종료.

# 🚀 작업 내용

ADR-0020 **Phase 1 — QueryDSL fork 교체 (Boot 3.5에서 선행)**.

죽은 원본 `com.querydsl:5.0.0`(2021년 이후 릴리스 없음, Boot 4·Hibernate 7 미동작)을 커뮤니티 유지보수 포크 `io.github.openfeign.querydsl:7.0`으로 교체한다. fork는 Boot 3.5에서도 동작하므로 Boot 4 전환과 분리해 가장 큰 변수를 선행 제거한다.

1. `gradle/libs.versions.toml`: 모듈 좌표 `com.querydsl` → `io.github.openfeign.querydsl`, 버전 `5.0.0` → `7.0`
2. `querydsl-jpa`(infra·admin·profanity): `variantOf { classifier("jakarta") }` 제거 → 평문 `libs.querydsl.jpa`. fork 7.x의 `querydsl-jpa`는 jakarta-native라 `jakarta` classifier 변형을 발행하지 않음
3. `querydsl-apt`(infra·admin·profanity·room·user·game 6개): annotationProcessor classifier `jakarta` → `jpa`. fork에서 `JPAAnnotationProcessor`를 담은 권장 경로
4. fork가 `com.querydsl.*` 패키지명을 그대로 보존하므로 **프로덕션 소스 import 무수정**

## 검증

- `clean compileJava compileTestJava` → `BUILD SUCCESSFUL`. 6개 모듈 전부 새 프로세서로 Q클래스 재생성 + main/test 컴파일 통과
- `:infra:dependencies --configuration annotationProcessor` → `io.github.openfeign.querydsl:querydsl-apt:7.0` + `querydsl-codegen`/`querydsl-core` 정상 해석 (빈 변형 폴백 아님)
- ArchUnit·TestContainers 통합 테스트 전체 통과는 CI 게이트에 위임

# 💬 리뷰 중점사항

- `querydsl-apt`의 classifier가 `jpa`인지 (jakarta 아님) — fork 7.x 권장 좌표. `querydsl-jpa`는 반대로 classifier 없음(jakarta 기본)
- ADR-0020 본문 명시 6개 모듈(`admin·infra·profanity·room·user·game`) 전부 교체, 누락 0
- 모듈 의존(`project(...)`) 변경 없음 → ADR-0011 의존 방향 제약 무영향
- 참고: `:room/:user/:game`이 `querydsl-jpa`를 직접 선언 안 하고 `:infra` 전이에 의존하는 건 **기존 구성 그대로**(이번 변경 무관). Phase 2 클래스패스 슬림화 재검토 후보


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * QueryDSL 버전을 5.0.0에서 7.0으로 업그레이드했습니다.
  * QueryDSL 의존성 설정을 표준화하여 모든 백엔드 모듈의 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->