### PR TITLE
[chore] create-pr 스킬 --base 버그 수정 및 예시 분리

### DIFF
--- a/backend/.claude/skills/create-pr/SKILL.md
+++ b/backend/.claude/skills/create-pr/SKILL.md
@@ -9,58 +9,34 @@ allowed-tools: Read, Bash, Glob
 
 ## 사전 작업
 
-1. base 브랜치를 정한다. `$ARGUMENTS`에 `--base=<브랜치>`가 있으면 그 값을, 없으면 `be/dev`를 쓴다. 이후 단계는 이 값(`$BASE`)을 기준으로 한다.
-2. `.github/pull_request_template.md`는 **모노레포 루트**에 있다. `backend/` 하위가 아니므로 `REPO_ROOT="$(git rev-parse --show-toplevel)"` 로 루트를 구한 뒤 `${REPO_ROOT}/.github/pull_request_template.md` 경로로 Read한다.
-3. `git log "$BASE"..HEAD --oneline`으로 이번 브랜치의 커밋 목록을 확인한다.
-4. `git diff "$BASE"...HEAD --stat`으로 변경된 파일 목록을 확인한다.
+1. base 브랜치를 정한다. `$ARGUMENTS`에 `--base=<브랜치>`가 있으면 그 값, 없으면 `be/dev`. 이후 이 값을 `$BASE`로 쓴다.
+2. PR 템플릿은 모노레포 루트에 있다. `REPO_ROOT="$(git rev-parse --show-toplevel)"` 로 루트를 구해 `${REPO_ROOT}/.github/pull_request_template.md`를 Read한다.
+3. `git log "$BASE"..HEAD --oneline` 와 `git diff "$BASE"...HEAD --stat` 으로 이번 브랜치의 커밋·변경 파일을 확인한다.
 
-## PR 제목 규칙
+## PR 제목
 
-- 형식: `[type] 한국어 설명` (예: `[fix] 카드 점수 집계 누락 수정`)
-- type 종류: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
-- `$ARGUMENTS`에 제목이 주어지면 그대로 사용, 없으면 커밋 내용을 분석해 자동 생성
-- type별 제목·본문 작성 예시는 [examples.md](examples.md)를 참조한다
+- 형식: `[type] 한국어 설명` (예: `[fix] 카드 점수 집계 누락 수정`). type: `feat`·`fix`·`refactor`·`chore`·`docs`·`test`
+- `$ARGUMENTS`에 제목이 있으면 그대로, 없으면 커밋 내용으로 자동 생성
+- type별 제목·본문 예시는 [examples.md](examples.md) 참조
 
 ## 라벨 & Assignee
 
-**라벨** — type에 따라 자동 선택 (중복 가능):
+- 라벨: 항상 `BE` + type별 1개 — feat `✨feat` / fix `🐞bug` / refactor `🛠️refactor` / chore `⚙️chore` / docs `📝docs` / test `🧪 test`. 우선순위(`p-*`)는 `$ARGUMENTS`에 있을 때만 추가
+- Assignee: `gh api user --jq '.login'` 결과로 자동 지정
 
-| type | 라벨 |
-|------|------|
-| feat | `✨feat`, `BE` |
-| fix | `🐞bug`, `BE` |
-| refactor | `🛠️refactor`, `BE` |
-| chore | `⚙️chore`, `BE` |
-| docs | `📝docs`, `BE` |
-| test | `🧪 test`, `BE` |
+## 템플릿 작성
 
-`BE` 라벨은 type에 관계없이 **항상** 포함한다.
+`.github/pull_request_template.md` 섹션을 유지하고 채운다.
 
