### PR TITLE
[refactor] 게임 모듈 통합 테스트 실행시간 최적화

### DIFF
--- a/backend/app/src/main/resources/config/game.yml
+++ b/backend/app/src/main/resources/config/game.yml
@@ -31,6 +31,7 @@ racing-game:
     description: 4000ms
     prepare: 2000ms
     race-finished-delay: 2000ms
+    move-interval: 100ms
 
 speed-touch:
   timing:

--- a/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/application/RacingGameService.java
@@ -12,7 +12,6 @@ import coffeeshout.racinggame.domain.SpeedCalculator;
 import coffeeshout.racinggame.domain.event.RaceFinishedEvent;
 import coffeeshout.racinggame.domain.event.RaceStateChangedEvent;
 import coffeeshout.racinggame.domain.event.RunnersMovedEvent;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ScheduledFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -92,7 +91,7 @@ public class RacingGameService implements MiniGameService {
 
     private ScheduledFuture<?> scheduleAutoMoveTask(RacingGame racingGame, String joinCode) {
         return taskScheduler.scheduleAtFixedRate(() -> executeAutoMove(racingGame, joinCode),
-                Duration.ofMillis(RacingGame.MOVE_INTERVAL_MILLIS));
+                timing.moveInterval());
     }
 
     private void executeAutoMove(RacingGame racingGame, String joinCode) {

--- a/backend/game/src/main/java/coffeeshout/racinggame/config/RacingGameTimingProperties.java
+++ b/backend/game/src/main/java/coffeeshout/racinggame/config/RacingGameTimingProperties.java
@@ -11,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 public record RacingGameTimingProperties(
         @NotNull @DurationMin(nanos = 1) Duration description,
         @NotNull @DurationMin(nanos = 1) Duration prepare,
-        @NotNull @DurationMin(nanos = 1) Duration raceFinishedDelay
+        @NotNull @DurationMin(nanos = 1) Duration raceFinishedDelay,
+        @NotNull @DurationMin(nanos = 1) Duration moveInterval
 ) {
 }

--- a/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/blindtimer/ui/BlindTimerGameIntegrationTest.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,80 +53,36 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
         session = createSession(joinCode.getValue(), host.getName());
     }
 
+    /**
+     * 시작→상태 전환→STOP 진행도→전원 STOP DONE은 모두 하나의 게임 플로우 위에서 순서대로 일어난다.
+     * 페이즈마다 게임을 재시작하면 description/prepare/playing 대기가 중복되므로,
+     * 단일 플로우에서 상태 전환·진행도 브로드캐스트·DONE 전환을 함께 검증한다.
+     */
     @Test
