### PR TITLE
[chore] 하네스 정리 — 낡은 always-on 규칙·스킬 드리프트 수정 (harness-legacy-scan 반영)

### DIFF
--- a/backend/.claude/agents/test-verifier.md
+++ b/backend/.claude/agents/test-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: test-verifier
 description: 테스트 코드를 docs/conventions-test.md 기준으로 독립적 시각에서 리뷰하고 관련 테스트를 실행·분석한다. 수정 제안만 출력하며 프로덕션/테스트 코드는 직접 수정하지 않는다.
-model: claude-haiku-4-5-20251001
+model: haiku
 tools: Bash, Read, Glob, Grep, Edit
 ---
 

--- a/backend/.claude/skills/ci-fix/SKILL.md
+++ b/backend/.claude/skills/ci-fix/SKILL.md
@@ -45,7 +45,7 @@ bash .claude/skills/ci-fix/fetch-failures.sh <PR번호>
 
 ## Step 5: 전체 회귀 확인
 
-모든 수정 완료 후 `./gradlew test` 로 영향 받은 모듈 전체를 확인한다. 실패 시 Step 4와 동일하게 XML을 분석한다.
+모든 수정 완료 후 `/run-tests`로 영향 받은 모듈 전체를 확인한다(전체 회귀는 `./gradlew test` 직접 실행 대신 위임 — CLAUDE.md 테스트 실행 규칙). 실패 시 Step 4와 동일하게 XML을 분석한다.
 
 ## Step 6: 커밋
 

--- a/backend/.claude/skills/commit/SKILL.md
+++ b/backend/.claude/skills/commit/SKILL.md
@@ -86,7 +86,7 @@ git add <그룹 내 파일 목록>
 git commit -m "$(cat <<'EOF'
 <커밋 메시지>
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+<하네스가 지정한 Co-Authored-By 트레일러를 그대로 붙인다 — 모델명 하드코딩 금지>
 EOF
 )"
 ```

--- a/backend/.claude/skills/create-issue/SKILL.md
+++ b/backend/.claude/skills/create-issue/SKILL.md
@@ -98,7 +98,7 @@ git checkout -b be/{type}/{issue-number}-{slug}
 - `{slug}`: 이슈 제목을 소문자 + 하이픈으로 변환, 최대 40자
 - 한국어 단어는 의미를 유지하는 영문으로 변환
 
-## 6. 완료 출력
+## 7. 완료 출력
 
 ```text
 ✅ 이슈 생성: https://github.com/.../issues/{N}

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -19,26 +19,18 @@
 - 모호한 목표는 구현 전에 검증 가능한 성공 기준으로 바꾼다 (예: "버그 수정" → "버그 재현 테스트 작성 후 통과")
 - 프로덕션 코드(`src/main/java/`) 작성 또는 수정 완료 시 `/write-tests`를 실행한다
 - 테스트 실행은 단일 클래스 빠른 확인을 제외하고 `/run-tests`를 사용한다
-- 이미 읽은 파일은 다시 읽지 않는다 diff를 통해 변경된 줄만 확인한다.
 - 20줄 이상의 대량 출력이 예상되는 탐색·분석 작업은 서브에이전트에 위임한다
-- **사용자가 이미 설명한 내용은 다시 반복하지 않는다**
 - 코드 작성 전 `docs/adr/index.md`의 **영향 범위** 컬럼을 작업 중인 패키지/주제와 비교한다. 겹치는 ADR이 있으면 해당 파일을 읽어 **핵심 제약**과 충돌 여부를 확인하고, 충돌 시 작업 전에 사용자에게 경고한다
 
 ## 코드 탐색
 
-파일을 Read하기 전에 **반드시 먼저 Grep으로 파일 경로와 줄 번호를 확인**한 뒤, `offset`과 `limit`을 지정해 필요한 범위만 읽는다.
+파일을 Read하기 전에 **먼저 Grep 툴로 파일 경로와 줄 번호를 확인**한 뒤, `offset`과 `limit`을 지정해 필요한 범위만 읽는다.
 