-우선순위 라벨(`p-*`)은 `$ARGUMENTS`에 명시된 경우에만 추가한다.
-
-**Assignee** — `gh api user --jq '.login'`으로 현재 git 사용자 GitHub 로그인을 조회해 자동 지정한다.
-
-## 템플릿 작성 규칙
-
-`.github/pull_request_template.md`의 섹션을 그대로 유지하고 아래 기준으로 채운다.
-
-| 섹션         | 작성 기준                                         |
-|------------|-----------------------------------------------|
-| ✅ 체크리스트    | `--base` 브랜치 확인 후 `[x]`로 체크                   |
-| 🔥 연관 이슈   | `$ARGUMENTS`에 이슈 번호가 있으면 `close #N`, 없으면 `없음` |
-| 🚀 작업 내용   | 변경된 파일·커밋을 분석해 번호 목록으로 작성                     |
-| 💬 리뷰 중점사항 | 리뷰어가 특히 확인해야 할 설계 결정, 트레이드오프, 주의 사항           |
+- ✅ 체크리스트: `--base` 확인 후 `[x]`
+- 🔥 연관 이슈: 이슈 번호가 있으면 `close #N`, 없으면 `없음`
+- 🚀 작업 내용: 변경 파일·커밋을 번호 목록으로
+- 💬 리뷰 중점사항: 설계 결정·트레이드오프·주의 사항
 
 ## 실행
 
 ```bash
-# base 브랜치 (사전 작업 1에서 정한 값, 기본 be/dev)
-BASE="be/dev"
-
-# assignee 조회
-gh api user --jq '.login'
-
-# 본문은 --body-file - 로 stdin에서 읽는다 (heredoc)
+BASE="be/dev"   # 사전 작업 1의 값
 gh pr create \
   --title "[fix] 카드 점수 집계 누락 수정" \
   --base "$BASE" \
@@ -71,4 +47,4 @@ gh pr create \
 EOF
 ```
 
-완료 후 생성된 PR의 본문이 의도대로 반영됐는지 확인하고, PR URL을 사용자에게 출력한다.
+완료 후 PR 본문이 반영됐는지 확인하고 URL을 출력한다.

--- a/backend/.claude/skills/create-pr/SKILL.md
+++ b/backend/.claude/skills/create-pr/SKILL.md
@@ -9,15 +9,17 @@ allowed-tools: Read, Bash, Glob
 
 ## 사전 작업
 
-1. `.github/pull_request_template.md`는 **모노레포 루트**에 있다. `backend/` 하위가 아니므로 `REPO_ROOT="$(git rev-parse --show-toplevel)"` 로 루트를 구한 뒤 `${REPO_ROOT}/.github/pull_request_template.md` 경로로 Read한다.
-2. `git log be/dev..HEAD --oneline`으로 이번 브랜치의 커밋 목록을 확인한다.
-3. `git diff be/dev...HEAD --stat`으로 변경된 파일 목록을 확인한다.
+1. base 브랜치를 정한다. `$ARGUMENTS`에 `--base=<브랜치>`가 있으면 그 값을, 없으면 `be/dev`를 쓴다. 이후 단계는 이 값(`$BASE`)을 기준으로 한다.
+2. `.github/pull_request_template.md`는 **모노레포 루트**에 있다. `backend/` 하위가 아니므로 `REPO_ROOT="$(git rev-parse --show-toplevel)"` 로 루트를 구한 뒤 `${REPO_ROOT}/.github/pull_request_template.md` 경로로 Read한다.
+3. `git log "$BASE"..HEAD --oneline`으로 이번 브랜치의 커밋 목록을 확인한다.
+4. `git diff "$BASE"...HEAD --stat`으로 변경된 파일 목록을 확인한다.
 
 ## PR 제목 규칙
 
-- 형식: `[type] 한국어 설명`
+- 형식: `[type] 한국어 설명` (예: `[fix] 카드 점수 집계 누락 수정`)
 - type 종류: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
 - `$ARGUMENTS`에 제목이 주어지면 그대로 사용, 없으면 커밋 내용을 분석해 자동 생성
+- type별 제목·본문 작성 예시는 [examples.md](examples.md)를 참조한다
 
 ## 라벨 & Assignee
 
