### PR TITLE
[docs] ADR-0022 RedisStreamContainerRegistry 구조 및 타임아웃 설정화 기록

### DIFF
--- a/backend/docs/adr/0022-redis-stream-listener-start-offset.md
+++ b/backend/docs/adr/0022-redis-stream-listener-start-offset.md
@@ -42,14 +42,25 @@
 final var container = createContainer(...);          // start() 호출 제거
 final Subscription subscription = container.register(buildReadRequest(streamKey), this::onMessage);
 container.start();
-subscription.await(Duration.ofSeconds(5));            // 폴링 태스크 시작 보장, 실패 시 기동 실패
+// 타임아웃은 commonSettings.subscriptionStartTimeout(기본 5s)으로 설정화
+subscription.await(properties.commonSettings().subscriptionStartTimeout());
 ```
 
 `await()` 실패(타임아웃·인터럽트)는 `IllegalStateException`으로 전환해 **앱 기동을 실패시킨다**. 메시지 처리 흐름 전체가 Redis Stream을 경유하므로(CLAUDE.md 핵심 제약) 구독 없는 기동은 무의미하다 — fail-fast 후 오케스트레이터 재시작이 옳다.
 
+대기 한도는 하드코딩하지 않고 `common-settings.subscription-start-timeout`(`@DefaultValue("5s")`)으로 바인딩한다 — 환경별로 조정 가능하다.
+
 ### 3. errorHandler 단일화
 
 container options의 errorHandler를 제거한다. 진실 공급원은 `buildReadRequest()` 하나다. options 쪽을 폴백으로 남기면 "errorHandler는 있는데 `cancelOnError`는 기본값(`t -> true`)인 구독"이 조용히 생길 수 있다 — 예외 1건으로 구독이 영구 취소되는, 직전에 수정한 버그(PR #1359)의 재발 경로다. 모든 구독 등록은 `buildReadRequest()`를 경유해야 한다.
+
+### 4. 컨테이너 장부 단일화: `RedisStreamContainerRegistry`
+
+기존에는 같은 컨테이너가 두 곳에 기록됐다 — Spring 컨텍스트에 동적 빈으로(`registerBean` + `stream-container-%s` 문자열 빈 이름) 등록하고, 종료용으로 별도 List에도 담았다. 이를 스트림 키별 단일 장부(`ConcurrentHashMap`)인 `RedisStreamContainerRegistry`로 일원화한다.
+
+- 등록은 Starter가 전담한다 (`registry.register()` — start/await **이전**에 호출하므로 await 실패로 기동이 중단돼도 stop 대상에 포함된다)
+- 조회는 Recovery·HealthIndicator가 `registry.find()`(Optional)로 한다 — 기존 `applicationContext.getBean(문자열, ...)` + `NoSuchBeanDefinitionException` catch 방식을 폐기한다
+- 동적 빈 등록·문자열 빈 이름 결합(프로덕션 + 테스트)이 완전히 제거된다
 
 ## 구현 시 주의사항
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- ADR-0022 후속 문서화 (코드는 #1361 에서 머지 완료)

# 🚀 작업 내용

1. ADR-0022 문서에 `RedisStreamContainerRegistry` 컨테이너 장부 단일화 결정(섹션 4) 추가
2. 구독 시작 타임아웃을 `common-settings.subscription-start-timeout`(`@DefaultValue("5s")`)으로 설정화한 내용 반영

# 💬 리뷰 중점사항

- 순수 문서 변경입니다. #1361 에서 이미 머지된 코드(`RedisStreamContainerRegistry`, 타임아웃 설정화)의 결정 근거를 ADR에 뒤늦게 보강하는 PR입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Redis Stream 리스너 초기화 과정의 순서 및 타임아웃 처리 메커니즘에 대한 아키텍처 문서 업데이트
  * 애플리케이션 시작 실패 시나리오 및 에러 처리 흐름 명확화
  * 컨테이너 관리 방식 개선에 대한 아키텍처 결정 문서화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->