### PR TITLE
[fix] 짧은 ASCII 비속어 키워드 오탐 차단 (@!@ → aa 붕괴 방지)

### DIFF
--- a/backend/app/src/main/resources/db/migration/V32__delete_short_ascii_profanity_words.sql
+++ b/backend/app/src/main/resources/db/migration/V32__delete_short_ascii_profanity_words.sql
@@ -1,0 +1,11 @@
+-- 정규화 아티팩트로 생성된 짧은 ASCII 비속어 키워드 삭제
+--
+-- `@!@`(시드 목록)가 정규화(리트 치환 @→a, 특수문자 제거)를 거치며 `aa`로 붕괴해 등록됐다.
+-- Aho-Corasick은 부분 매칭이라 닉네임에 `aa`가 포함되기만 해도 차단되는 오탐이 발생한다.
+-- ProfanityWord 도메인 가드(ASCII-only & 3자 미만 거부)와 정합을 맞춰 기존 행을 제거한다.
+--
+-- 조건: 글자 수 3 미만(CHAR_LENGTH) AND ASCII 전용(바이트 길이 == 글자 수).
+--   한글은 utf8mb4에서 글자당 3바이트이므로 LENGTH > CHAR_LENGTH → 제외된다(`씨발` 등 보존).
+DELETE FROM profanity_word
+WHERE CHAR_LENGTH(word) < 3
+  AND LENGTH(word) = CHAR_LENGTH(word);