@@ -52,18 +54,21 @@ allowed-tools: Read, Bash, Glob
 ## 실행
 
 ```bash
+# base 브랜치 (사전 작업 1에서 정한 값, 기본 be/dev)
+BASE="be/dev"
+
 # assignee 조회
 gh api user --jq '.login'
 
+# 본문은 --body-file - 로 stdin에서 읽는다 (heredoc)
 gh pr create \
-  --title "[type] 제목" \
-  --base be/dev \
-  --label "라벨1,라벨2" \
+  --title "[fix] 카드 점수 집계 누락 수정" \
+  --base "$BASE" \
+  --label "🐞bug,BE" \
   --assignee "$(gh api user --jq '.login')" \
-  --body "$(cat <<'EOF'
+  --body-file - <<'EOF'
 <템플릿 채운 내용>
 EOF
-)"
 ```
 
-완료 후 PR URL을 사용자에게 출력한다.
+완료 후 생성된 PR의 본문이 의도대로 반영됐는지 확인하고, PR URL을 사용자에게 출력한다.

--- a/backend/.claude/skills/create-pr/examples.md
+++ b/backend/.claude/skills/create-pr/examples.md
@@ -1,0 +1,39 @@
+# create-pr 작성 예시
+
+[SKILL.md](SKILL.md)에서 분리한 type별 제목·본문 예시 모음이다. 메인 스킬 파일은 규칙만 담고, 구체 예시는 이 파일에서 관리한다.
+
+## type별 제목 예시
+
+| type | 라벨 | 제목 예시 |
+|------|------|-----------|
+| feat | `✨feat`, `BE` | `[feat] 친구 초대 알림 Redis Stream 발행 추가` |
+| fix | `🐞bug`, `BE` | `[fix] 카드 점수 집계 누락 수정` |
+| refactor | `🛠️refactor`, `BE` | `[refactor] Room-GameSession 책임 분리` |
+| chore | `⚙️chore`, `BE` | `[chore] Testcontainers reuse 재활성화` |
+| docs | `📝docs`, `BE` | `[docs] ADR-0020 작성` |
+| test | `🧪 test`, `BE` | `[test] 카드 점수 집계 회귀 테스트 추가` |
+
+## 본문 작성 예시
+
+`.github/pull_request_template.md`의 4개 섹션을 그대로 유지하고 아래처럼 채운다.
+
+```text
+# ✅ 체크리스트
+
+- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)
+
+# 🔥 연관 이슈
+
+- close #1404
+
+# 🚀 작업 내용
+
+1. 카드 점수 집계 시 마지막 라운드가 누락되던 인덱스 오류 수정
+2. 누락 재현 테스트 추가
+
+# 💬 리뷰 중점사항
+
+- 집계 경계 조건(마지막 라운드 포함)에 대한 검증 로직을 중점적으로 확인 부탁드립니다.
+```
+
+연관 이슈가 없으면 `🔥 연관 이슈` 항목에 `없음`을 적는다.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

`create-pr` 스킬(`backend/.claude/skills/create-pr/`)을 정비했습니다.

1. **`--base` 무시 버그 수정** — 기존에 `git log be/dev..HEAD` / `git diff be/dev...HEAD` / `--base be/dev`가 be/dev로 하드코딩되어 있어, `--base=fe/dev` 등을 넘겨도 diff·log를 엉뚱한 기준으로 분석했습니다. `--base` 인자를 `$BASE`로 먼저 확정해 세 곳이 모두 그 값을 따르도록 통일했습니다.
2. **본문 전달 방식 정렬** — `--body "$(cat <<EOF)"` → `--body-file -` + stdin(heredoc)으로 변경하고, 생성 후 본문 반영 확인 단계를 추가했습니다.
3. **제목·본문 예시 분리** — type별 제목 예시와 템플릿 본문 작성 예시를 `examples.md`로 분리하고, SKILL.md는 규칙만 담아 슬림화했습니다. (메인 스킬 파일 크기를 작게 유지하려는 의도)

# 💬 리뷰 중점사항

- 제목 형식(`[type]`)은 기존부터 동일하며, 이번 변경은 실행 예시의 플레이스홀더를 구체 예시로 다듬은 표기 정리입니다.
- 라벨 표는 실제 repo 라벨(`🧪 test`의 공백 포함)과 일치해 수정하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * PR 생성 절차 가이드 문서를 단계별 형식으로 재작성하여 명확성 개선
  * PR 제목 작성 및 본문 작성 예시 문서 신규 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->