### PR TITLE
[chore] fe/dev 직접 push 방지 git push 안전 규칙 추가

### DIFF
--- a/frontend/.claude/rules/git-push-safety.md
+++ b/frontend/.claude/rules/git-push-safety.md
@@ -1,0 +1,36 @@
+## 공유 브랜치 보호 & push 안전
+
+2026-06-11 작업 브랜치 push 중 `be/dev`가 PR 없이 직접 전진한 사고(#1404)에서 정립된 push 안전 규칙의 프론트엔드 적용판이다. 원인은 작업 브랜치의 upstream(`branch.<name>.merge`)이 보호 브랜치로 설정되어, 이후 push·IDE Sync가 작업 커밋을 보호 브랜치로 직행시킨 것이다. FE 작업은 `fe/*` 브랜치에서 이뤄지므로 동일 사고가 `fe/dev`에서도 재현될 수 있다.
+
+### 보호 브랜치 (직접 push·commit 금지)
+
+`fe/dev`, `fe/prod`, `main`, `be/dev`, `be/prod`, `master`
+
+이 브랜치들의 변경은 **PR로만** 반영한다. Claude는 어떤 경우에도 이 브랜치로 직접 push하거나, 이 브랜치를 체크아웃해 직접 커밋하지 않는다. FE 작업의 기본 머지 대상은 `fe/dev`이며, 릴리스는 `fe/prod`다.
+
+### 작업 브랜치 upstream을 보호 브랜치로 두지 않기 (★ 사고 핵심 원인)
+
+- `fe/dev` 등에서 체크아웃하거나 `git worktree add ... origin/fe/dev`로 만들면 git의 `autoSetupMerge` 기본동작이 upstream을 `fe/dev`로 잡는다. **반드시 떼어낸다**: `git branch --unset-upstream`.
+- 금지 패턴:
+
+```bash
+# 금지 — upstream이 fe/dev가 되어 이후 push가 fe/dev로 직행
+git checkout -b fe/feat/x fe/dev && git branch -u origin/fe/dev
+git push -u origin fe/feat/x:fe/dev
+```
+
+- 첫 push는 반드시 **자기 이름**으로 하고 upstream도 자기 이름으로 잡는다:
+
+```bash
+git push -u origin HEAD:fe/feat/x
+```
+
+### push 전 검증 절차
+
+1. `git rev-parse --abbrev-ref @{u}` 로 현재 upstream을 확인한다. 결과가 보호 브랜치면 **중단하고 사용자에게 보고**한다.
+2. push는 인자 없는 bare `git push` 대신 **명시 refspec**을 사용한다: `git push origin HEAD:<work-branch>`.
+3. push 명령의 destination에 보호 브랜치명이 나타나면 실행하지 않고 사용자에게 보고한다.
+
+### 이 규칙의 한계 (사용자 인지 필요)
+
+이 규칙은 **Claude의 git 조작에만** 적용된다. 사용자의 수동 push나 VS Code "Push/Sync" 버튼은 이 규칙으로 막지 못한다. 다만 Claude가 작업 브랜치 upstream을 보호 브랜치로 만들지 않으면, IDE Sync가 보호 브랜치를 target으로 삼을 소지 자체가 사라진다(근본 원인 제거). 완전 차단이 필요하면 서버측 `enforce_admins=true` 또는 로컬 pre-push hook을 별도로 도입한다.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -46,6 +46,7 @@ BE 의 `GET /dev/ws-catalog` 에 모든 토픽/큐/send destination 의 path·pa
 | 파일 | 범위 | 내용 |
 | --- | --- | --- |
 | `principles.md` | 전역 | 역할, 코딩 원칙, 외과적 변경, 작업 원칙 |
+| `git-push-safety.md` | 전역 | 보호 브랜치(fe/dev·fe/prod·main 등) 직접 push 금지, upstream·refspec 검증 절차 |
 | `style.md` | 전역 | 색상·타이포그래피·z-index 토큰, Emotion 패턴 금지 항목 |
 | `qmd.md` | 전역 | 코드베이스 시맨틱 검색 사용법 |
 | `websocket.md` | `src/apis/websocket/**`, `src/contexts/**` | WebSocket 구독·발행 패턴, destination 형식 |


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev)

# 🔥 연관 이슈

- PR #1405 (BE) 의 git push 안전 규칙을 FE에 미러링 / 사고 #1404 재발방지

# 🚀 작업 내용

`be/dev`가 PR 없이 직접 전진한 사고(#1404)에서 정립된 push 안전 규칙(BE PR #1405)을 프론트엔드에 적용한다. FE 작업은 `fe/*` 브랜치에서 이뤄지므로 동일한 upstream 직행 문제가 `fe/dev`에서도 재현될 수 있다.

1. `frontend/.claude/rules/git-push-safety.md` 추가 (전역 규칙, 자동 로드)
   - 보호 브랜치 목록을 FE 관점으로 재정렬: `fe/dev`·`fe/prod`·`main` 우선 + `be/dev`·`be/prod`·`master`
   - 작업 브랜치 upstream을 보호 브랜치로 두지 않기 (★ 사고 핵심 원인, `git branch --unset-upstream`)
   - push 전 `@{u}` 확인·명시 refspec 사용 검증 절차
2. `frontend/CLAUDE.md` Rules 표에 `git-push-safety.md` 등록 (범위: 전역)

# 💬 리뷰 중점사항

- 문서 전용 변경(코드/동작 변경 없음). BE PR #1405 와 구조 일치, 보호 브랜치 목록만 FE 기준으로 재정렬했습니다.
- BE 문서와 동일하게 한계 명시: 본 규칙은 Claude의 git 조작에만 적용되며 사용자 수동 push·IDE Sync는 막지 못합니다. 완전 차단은 `enforce_admins=true` 또는 pre-push hook 별도 도입 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
