### PR TITLE
[refactor] Testcontainers reuse 영구 비활성화 확정 + 모듈별 DB/Redis 격리 제거 (#1402)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -66,19 +66,6 @@ subprojects {
         "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     }
 
-    // 모듈별 Redis DB 인덱스 — 새 모듈 추가 시 여기에 등록
-    val redisDbByModule = mapOf(
-        "app"       to 0,
-        "room"      to 1,
-        "user"      to 2,
-        "websocket" to 3,
-        "game"      to 4,
-        "zzolbot"   to 5,
-        "infra"     to 6,
-        "admin"     to 7,
-        "profanity" to 8,
-    )
-
     tasks.named<JacocoReport>("jacocoTestReport") {
         dependsOn(tasks.named("test"))
         reports {
@@ -98,15 +85,6 @@ subprojects {
         exclude("**/QueryPerformanceTest.class")
         systemProperty("updateFixture", System.getProperty("updateFixture", "false"))
         jvmArgs("-Xmx1g", "-XX:+HeapDumpOnOutOfMemoryError")
-
-        // 모듈별 독립 DB/Redis — 병렬 테스트 실행 시 간섭 방지
-        // :app은 전 모듈 통합 DB로 zzol_test 유지
-        val dbName = if (project.name == "app") "zzol_test"
-                     else "zzol_test_${project.name.replace("-", "_")}"
-        require(dbName.matches(Regex("[a-zA-Z0-9_]+"))) {
-            "Invalid test DB name '$dbName' for module '${project.name}': only alphanumeric and underscore allowed"
-        }
-        systemProperty("test.db.name", dbName)
-        systemProperty("test.redis.db", redisDbByModule[project.name] ?: 0)
+        // reuse-off로 JVM(모듈)마다 독립 컨테이너를 쓰므로 모듈별 DB/Redis 인덱스 격리는 불필요(이슈 #1402)
     }
 }

--- a/backend/docs/adr/0013-domain-module-test-isolation.md
+++ b/backend/docs/adr/0013-domain-module-test-isolation.md
@@ -169,6 +169,23 @@ user      JVM  ──┘
 정합성 문제는 없고, 최악의 경우가 reuse 비활성 상태와 동일하다.
 CI 러너는 잡 종료 시 폐기되므로 잔여 컨테이너 정리도 불필요하다.
 
+### reuse 영구 비활성화 — 모듈별 격리 제거 (2026-06-11)
+
+위 reuse 활성화는 철회한다. 모듈별 DB·Redis 인덱스 격리는 **데이터 충돌**만 막을 뿐,
+병렬 모듈 테스트가 단일 공유 컨테이너(한 MySQL·Valkey 프로세스)를 동시에 두드릴 때 생기는
+**자원 경합**(처리량 한계·지연 변동)은 막지 못한다. 타이밍 민감한 게임 통합테스트가 이
+경합으로 간헐 awaitility 타임아웃했고, 스트림/컨텍스트 개선(#1361/#1369)이 머지된 뒤에도
+reuse-on은 플레이키로 재현됐다(로컬 `./gradlew test --rerun-tasks`).
+
+따라서 `withReuse(true)` 를 제거(JVM별 독립 컨테이너 = 물리적 자원 격리)하고, 그에 따라
+무효가 된 모듈별 DB(`zzol_test_<module>`)·Redis 인덱스(0~8) 격리와 `test.db.name` /
+`test.redis.db` 시스템 프로퍼티를 함께 제거했다. 각 모듈 JVM은 자기 컨테이너의 `zzol_test` 와
+redis db 0 을 단독 사용한다. 기동 시간 증가는 #1369(컨텍스트 기동 횟수↓)·#1401(게임 IT 시간↓)로
+상쇄됐다.
+
+- 이슈: #1402
+- CI `backend-ci.yml` 의 "Enable Testcontainers reuse" 스텝은 no-op이 된다 — 워크플로 정리는 별도(main 전용)
+
 ### TestContainers 버전 고정
 
 Spring Boot BOM 이 트랜지티브 의존으로 `testcontainers` 를 1.x 로 다운그레이드한다.

--- a/backend/test-support/src/main/java/coffeeshout/support/TestContainerSupport.java
+++ b/backend/test-support/src/main/java/coffeeshout/support/TestContainerSupport.java
@@ -20,16 +20,13 @@ public abstract class TestContainerSupport {
     private static final Logger log = LoggerFactory.getLogger(TestContainerSupport.class);
     private static final int VALKEY_PORT = 6379;
     private static final String BASE_DB = "zzol_test";
-    private static final String MODULE_DB = System.getProperty("test.db.name", BASE_DB);
-    private static final int MODULE_REDIS_DB = Integer.parseInt(System.getProperty("test.redis.db", "0"));
 
-    // 컨테이너 reuse를 끈다(JVM별 독립 컨테이너). ADR-0013은 모듈별 DB·Redis 인덱스 격리로 reuse
-    // 병렬 안전을 전제했으나, 병렬 모듈 테스트(parallel=true·workers=4)가 단일 공유 컨테이너를 동시에
-    // 두드리면 그 전제가 깨진다: 공유 Valkey는 스트림 처리가 지연되며 비동기로 늦게 발행된 stale
-    // 이벤트(이미 정리된 방 참조)가 컨슈머 풀을 잠식하고, 공유 MySQL은 경합으로 처리가 밀려, 게임
-    // 통합테스트가 간헐 타임아웃한다(로컬 재현으로 확인 — reuse off 시 통과, valkey만 off로는 MySQL
-    // 경합 잔존으로 실패). 스트림/컨텍스트 격리의 근본 개선은 별도 작업(#1361/#1369)이며, 그 전까지
-    // reuse를 비활성화한다. ff452199의 기동 시간 최적화를 일부 되돌리는 트레이드오프.
+    // 컨테이너 reuse를 끄고 JVM별 독립 컨테이너(=물리적 자원 격리)를 쓴다 — 영구 결정(이슈 #1402).
+    // 단일 공유 컨테이너 + 모듈별 DB·Redis 인덱스 격리(ADR-0013)는 데이터 충돌만 막을 뿐, 병렬 모듈
+    // 테스트(parallel=true·workers=4)가 한 MySQL·Valkey 프로세스를 동시에 두드릴 때 생기는 자원 경합
+    // (처리량 한계·지연 변동)은 막지 못한다 — 타이밍 민감한 게임 통합테스트가 간헐 awaitility
+    // 타임아웃했다. 스트림/컨텍스트 개선(#1361/#1369)이 이미 머지된 상태에서도 reuse-on은 플레이키로
+    // 재현돼, 물리적 격리만이 유효 해법임을 확정했다. 그에 따라 무효가 된 모듈별 DB/Redis 격리는 제거했다.
     protected static final MySQLContainer mysql = new MySQLContainer(DockerImageName.parse("mysql:8.0"))
             .withDatabaseName(BASE_DB)
             .withUsername("test")
@@ -48,9 +45,6 @@ public abstract class TestContainerSupport {
     static {
         mysql.start();
         valkey.start();
-        if (!MODULE_DB.equals(BASE_DB)) {
-            createDatabaseIfAbsent(MODULE_DB);
-        }
     }
 
     @Autowired(required = false)
@@ -61,34 +55,11 @@ public abstract class TestContainerSupport {
 
     @DynamicPropertySource
     static void registerContainerProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url",
-                () -> mysql.getJdbcUrl().replace("/" + BASE_DB, "/" + MODULE_DB));
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.data.redis.host", valkey::getHost);
         registry.add("spring.data.redis.port", () -> valkey.getMappedPort(VALKEY_PORT));
-        registry.add("spring.data.redis.database", () -> MODULE_REDIS_DB);
-    }
-
-    private static void createDatabaseIfAbsent(String dbName) {
-        try {
-            var result = mysql.execInContainer(
-                    "mysql",
-                    "--user=root",
-                    "--password=" + mysql.getPassword(),
-                    "--execute=CREATE DATABASE IF NOT EXISTS `" + dbName + "`"
-                            + "; GRANT ALL PRIVILEGES ON `" + dbName + "`.* TO '" + mysql.getUsername() + "'@'%'"
-                            + "; FLUSH PRIVILEGES"
-            );
-            if (result.getExitCode() != 0) {
-                throw new RuntimeException(result.getStderr());
-            }
-            log.info("모듈 테스트 DB 생성: {}", dbName);
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException("모듈 테스트 DB 생성 실패: " + dbName, e);
-        }
     }
 
     @BeforeEach


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)
  - 이 PR은 #1397(`be/refactor/game-room-to-joincode`)의 reuse-off 커밋 위에 **스택**했으므로 base를 `be/dev`가 아닌 **`be/refactor/game-room-to-joincode`** 로 설정했습니다. (be/dev로 두면 베이스에 reuse-off가 없어 격리 제거가 데이터 충돌을 유발하고, #1397 전체가 diff에 섞입니다)
  - 머지 순서: **#1397 → 본 PR** 순으로 be/dev에 반영돼야 합니다.

# 🔥 연관 이슈

- close #1402

# 🚀 작업 내용

Testcontainers `reuse` 비활성화를 **영구 선택으로 확정**하고, 그에 따라 무효가 된 모듈별 DB/Redis 격리 코드를 제거합니다.

## 배경 — 왜 영구 비활성화인가

reuse-off(`ecfba2c9`)는 "임시 조치, 근본 개선은 #1361/#1369"로 적혔으나 타임라인이 이를 반증합니다.

- #1361(`b874db60`)·#1369(`c5c64570`) → be/dev 머지 **2026-06-08**
- reuse 비활성화(`ecfba2c9`) **2026-06-11** — `b874db60`은 `ecfba2c9`의 **조상**

즉 reuse를 끈 시점에 #1361/#1369는 **이미 트리에 있었고**, 그 상태로 돌린 로컬 재현에서도 reuse-on은 여전히 플레이키였습니다. 두 작업으로는 병렬 안정성 문제가 풀리지 않음이 경험적으로 확인됐습니다.

근본 원인은 **단일 공유 컨테이너의 자원 경합**입니다. 한 MySQL·Valkey 프로세스가 4-way 병렬 모듈 부하를 받으면 지연 변동이 커져 타이밍 민감한 게임 IT의 awaitility 예산을 깨뜨립니다. ADR-0013의 모듈별 DB·Redis 인덱스 격리는 **데이터 충돌**만 막을 뿐 **자원 경합**은 막지 못합니다. 처리량을 늘리는 건 물리적 컨테이너 분리(reuse-off)뿐입니다.

## 변경

1. **`TestContainerSupport.java`** — `MODULE_DB`/`MODULE_REDIS_DB` 상수, `createDatabaseIfAbsent`, `datasource.url`의 `BASE_DB→MODULE_DB` 치환, `spring.data.redis.database` 등록 제거. `datasource.url`은 `mysql.getJdbcUrl()` 직접 사용(컨테이너 기본 `zzol_test`·redis db 0 단독 사용). reuse-off 주석을 영구 결정으로 정리.
2. **`build.gradle.kts`** — `test.db.name`/`test.redis.db` systemProperty, `redisDbByModule` 맵, `dbName` 분기·검증 로직 제거.
3. **`docs/adr/0013-...md`** — reuse 활성화 철회·격리 제거 섹션 보강(2026-06-11).

## 범위 밖 (별도)

- CI `backend-ci.yml`의 "Enable Testcontainers reuse" 스텝은 reuse-off 후 no-op — 워크플로 정리는 `main` 전용이라 별도 PR.

## 검증

- `:test-support:compileJava` — Kotlin DSL + Java 컴파일 통과
- `:room RoomEnterStreamProducerTest` (DB+Redis 풀 컨텍스트 IT) — 단순화된 와이어링으로 통과
- 코드 잔여 참조 0 (문서만 갱신)

# 💬 리뷰 중점사항

1. **격리 제거의 전제는 reuse-off** — 이 PR은 reuse가 꺼진 #1397 head 위에 스택돼야 안전합니다. base가 #1397인지 확인 부탁드립니다. (be/dev 단독 베이스에서는 reuse가 켜진 채 격리만 빠져 데이터 충돌)
2. **game IT 3회 검증 미수행** — 원래 플레이키의 진앙인 `:game:test --rerun-tasks` 3회 연속 통과는 아직 돌리지 않았습니다. 머지 전 CI 또는 로컬에서 확인이 필요합니다(완료 기준 #1402).
3. **redis db 0 고정** — 전용 컨테이너이므로 논리 인덱스 분리가 불필요합니다. `@BeforeEach`의 `flushDb()`는 현재 db(0)만 비우면 충분합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
