### PR TITLE
[fix] CodeQL High 알림 해소 — 루프 카운터 int→long

### DIFF
--- a/backend/admin/src/test/java/coffeeshout/report/ratelimit/ReportRateLimitStoreTest.java
+++ b/backend/admin/src/test/java/coffeeshout/report/ratelimit/ReportRateLimitStoreTest.java
@@ -36,14 +36,14 @@ class ReportRateLimitStoreTest extends AdminModuleServiceTest {
 
         @Test
         void 임계값_이내_요청은_토큰을_획득한다() {
-            for (int i = 0; i < rateLimitProperties.rate(); i++) {
+            for (long i = 0; i < rateLimitProperties.rate(); i++) {
                 assertThat(rateLimitStore.tryAcquire(TEST_IP)).isTrue();
             }
         }
 
         @Test
         void 임계값_초과_요청은_토큰_획득에_실패한다() {
-            for (int i = 0; i < rateLimitProperties.rate(); i++) {
+            for (long i = 0; i < rateLimitProperties.rate(); i++) {
                 rateLimitStore.tryAcquire(TEST_IP);
             }
 
@@ -52,7 +52,7 @@ class ReportRateLimitStoreTest extends AdminModuleServiceTest {
 
         @Test
         void 다른_IP는_카운트가_별도로_관리된다() {
-            for (int i = 0; i < rateLimitProperties.rate(); i++) {
+            for (long i = 0; i < rateLimitProperties.rate(); i++) {
                 rateLimitStore.tryAcquire(TEST_IP);
             }
 
@@ -67,7 +67,7 @@ class ReportRateLimitStoreTest extends AdminModuleServiceTest {
         @Test
         void Rate_Limit_초과_시_dropped_카운터가_증가한다() {
             String ip = "10.0.0.1";
-            for (int i = 0; i < rateLimitProperties.rate(); i++) {
+            for (long i = 0; i < rateLimitProperties.rate(); i++) {
                 rateLimitStore.tryAcquire(ip);
             }
             double before = meterRegistry.find("report.ratelimit.dropped.total").counter().count();
@@ -106,7 +106,7 @@ class ReportRateLimitStoreTest extends AdminModuleServiceTest {
         @Test
         void TTL_만료_후_Rate_Limit이_초기화된다() {
             String ip = "172.16.0.2";
-            for (int i = 0; i < rateLimitProperties.rate(); i++) {
+            for (long i = 0; i < rateLimitProperties.rate(); i++) {
                 rateLimitStore.tryAcquire(ip);
             }
             assertThat(rateLimitStore.tryAcquire(ip)).isFalse();


### PR DESCRIPTION
## 개요

PR #1422(`be/dev` → `be/prod`)의 **CodeQL 체크 실패** 중 High 5건을 해소한다.

- 규칙: `java/comparison-with-wider-type` (Comparison of narrow type with wide type in loop condition)
- 심각도: **High** × 5
- 위치: `admin` 모듈 테스트 `ReportRateLimitStoreTest`

## 원인

`ReportRateLimitProperties.rate()`의 반환 타입은 `long`이다. 테스트의 `for (int i = 0; i < rateLimitProperties.rate(); i++)` 루프에서 `int` 카운터를 더 넓은 타입 `long`과 비교해 CodeQL이 narrow/wide 타입 비교를 탐지했다.

## 변경

루프 카운터 타입을 `int` → `long`으로 변경 (5곳). 비교 양변의 타입을 일치시켜 알림을 해소한다.

- 테스트 코드만 변경, 프로덕션 동작 영향 없음
- `rate()`는 작은 임계값이라 실제 오버플로 위험은 없으나, CodeQL 게이트(릴리스 PR #1422 차단)를 통과시키기 위한 수정

## 범위 밖 (별도 처리)

같은 CodeQL 실행의 **Medium — Log Injection 10건**은 이 PR에 포함하지 않는다. 로그 입력값 sanitize는 별도 PR로 진행한다.

## 검증

- [ ] 머지 대상 브랜치에서 CodeQL 재실행 시 `java/comparison-with-wider-type` High 알림 0건 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 테스트 코드의 루프 인덱스 타입을 개선하여 테스트 신뢰성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->