--- a/backend/profanity/src/main/java/coffeeshout/profanity/domain/ProfanityErrorCode.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/domain/ProfanityErrorCode.java
@@ -8,7 +8,8 @@ public enum ProfanityErrorCode implements ErrorCode {
     WORD_TOO_LONG("P002", "비속어는 " + ProfanityWord.MAX_WORD_LENGTH + "자 이하여야 합니다.", 400),
     WORD_NOT_FOUND("P003", "등록되지 않은 비속어입니다.", 404),
     LANGUAGE_REQUIRED("P004", "language는 null일 수 없습니다.", 400),
-    SOURCE_REQUIRED("P005", "source는 null일 수 없습니다.", 400);
+    SOURCE_REQUIRED("P005", "source는 null일 수 없습니다.", 400),
+    WORD_TOO_SHORT("P006", "ASCII 비속어는 " + ProfanityWord.MIN_ASCII_WORD_LENGTH + "자 이상이어야 합니다.", 400);
 
     private final String code;
     private final String message;

--- a/backend/profanity/src/main/java/coffeeshout/profanity/domain/ProfanityWord.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/domain/ProfanityWord.java
@@ -5,6 +5,7 @@ import coffeeshout.global.exception.custom.BusinessException;
 public record ProfanityWord(String word, Language language, WordSource source, boolean isActive) {
 
     public static final int MAX_WORD_LENGTH = 200;
+    public static final int MIN_ASCII_WORD_LENGTH = 3;
 
     public ProfanityWord {
         validate(word, language, source);
@@ -23,11 +24,30 @@ public record ProfanityWord(String word, Language language, WordSource source, b
             throw new BusinessException(ProfanityErrorCode.WORD_TOO_LONG,
                     "비속어는 " + MAX_WORD_LENGTH + "자 이하여야 합니다. 현재 길이: " + word.length());
         }
+        if (isDegenerateAsciiKeyword(word)) {
+            throw new BusinessException(ProfanityErrorCode.WORD_TOO_SHORT,
+                    "ASCII 비속어는 " + MIN_ASCII_WORD_LENGTH + "자 이상이어야 합니다. "
+                            + "너무 짧은 ASCII 키워드는 무관한 닉네임을 부분 매칭으로 오탐한다. 입력값: '" + word + "'");
+        }
         if (language == null) {
             throw new BusinessException(ProfanityErrorCode.LANGUAGE_REQUIRED, "language는 null일 수 없습니다.");
         }
         if (source == null) {
             throw new BusinessException(ProfanityErrorCode.SOURCE_REQUIRED, "source는 null일 수 없습니다.");
         }
+    }
+
+    /**
+     * 정규화 후 ASCII 문자만으로 구성된 {@value #MIN_ASCII_WORD_LENGTH}자 미만 키워드를 차단한다.
+     *
+     * <p>{@code @!@} 같은 기호 항목이 정규화(리트 치환 {@code @}→{@code a}, 특수문자 제거)를 거치며
+     * {@code aa}로 붕괴해, 닉네임에 해당 문자열이 부분 포함되기만 해도 차단되는 오탐을 막는다.
+     * 한글은 단일 문자가 ASCII 범위를 벗어나므로 {@code 씨발}(2자) 같은 짧은 한글 단어는 그대로 허용된다.
+     */
+    private static boolean isDegenerateAsciiKeyword(String word) {
+        if (word.length() >= MIN_ASCII_WORD_LENGTH) {
+            return false;
+        }
+        return word.chars().allMatch(c -> c < 128);
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/domain/ProfanityWordTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/domain/ProfanityWordTest.java
@@ -106,6 +106,40 @@ class ProfanityWordTest {
                 );
             }
         }
+
+        @Nested
+        class ASCII_최소_길이_미만 {
+
+            @Test
+            void 두_글자_ASCII_단어면_예외가_발생한다() {
+                assertCoffeeShoutException(
+                        () -> ProfanityWord.of("aa", Language.ENGLISH, WordSource.VANE),
+                        ProfanityErrorCode.WORD_TOO_SHORT
+                );
+            }
+
+            @Test
+            void 한_글자_ASCII_단어면_예외가_발생한다() {
+                assertCoffeeShoutException(
+                        () -> ProfanityWord.of("a", Language.ENGLISH, WordSource.VANE),
+                        ProfanityErrorCode.WORD_TOO_SHORT
+                );
+            }
+
+            @Test
+            void 세_글자_ASCII_단어는_정상_생성된다() {
+                final ProfanityWord word = ProfanityWord.of("sex", Language.ENGLISH, WordSource.VANE);
+
+                assertThat(word.word()).isEqualTo("sex");
+            }
+
+            @Test
+            void 두_글자_한글_단어는_ASCII가_아니므로_정상_생성된다() {
+                final ProfanityWord word = ProfanityWord.of("씨발", Language.KOREAN, WordSource.VANE);
+
+                assertThat(word.word()).isEqualTo("씨발");
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- #1444 (별건 체크리스트 항목 ①)

# 🚀 작업 내용

1. `ProfanityWord` 도메인에 ASCII 최소 길이 가드 추가 — 정규화 결과가 **ASCII 전용이고 3자 미만**이면 `WORD_TOO_SHORT`(P006)로 거부. 시드·관리자 추가·AI 등록 전 경로가 `ProfanityWord` 생성을 거치므로 중앙에서 차단.
2. `V32__delete_short_ascii_profanity_words.sql` — 이미 적재된 짧은 ASCII 행 삭제 (`@!@`→`aa` 등).

## 배경

시드 목록의 기호 항목 `@!@`가 `TextNormalizer` 정규화(리트 치환 `@`→`a`, 특수문자 제거)를 거치며 `aa`로 붕괴해 비속어로 등록됨. Aho-Corasick은 부분 매칭이라 닉네임에 `aa`가 포함되기만 해도 차단되는 오탐 발생. (prod/dev DB에서 `word='aa'`(source VANE) 확인됨.)

# 💬 리뷰 중점사항

- **가드 기준:** `ASCII 전용 && 길이 < 3`. 한글은 단일 문자가 ASCII 범위를 벗어나므로 `씨발`(2자) 등 짧은 한글 단어는 그대로 허용됩니다. `sex`/`huj`/`cul`(3자)도 유지. 시드 파일에서 이 기준에 걸리는 항목은 `@!@`(→`aa`) 하나뿐임을 확인했습니다.
- **마이그레이션 DELETE vs 비활성화:** 삭제를 택했습니다. (1) 정규화 아티팩트라 이력 보존 가치 없음 (2) `ProfanityWordEntity.toDomain()`이 가드를 포함한 record 생성자를 거치므로, 비활성 잔존 행이 관리자 목록 조회 등에서 도메인 변환될 때 예외를 유발할 수 있음. SQL 판별은 `LENGTH(word)=CHAR_LENGTH(word)`(utf8mb4에서 ASCII만 바이트==글자수)로 도메인 가드와 정합.
- **검증:** `:profanity` 모듈 테스트 161 통과/0 실패(Docker 기동). 기존 픽스처·테스트 단어는 모두 3자 이상 또는 한글이라 영향 없음.

## 참고

PR #1445(트라이 주기 재빌드 안전망)와 독립적입니다 — 변경 파일이 겹치지 않습니다.
