### PR TITLE
[fix] 비속어 트라이 주기적 재빌드 스케줄러 추가 (pub/sub 신호 유실 안전망)

### DIFF
--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/ProfanityTrieRebuildScheduler.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/ProfanityTrieRebuildScheduler.java
@@ -1,0 +1,35 @@
+package coffeeshout.profanity.infra;
+
+import coffeeshout.profanity.application.ProfanityFilterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비속어 트라이 주기적 재빌드 스케줄러.
+ *
+ * <p>단어 변경 시 Redis pub/sub({@code profanity:trie:refresh})으로 즉시 동기화하지만(ADR-0018),
+ * pub/sub은 비영속(fire-and-forget)이라 인스턴스가 구독 전이거나 일시 단절된 동안 발행된 신호는 유실된다.
+ * 신호가 유실되면 해당 인스턴스의 인메모리 트라이는 재기동 전까지 DB와 영구히 불일치 상태로 남는다.
+ *
+ * <p>이 스케줄러는 그 유실을 자가 치유하는 <b>안전망</b>이다. 즉시성은 기존 pub/sub이 담당하고,
+ * 본 스케줄러는 매시간 DB 기준으로 트라이를 재구성해 최대 1시간 내 정합성을 복구한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProfanityTrieRebuildScheduler {
+
+    private final ProfanityFilterService filterService;
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void rebuildPeriodically() {
+        log.debug("주기적 비속어 트라이 재빌드 시작 (pub/sub 신호 유실 대비 안전망)");
+        try {
+            filterService.rebuildTrie();
+        } catch (Exception e) {
+            log.error("주기적 비속어 트라이 재빌드 실패", e);
+        }
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/ProfanityTrieRebuildSchedulerTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/ProfanityTrieRebuildSchedulerTest.java
@@ -1,0 +1,48 @@
+package coffeeshout.profanity.infra;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.profanity.application.ProfanityFilterService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProfanityTrieRebuildSchedulerTest {
+
+    @Mock
+    private ProfanityFilterService filterService;
+
+    @InjectMocks
+    private ProfanityTrieRebuildScheduler scheduler;
+
+    @Nested
+    @DisplayName("주기적 재빌드 실행 시")
+    class RebuildPeriodically {
+
+        @Test
+        @DisplayName("필터 서비스의 트라이 재빌드를 호출한다")
+        void 트라이_재빌드를_호출한다() {
+            scheduler.rebuildPeriodically();
+
+            verify(filterService, times(1)).rebuildTrie();
+        }
+
+        @Test
+        @DisplayName("재빌드가 예외를 던져도 전파하지 않고 삼킨다")
+        void 재빌드_예외를_삼킨다() {
+            doThrow(new RuntimeException("DB 조회 실패")).when(filterService).rebuildTrie();
+
+            assertThatCode(() -> scheduler.rebuildPeriodically())
+                    .doesNotThrowAnyException();
+            verify(filterService, times(1)).rebuildTrie();
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- close #1444

# 🚀 작업 내용

1. `ProfanityTrieRebuildScheduler` 추가 — 매시간(`cron = "0 0 * * * *"`) `ProfanityFilterService.rebuildTrie()`를 호출해 인메모리 트라이를 DB 기준으로 재구성하는 안전망.
2. 재빌드 중 예외가 나도 전파하지 않고 로깅 후 삼켜 다음 주기 실행을 보장.
3. 단위 테스트 추가 (호출 검증 + 예외 삼킴 검증).

## 배경

prod에서 한국어 비속어 닉네임이 검열되지 않는 사고. DB에는 단어가 정상 적재돼 있었으나, 떠 있던 인스턴스의 트라이가 DB보다 오래된 상태(한국어 누락)였다. 원인은 트라이 동기화가 Redis pub/sub 하나에만 의존하는데(ADR-0018) pub/sub이 비영속이라 신호 유실 시 영구 불일치가 되는 것. 자가 치유 장치를 추가한다.

# 💬 리뷰 중점사항

- 즉시성은 기존 pub/sub이 그대로 담당하고, 본 스케줄러는 **신호 유실 대비 안전망**(최대 1시간 내 복구)입니다. ADR-0018의 "Redis pub/sub 즉시 동기화" 결정을 대체하지 않고 보완합니다. 진실 공급원은 `profanity_word` 테이블 그대로.
- 주기 1시간 적정성: AI 감사 스케줄러가 12시간 주기로 신규 비속어를 등록하므로, 안전망은 그보다 촘촘해야 합니다. `rebuildTrie()`는 수천 건 조회 + 인메모리 빌드라 비용이 무시할 수준(ADR-0018 명시)이라 1시간으로 잡았습니다.
- 다중 인스턴스에서 매시 정각 동시 재빌드가 발생하나, 연산이 가벼워 부하는 무시 가능 수준으로 판단했습니다.

## 별건 (이번 PR 범위 밖, 이슈에 기록)

`TextNormalizer`의 `@!@`→`aa` 오탐 / `gemini-3.5-flash` 모델명 / V28 Flyway checksum 위험 — 분리 처리 예정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 비속어 필터링 트라이가 매시간 자동으로 데이터베이스 기준으로 재구성됩니다.
  * 재구성 중 발생하는 오류는 안전하게 처리됩니다.

* **테스트**
  * 스케줄러 동작 및 예외 처리 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->