-    void 블라인드타이머_게임을_시작하면_상태_변경_메시지가_전송된다() {
+    void 게임_시작부터_전원_STOP까지_상태와_진행도가_순서대로_브로드캐스트된다() {
         // given
         final String joinCodeValue = joinCode.getValue();
         final String subscribeStateUrl = String.format("/topic/room/%s/blind-timer/state", joinCodeValue);
         final String subscribeProgressUrl = String.format("/topic/room/%s/blind-timer/progress", joinCodeValue);
+        final String stopUrl = String.format("/app/room/%s/blind-timer/stop", joinCodeValue);
 
         var stateResponses = session.subscribe(subscribeStateUrl);
         var progressResponses = session.subscribe(subscribeProgressUrl);
 
-        // when
+        // when - 게임 시작
         startBlindTimerGame();
 
-        // then - DESCRIPTION 상태 (targetTimeMillis 포함)
+        // 상태 전환: DESCRIPTION(targetTimeMillis) → PREPARE → PLAYING
         BlindTimerStateResponse descriptionState = payloadAs(stateResponses.get(2, TimeUnit.SECONDS), BlindTimerStateResponse.class);
-        assertThat(descriptionState.state()).isEqualTo("DESCRIPTION");
-        assertThat(descriptionState.targetTimeMillis()).isEqualTo(10000);
-
-        // PREPARE 상태
         BlindTimerStateResponse prepareState = payloadAs(stateResponses.get(6, TimeUnit.SECONDS), BlindTimerStateResponse.class);
-        assertThat(prepareState.state()).isEqualTo("PREPARE");
-
-        // PLAYING 상태
-        BlindTimerStateResponse playingState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
-        assertThat(playingState.state()).isEqualTo("PLAYING");
-    }
-
-    @Test
-    void STOP하면_진행도_브로드캐스트_메시지가_전송된다() {
-        // given
-        final String joinCodeValue = joinCode.getValue();
-        final String subscribeStateUrl = String.format("/topic/room/%s/blind-timer/state", joinCodeValue);
-        final String subscribeProgressUrl = String.format("/topic/room/%s/blind-timer/progress", joinCodeValue);
-        final String stopUrl = String.format("/app/room/%s/blind-timer/stop", joinCodeValue);
-
-        var stateResponses = session.subscribe(subscribeStateUrl);
-        var progressResponses = session.subscribe(subscribeProgressUrl);
-
-        // 게임 시작
-        startBlindTimerGame();
-
-        stateResponses.get(2, TimeUnit.SECONDS); // DESCRIPTION
-        stateResponses.get(6, TimeUnit.SECONDS); // PREPARE
         progressResponses.get(6, TimeUnit.SECONDS); // PREPARE 시 초기 progress
-        stateResponses.get(10, TimeUnit.SECONDS); // PLAYING
+        BlindTimerStateResponse playingState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
 
-        // when - STOP
+        // host STOP → 진행도 브로드캐스트
         session.send(stopUrl, new StopCommand(host.getName()));
-
-        // then - 진행도 응답
         BlindTimerProgressResponse progressUpdate = payloadAs(progressResponses.get(3, TimeUnit.SECONDS), BlindTimerProgressResponse.class);
-        assertThat(progressUpdate.players()).isNotEmpty();
-    }
 
-    @Test
-    void 전원_STOP하면_DONE_상태가_전송된다() {
-        // given
-        final String joinCodeValue = joinCode.getValue();
-        final String subscribeStateUrl = String.format("/topic/room/%s/blind-timer/state", joinCodeValue);
-        final String subscribeProgressUrl = String.format("/topic/room/%s/blind-timer/progress", joinCodeValue);
-        final String stopUrl = String.format("/app/room/%s/blind-timer/stop", joinCodeValue);
-
-        var stateResponses = session.subscribe(subscribeStateUrl);
-        var progressResponses = session.subscribe(subscribeProgressUrl);
-
-        // 게임 시작 후 PLAYING 까지 대기
-        startBlindTimerGame();
-
-        stateResponses.get(2, TimeUnit.SECONDS); // DESCRIPTION
-        stateResponses.get(6, TimeUnit.SECONDS); // PREPARE
-        progressResponses.get(6, TimeUnit.SECONDS); // initial progress
-        stateResponses.get(10, TimeUnit.SECONDS); // PLAYING
-
-        // when - 모든 플레이어 STOP
+        // 전원 STOP (host 포함, 재STOP은 멱등) → DONE
         for (Gamer gamer : gamers) {
             final String playerName = gamer.getName();
             session.send(stopUrl, new StopCommand(playerName));
@@ -136,10 +93,17 @@ class BlindTimerGameIntegrationTest extends GameModuleWebSocketTest {
                             assertThat(game.findPlayer(playerName).isStopped()).isTrue()
                     );
         }
-
-        // then - DONE 상태 확인
         BlindTimerStateResponse doneState = payloadAs(stateResponses.get(10, TimeUnit.SECONDS), BlindTimerStateResponse.class);
-        assertThat(doneState.state()).isEqualTo("DONE");
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(descriptionState.state()).isEqualTo("DESCRIPTION");
+            softly.assertThat(descriptionState.targetTimeMillis()).isEqualTo(10000);
+            softly.assertThat(prepareState.state()).isEqualTo("PREPARE");
+            softly.assertThat(playingState.state()).isEqualTo("PLAYING");
+            softly.assertThat(progressUpdate.players()).isNotEmpty();
+            softly.assertThat(doneState.state()).isEqualTo("DONE");
+        });
     }
 
     /**

--- a/backend/game/src/test/java/coffeeshout/blockstacking/ui/BlockStackingIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/blockstacking/ui/BlockStackingIntegrationTest.java
@@ -19,6 +19,7 @@ import coffeeshout.support.MessageResponse;
 import coffeeshout.support.TestStompSession;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,67 +78,21 @@ class BlockStackingIntegrationTest extends GameModuleWebSocketTest {
             assertThat(playingMessage.duration()).isGreaterThanOrEqualTo(PREPARE_MS - 100);
             assertThat(playing.endTimeEpochMs()).isNotNull();
             assertThat(done.state()).isEqualTo(BlockStackingGameState.DONE);
+            // DONE 전환은 playing 제한 시간(2000ms) 이후여야 한다
             assertThat(doneMessage.duration()).isGreaterThanOrEqualTo(PLAYING_MS - 100);
             assertThat(done.endTimeEpochMs()).isNull();
-        }
-
-        @Test
-        void PREPARE_단계에서_state_필드가_포함된_응답을_받는다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startBlockStackingGame();
-
-            final BlockStackingStateResponse prepare = payloadAs(stateResponses.get(), BlockStackingStateResponse.class);
-
-            assertThat(prepare.state()).isEqualTo(BlockStackingGameState.PREPARE);
-        }
-
-        @Test
-        void 타이머_만료_후_게임이_완료된다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startBlockStackingGame();
-
-            stateResponses.get(); // PREPARE
-            stateResponses.get(); // PLAYING
-
-            // playing(2000ms) 후 DONE 전환
-            final MessageResponse doneMessage = stateResponses.get(4, TimeUnit.SECONDS);
-            final BlockStackingStateResponse done = payloadAs(doneMessage, BlockStackingStateResponse.class);
-
-            assertThat(done.state()).isEqualTo(BlockStackingGameState.DONE);
-
-            // 핵심 검증: playing 제한 시간(2000ms) 이내에 done으로 전환되지 않음
-            assertThat(doneMessage.duration())
-                    .as("DONE 전환은 playing 제한 시간(%dms) 이후여야 합니다", PLAYING_MS)
-                    .isGreaterThanOrEqualTo(PLAYING_MS - 100);
         }
     }
 
     @Nested
     class 진행_이벤트_테스트 {
 
+        /**
+         * 유효한 안착이 층수를 갱신하고, 여러 플레이어의 진행이 랭킹 내림차순으로 정렬되는지를
+         * 한 번의 PLAYING 플로우에서 함께 검증한다. (개별 안착 검증과 랭킹 검증이 같은 진행 시퀀스를 공유)
+         */
         @Test