-```bash
-# 1단계: 파일 경로 + 줄 번호 획득 (내용은 읽지 않음)
-grep -rn "class CardGameFlowOrchestrator" src/
-grep -rn "void startRound" src/
+1. Grep 툴로 심볼 위치를 찾는다 (예: 패턴 `class CardGameFlowOrchestrator`, `void startRound`) — 내용은 읽지 않고 경로·줄 번호만 얻는다
+2. 얻은 줄 번호로 `Read(file, offset=N, limit=40)` — 전체 파일 Read는 피한다
 
-# 2단계: 해당 범위만 읽기 — 전체 파일 Read 금지
-Read(file, offset=N, limit=40)
-```
-
-- 구조 파악이 목적이면 `grep -n "public\|private\|class\|interface" 파일` 로 메서드 목록만 먼저 확인한다
-- Java는 파일명 = 클래스명 규칙이 강제되므로 클래스명을 알면 경로를 예측해 Grep 없이 바로 Read할 수 있다
+- 구조 파악이 목적이면 Grep 툴로 `public|private|class|interface` 패턴을 잡아 메서드 목록만 먼저 확인한다
+- Java는 파일명 = 클래스명 규칙이 강제되므로 클래스명을 알면 경로를 예측해 바로 Read할 수 있다 (이 경우 Grep 생략 가능)
 
 ## 아키텍처 핵심 제약
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- 없음 (harness-legacy-scan 감사 결과 반영)

# 🚀 작업 내용

https://gist.github.com/devbrother2024/3774b32bccce69e0e0eeb9dbc953c6bf 해당 프롬프트를 보고 활용해본 내용입니다.

읽기 전용 하네스 감사(harness-legacy-scan)에서 **UPHOLD·low-risk로 확인된 7건**만 반영했습니다. 권한(settings)·유저 메모리·SOFTEN 항목은 제외했습니다.

1. **CLAUDE.md (always-on 감량)**
   - 제품 하네스가 동일 보장하는 '이미 읽은 파일 재read 금지' 불릿 제거
   - 시스템 기본 스타일과 중복되는 '사용자가 이미 설명한 내용 반복 금지' 불릿 제거
   - `## 코드 탐색`: `grep -rn` bash 예시 → Grep 툴 프레이밍으로 교체 (Bash 툴이 권고하는 전용 툴 사용과 정합). locate→narrow 원칙과 Java(파일명=클래스명) 예외는 그대로 보존
2. **skills/commit**: `Co-Authored-By` 모델명 하드코딩(`Claude Sonnet 4.6`) 제거 → 하네스가 매 세션 지정하는 트레일러 사용 (모델 버전 드리프트 제거)
3. **skills/ci-fix**: Step 5 전체 회귀를 `./gradlew test` 직접 실행 → `/run-tests` 위임으로 정렬 (CLAUDE.md 테스트 실행 규칙). Step 4 단일 테스트 빠른 확인은 예외로 유지
4. **skills/create-issue**: 헤딩 번호 중복(`## 6` 두 번) → `## 7. 완료 출력`로 정정
5. **agents/test-verifier**: `model: claude-haiku-4-5-20251001` 날짜 핀 → `haiku` 별칭 (모델 리네임/폐기 시 깨짐 방지, code-reviewer의 `model: opus`와 형식 통일)

변경 규모: 5 files, +9 / −17.

## 보류한 항목 (의도적 제외)

- **'20줄 위임' 압축**: 이미 구체 임계치를 담은 한 줄이라 줄일 게 없음
- **impl Phase 1/2/3 중복 제거**: impl은 lazy-load 스킬이라 always-on 비용이 0이고, Phase별 반복 `/write-tests` 호출이 "계층별 테스트 누락"을 막는 안전장치라 합치면 회귀 위험 → 보류
- 권한(settings.local.json)·유저 MEMORY·SOFTEN 2건은 사람 승인/부분손실 위험으로 이번 범위 밖

# 💬 리뷰 중점사항

- CLAUDE.md 코드 탐색 섹션 재작성이 기존 의도(부분 읽기·Java 직접 Read 예외)를 훼손하지 않는지
- `agents/test-verifier`의 `model: haiku` 별칭이 의도한 haiku 티어로 정상 동작하는지