-        void 유효한_블록_안착_이벤트가_랭킹을_업데이트한다() {
-            final var stateResponses = session.subscribe(stateUrl());
-            final var progressResponses = session.subscribe(progressUrl());
-
-            startBlockStackingGame();
-
-            stateResponses.get(); // PREPARE
-            stateResponses.get(); // PLAYING
-
-            session.send(progressCommandUrl(), progressCommand(1, 100.0, 85.0, 150.0));
-
-            final BlockStackingProgressResponse progress =
-                    payloadAs(progressResponses.get(), BlockStackingProgressResponse.class);
-
-            final BlockStackingPlayerRankInfo 꾹이 = findByName(progress, "꾹이");
-            assertThat(꾹이.floor()).isEqualTo(1);
-        }
-
-        @Test
-        void 여러_플레이어의_진행을_랭킹_내림차순으로_브로드캐스트한다() throws Exception {
+        void 유효한_안착이_층수를_갱신하고_여러_플레이어가_랭킹_내림차순으로_브로드캐스트된다() throws Exception {
             final TestStompSession 루키세션 = createSession(joinCode.getValue(), "루키");
 
             final var stateResponses = session.subscribe(stateUrl());
@@ -148,25 +103,30 @@ class BlockStackingIntegrationTest extends GameModuleWebSocketTest {
             stateResponses.get(); // PREPARE
             stateResponses.get(); // PLAYING
 
-            // 꾹이: 2층, 루키: 1층
+            // 꾹이 1층
             session.send(progressCommandUrl(), progressCommand(1, 100.0, 85.0, 150.0));
-            progressResponses.get(); // 꾹이 1층 브로드캐스트
+            final BlockStackingProgressResponse 꾹이1층 =
+                    payloadAs(progressResponses.get(), BlockStackingProgressResponse.class);
 
+            // 꾹이 2층
             session.send(progressCommandUrl(), progressCommand(2, 100.0, 85.0, 135.0));
             progressResponses.get(); // 꾹이 2층 브로드캐스트
 
+            // 루키 1층
             루키세션.send(progressCommandUrl(), progressCommand(1, 100.0, 85.0, 135.0));
             final BlockStackingProgressResponse ranking =
                     payloadAs(progressResponses.get(), BlockStackingProgressResponse.class);
 
-            // 꾹이(2층)가 루키(1층)보다 앞에 위치
-            final int 꾹이위치 = indexOfName(ranking, "꾹이");
-            final int 루키위치 = indexOfName(ranking, "루키");
-            assertThat(꾹이위치).isLessThan(루키위치);
+            SoftAssertions.assertSoftly(softly -> {
+                // 유효한 안착이 층수를 1로 갱신
+                softly.assertThat(findByName(꾹이1층, "꾹이").floor()).isEqualTo(1);
+                // 꾹이(2층)가 루키(1층)보다 앞에 위치
+                softly.assertThat(indexOfName(ranking, "꾹이")).isLessThan(indexOfName(ranking, "루키"));
+            });
         }
 
         @Test
-        void 유효하지_않은_overlap_이벤트는_브로드캐스트되지_않는다() {
+        void 유효하지_않은_진행_이벤트는_브로드캐스트되지_않는다() {
             final var stateResponses = session.subscribe(stateUrl());
             final var progressResponses = session.subscribe(progressUrl());
 
@@ -175,25 +135,12 @@ class BlockStackingIntegrationTest extends GameModuleWebSocketTest {
             stateResponses.get(); // PREPARE
             stateResponses.get(); // PLAYING
 
-            // overlap <= 0: movingBlockX=300으로 stackTop 범위(85~235) 완전 이탈
+            // (1) overlap <= 0: movingBlockX=300으로 stackTop 범위(85~235) 완전 이탈
             session.send(progressCommandUrl(), progressCommand(1, 300.0, 85.0, 150.0));
-
-            progressResponses.assertNoMessage();
-        }
-
-        @Test
-        void 비연속적_floor_이벤트는_브로드캐스트되지_않는다() {
-            final var stateResponses = session.subscribe(stateUrl());
-            final var progressResponses = session.subscribe(progressUrl());
-
-            startBlockStackingGame();
-
-            stateResponses.get(); // PREPARE
-            stateResponses.get(); // PLAYING
-
-            // floor=1을 건너뛰고 floor=2 전송 → 무시됨
+            // (2) 비연속 floor: floor=1을 건너뛰고 floor=2 전송 (앞의 이벤트가 무시되어 currentFloor=0 유지)
             session.send(progressCommandUrl(), progressCommand(2, 100.0, 85.0, 150.0));
 
+            // 둘 다 무시되어 progress 토픽으로 어떤 브로드캐스트도 발행되지 않는다
             progressResponses.assertNoMessage();
         }
     }

--- a/backend/game/src/test/java/coffeeshout/laddergame/ui/LadderIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/laddergame/ui/LadderIntegrationTest.java
@@ -1,7 +1,5 @@
 package coffeeshout.laddergame.ui;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import coffeeshout.GameModuleWebSocketTest;
 import coffeeshout.fixture.GamerFixture;
 import coffeeshout.gamecommon.Gamer;
@@ -24,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * 타이밍 설정 (application-test.yml): description=500ms, prepare=500ms, drawing=1000ms, result=500ms
+ * 타이밍 설정 (application-test-game.yml): description=500ms, prepare=500ms, drawing=500ms(+grace 300ms), result=500ms
  */
 class LadderIntegrationTest extends GameModuleWebSocketTest {
 
@@ -56,8 +54,13 @@ class LadderIntegrationTest extends GameModuleWebSocketTest {
     @Nested
     class 상태_전환_테스트 {
 
+        /**
+         * 페이즈 전환은 한 번의 게임 플로우로 모든 상태 브로드캐스트가 순서대로 도착하므로,
+         * 페이즈별 페이로드 검증을 단일 플로우에서 SoftAssertions로 한꺼번에 확인한다.
+         * (페이즈마다 게임을 재시작하면 phase 대기가 중복되어 IT 시간이 불필요하게 늘어난다.)
+         */
         @Test
-        void 게임_페이즈가_DESCRIPTION_PREPARE_DRAWING_RESULT_DONE_순서로_전환된다() {
+        void 페이즈가_순서대로_전환되며_각_상태가_올바른_페이로드를_브로드캐스트한다() {
             final var stateResponses = session.subscribe(stateUrl());
 
             startLadderGame();
@@ -70,76 +73,18 @@ class LadderIntegrationTest extends GameModuleWebSocketTest {
 
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(description.state()).isEqualTo(LadderGameState.DESCRIPTION);
-                softly.assertThat(prepare.state()).isEqualTo(LadderGameState.PREPARE);
-                softly.assertThat(drawing.state()).isEqualTo(LadderGameState.DRAWING);
-                softly.assertThat(result.state()).isEqualTo(LadderGameState.RESULT);
-                softly.assertThat(done.state()).isEqualTo(LadderGameState.DONE);
-            });
-        }
 
-        @Test
-        void PREPARE_응답에_poles와_bottomRanks가_포함된다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            final LadderStateResponse prepare = payloadAs(stateResponses.get(2, TimeUnit.SECONDS), LadderStateResponse.class);
-
-            SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(prepare.state()).isEqualTo(LadderGameState.PREPARE);
                 softly.assertThat(prepare.poles()).isNotEmpty();
                 softly.assertThat(prepare.bottomRanks()).isNotEmpty();
-            });
-        }
 
-        @Test
-        void DRAWING_응답에_endTimeEpochMs가_포함된다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            stateResponses.get(2, TimeUnit.SECONDS); // PREPARE
-            final LadderStateResponse drawing = payloadAs(stateResponses.get(2, TimeUnit.SECONDS), LadderStateResponse.class);
-
-            SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(drawing.state()).isEqualTo(LadderGameState.DRAWING);
                 softly.assertThat(drawing.endTimeEpochMs()).isNotNull();
-            });
-        }
 
-        @Test
-        void RESULT_응답에_rankings와_animationDurationMs가_포함된다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            stateResponses.get(2, TimeUnit.SECONDS); // PREPARE
-            stateResponses.get(2, TimeUnit.SECONDS); // DRAWING
-            final LadderStateResponse result = payloadAs(stateResponses.get(3, TimeUnit.SECONDS), LadderStateResponse.class);
-
-            SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.state()).isEqualTo(LadderGameState.RESULT);
                 softly.assertThat(result.rankings()).isNotEmpty();
                 softly.assertThat(result.animationDurationMs()).isEqualTo(500);
-            });
-        }
 
-        @Test
-        void DONE_응답에는_state_필드만_포함된다() {
-            final var stateResponses = session.subscribe(stateUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            stateResponses.get(2, TimeUnit.SECONDS); // PREPARE
-            stateResponses.get(2, TimeUnit.SECONDS); // DRAWING
-            stateResponses.get(3, TimeUnit.SECONDS); // RESULT
-            final LadderStateResponse done = payloadAs(stateResponses.get(2, TimeUnit.SECONDS), LadderStateResponse.class);
-
-            SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(done.state()).isEqualTo(LadderGameState.DONE);
                 softly.assertThat(done.poles()).isNull();
                 softly.assertThat(done.rankings()).isNull();
@@ -149,46 +94,6 @@ class LadderIntegrationTest extends GameModuleWebSocketTest {
 
     @Nested
     class 선_긋기_테스트 {
-
-        @Test
-        void DRAWING_중_선_긋기_요청이_line_토픽으로_브로드캐스트된다() throws Exception {
-            final var stateResponses = session.subscribe(stateUrl());
-            final var lineResponses = session.subscribe(lineUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            stateResponses.get(2, TimeUnit.SECONDS); // PREPARE
-            stateResponses.get(2, TimeUnit.SECONDS); // DRAWING
-
-            session.send(drawCommandUrl(), drawRequest(0));
-
-            final LadderLineResponse line = payloadAs(lineResponses.get(), LadderLineResponse.class);
-
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(line.playerName()).isEqualTo("꾹이");
-                softly.assertThat(line.segmentIndex()).isEqualTo(0);
-                softly.assertThat(line.row()).isPositive();
-            });
-        }
-
-        @Test
-        void 브로드캐스트된_선의_row는_양수다() throws Exception {
-            final var stateResponses = session.subscribe(stateUrl());
-            final var lineResponses = session.subscribe(lineUrl());
-
-            startLadderGame();
-
-            stateResponses.get(); // DESCRIPTION
-            stateResponses.get(2, TimeUnit.SECONDS); // PREPARE
-            stateResponses.get(2, TimeUnit.SECONDS); // DRAWING
-
-            session.send(drawCommandUrl(), drawRequest(0));
-
-            final LadderLineResponse line = payloadAs(lineResponses.get(), LadderLineResponse.class);
-
-            assertThat(line.row()).isPositive();
-        }
 
         @Test
         void 이미_선을_그은_플레이어의_재요청은_브로드캐스트되지_않는다() {
@@ -227,7 +132,7 @@ class LadderIntegrationTest extends GameModuleWebSocketTest {
         }
 
         @Test
-        void 여러_플레이어가_각자_선을_그을_수_있다() throws Exception {
+        void 여러_플레이어가_각자_선을_그으면_각_선이_line_토픽으로_브로드캐스트된다() throws Exception {
             try (final TestStompSession 루키세션 = createSession(joinCode.getValue(), "루키")) {
                 final var stateResponses = session.subscribe(stateUrl());
                 final var lineResponses = session.subscribe(lineUrl());
@@ -239,14 +144,18 @@ class LadderIntegrationTest extends GameModuleWebSocketTest {
                 stateResponses.get(2, TimeUnit.SECONDS); // DRAWING
 
                 session.send(drawCommandUrl(), drawRequest(0));
-                lineResponses.get(); // 꾹이 선 브로드캐스트
+                final LadderLineResponse 꾹이라인 = payloadAs(lineResponses.get(), LadderLineResponse.class);
 
                 루키세션.send(drawCommandUrl(), drawRequest(2));
                 final LadderLineResponse 루키라인 = payloadAs(lineResponses.get(), LadderLineResponse.class);
 
                 SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(꾹이라인.playerName()).isEqualTo("꾹이");
+                    softly.assertThat(꾹이라인.segmentIndex()).isEqualTo(0);
+                    softly.assertThat(꾹이라인.row()).isPositive();
                     softly.assertThat(루키라인.playerName()).isEqualTo("루키");
                     softly.assertThat(루키라인.segmentIndex()).isEqualTo(2);
+                    softly.assertThat(루키라인.row()).isPositive();
                 });
             }
         }

--- a/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/racinggame/ui/RacingGameIntegrationTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.racinggame.ui;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import coffeeshout.GameModuleWebSocketTest;
 import coffeeshout.fixture.GamerFixture;
@@ -14,8 +15,10 @@ import coffeeshout.racinggame.ui.request.TapCommand;
 import coffeeshout.racinggame.ui.response.RacingGameRunnersStateResponse;
 import coffeeshout.racinggame.ui.response.RacingGameStateResponse;
 import coffeeshout.support.TestStompSession;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,18 +102,25 @@ class RacingGameIntegrationTest extends GameModuleWebSocketTest {
         stateResponses.get(3, TimeUnit.SECONDS); // PLAYING (2초 후)
 
         /*
-         100ms마다 moveAll → 최고속도(30)로 달린다고 가정하면 결승점(3000)까지 10000ms걸림
+         IT 가속: move-interval=50ms(application-test-game.yml)로 자동이동이 돌고, 속도는 rate 기반이라
+         최고속도 유지를 위해 ~50ms마다 탭한다. 결승(3000) 도달·감속·정지하면 DONE.
+         고정 대기(Thread.sleep)는 컨벤션상 금지이므로 Awaitility 폴링으로 탭을 송신하고,
+         충분한 탭 라운드(120회 ≈ 6s) 후 종료한다. (racingGame.state는 비휘발성이라 폴링 조건으로 쓰지 않고,
+         종료 판정은 아래의 신뢰 가능한 DONE 브로드캐스트로 한다.) 프로덕션 100ms 기준 ~10s 구간이 ~6s로 단축된다.
         */
-        for (int i = 0; i < 100; i++) {
-            for (Gamer gamer : gamers) {
-                singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 10));
-            }
-            Thread.sleep(100);
-        }
+        final AtomicInteger tapRounds = new AtomicInteger();
+        await().atMost(Duration.ofSeconds(8))
+                .pollInterval(Duration.ofMillis(50))
+                .until(() -> {
+                    for (Gamer gamer : gamers) {
+                        singleSession.send(tapRequestUrl, new TapCommand(gamer.getName(), 10));
+                    }
+                    return tapRounds.incrementAndGet() >= 120;
+                });
 
-        // then - DONE 상태 확인 (최대 30초 대기)
+        // then - DONE 상태 확인
         RacingGameStateResponse finishedState =
-                payloadAs(stateResponses.get(30, TimeUnit.SECONDS), RacingGameStateResponse.class);
+                payloadAs(stateResponses.get(5, TimeUnit.SECONDS), RacingGameStateResponse.class);
         assertThat(finishedState.state()).isEqualTo(RacingGameState.DONE);
     }
 

--- a/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
+++ b/backend/game/src/test/java/coffeeshout/speedtouch/ui/SpeedTouchGameIntegrationTest.java
@@ -112,6 +112,11 @@ class SpeedTouchGameIntegrationTest extends GameModuleWebSocketTest {
         var stateResponses = session.subscribe(subscribeStateUrl);
         var progressResponses = session.subscribe(subscribeProgressUrl);
 
+        // IT 가속: 터치는 strict sequential(number != currentNumber면 거부)이라 터치마다 직렬 await가 필수다.
+        // 라운드트립 횟수가 곧 실행시간이므로, 전원 완주→DONE 검증(다중 플레이어 allMatch)은 유지하되
+        // 플레이어를 2명으로 줄여 100회(4명×25)였던 직렬 라운드트립을 50회로 절반화한다.
+        gamers = gamers.subList(0, 2);
+
         // 게임 시작 후 PLAYING 까지 대기
         startSpeedTouchGame();
 

--- a/backend/game/src/testFixtures/resources/application-test-game.yml
+++ b/backend/game/src/testFixtures/resources/application-test-game.yml
@@ -11,7 +11,7 @@ ladder:
   timing:
     description: 500ms
     prepare: 500ms
-    drawing: 1000ms
+    drawing: 500ms
     drawing-grace-period: 300ms
     result: 500ms
 
@@ -29,6 +29,10 @@ racing-game:
     description: 500ms
     prepare: 500ms
     race-finished-delay: 500ms
+    # IT 가속: 프로덕션 100ms 대비 자동이동 주기를 절반으로 줄여 완주(거리 3000) 도달을 ~2.5s로 단축.
+    # 도메인 Runner.finishTime 정밀도는 static MOVE_INTERVAL_MILLIS(100ms)를 그대로 쓰지만,
+    # 완주 IT는 DONE 상태만 검증하고 순위/완주시간은 검증하지 않으므로 영향 없음.
+    move-interval: 50ms
 
 speed-touch:
   timing:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)
  - 본 브랜치는 `be/refactor/game-room-to-joincode`에서 분기했으므로 base를 `be/dev`가 아닌 **`be/refactor/game-room-to-joincode`** 로 설정했습니다. (be/dev로 두면 리팩터 전체가 diff에 섞입니다)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

게임 모듈 통합 테스트(IT)의 실행시간을 분석해, **중복 game-flow 재실행**과 **불필요한 벽시계 대기**를 줄였습니다. 프로덕션 동작은 보존합니다.

1. **Racing 자동이동 주기(move-interval) 설정화** — 하드코딩 `RacingGame.MOVE_INTERVAL_MILLIS(100ms)` 대신 `RacingGameTimingProperties.moveInterval`을 도입해 `RacingGameService`가 사용. 프로덕션 `game.yml`은 100ms로 기존 동작을 그대로 유지하고, 테스트만 50ms로 낮춰 완주 도달(거리 3000)을 가속.
2. **Ladder `drawing` 1000→500ms** — `drawing-grace-period(300ms)`로 유효 그리기 창 800ms를 확보하면서 단축.
3. **통합 테스트 통합** — 같은 게임 플로우를 반복 실행해 facet만 따로 검증하던 테스트를 단일 플로우 + `SoftAssertions`로 합침.
   - Ladder 10→4 (상태_전환 5→1, 선_긋기 5→3)
   - BlockStacking 7→3 (페이즈 종속 테스트 2개는 상위 테스트가 완전 검증하므로 삭제)
   - BlindTimer 3→1
4. **Racing 완주 IT** — 컨벤션 위반인 `Thread.sleep`을 Awaitility 폴링으로 교체.
5. **SpeedTouch 완주 IT** — strict-sequential 터치의 직렬 라운드트립을 줄이려 완주 검증을 2인 게임으로 축소(다중 플레이어 allMatch→DONE 의미는 유지).

### 검증된 효과 (각 IT 3회 반복, 플래키 0건)

| 클래스 | 테스트 수 | 전 → 후 |
|---|---|---|
| Ladder | 10→4 | 25.8s → 16.5s |
| BlockStacking | 7→3 | 15.5s → 8.1s |
| BlindTimer | 3→1 | 6.9s → 5.9s |
| Racing 완주(단일) | — | 12.5s → 6.0s |
| SpeedTouch 완주(단일) | — | 9.3s → 7.0s |

> suite 총량은 컨테이너 기동·머신 부하 변동이 지배하므로 "전체 N초"로 못 박지 않습니다. 핵심은 **중복 game-flow 10건 제거**로 구조적 실행시간 floor를 낮춘 것입니다.

# 💬 리뷰 중점사항

1. **Racing move-interval 설정 추출(프로덕션 변경)** — 유일한 main 코드 변경입니다. `game.yml` 기본값 100ms로 프로덕션 동작이 보존되는지 확인 부탁드립니다. `Runner.finishTime` 정밀도 계산은 의도적으로 static `MOVE_INTERVAL_MILLIS(100ms)`를 그대로 둡니다(B-lite 범위) — 완주 IT는 DONE 상태만 검증하고 순위/완주시간은 검증하지 않아 영향이 없습니다.
2. **테스트 통합의 granularity 트레이드오프** — 여러 테스트를 한 플로우로 합쳐 실패 시 테스트명 단위 식별성은 줄지만, `SoftAssertions`가 어느 검증이 깨졌는지 보고합니다. 과병합을 피해 "behavior-cluster당 1 플로우" 수준에서 멈췄습니다.
3. **`assertNoMessage`(1초) 제약** — BlockStacking(PLAYING 2000ms)에서는 두 무효 커맨드를 한 창에서 묶었지만, 연속 2회 `assertNoMessage`나 짧은 창(Ladder 800ms)에서는 묶지 않고 분리 유지했습니다.
4. **플래키** — Ladder `drawing` 단축이 그리기 창을 줄이므로, 관련 IT를 각 3회 반복 실행해 안정성을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)