### PR TITLE
[chore] Google Tag Manager 설치 (GA4 이관 1단계)

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,6 +1,20 @@
 <!doctype html>
 <html lang="ko">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-PPFVK27G');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta
       name="viewport"
@@ -178,6 +192,16 @@
     <%= DEV_SNIPPET %>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-PPFVK27G"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root">
       <main id="zzol-splash">
         <svg width="120" height="31" viewBox="0 0 206 53" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev)

# 🔥 연관 이슈

- close #1453

# 🚀 작업 내용

1. Google Tag Manager(`GTM-PPFVK27G`) `<script>` 스니펫을 `public/index.html` `<head>` 상단에 추가
2. GTM `<noscript>` iframe을 `<body>` 여는 태그 바로 다음에 추가
3. 기존 GA4 직접 설치(gtag.js, `G-2150P8R4FF`)는 **유지** — 추적 끊김 방지

# 💬 리뷰 중점사항

### ⚠️ 왜 gtag를 같이 안 지웠나 (이관 2단계 분리)
프론트 이관 과정에서 기존 애널리틱스 설정 정보가 인계되지 않아, GTM 컨테이너(`GTM-PPFVK27G`)의 **발행된 설정을 직접 받아 확인**했습니다. 결과 컨테이너 내부에 GA4 태그가 **설정돼 있지 않음**(`G-...`/`UA-...`/`AW-...` 0건). 따라서 지금 코드의 gtag를 제거하면 애널리틱스 추적이 완전히 끊깁니다.

그래서 안전한 2단계 이관으로 분리했습니다.
- **1단계 (이 PR)**: GTM 스니펫만 추가, gtag 유지 → 추적 끊김 없음, 이중 집계 없음(컨테이너가 비어있으므로)
- **2단계 (후속, GTM 웹 UI)**: tagmanager.google.com에서 GA4 Configuration 태그 생성 → `G-2150P8R4FF` 입력 → 발행 → GA4 실시간 리포트로 수신 확인 → **그 후** 코드에서 gtag 제거(별도 PR)

### 검토 포인트
- `<script>`는 Google 권장대로 `<head>` 최상단에 배치
- `<noscript>` iframe 인라인 `style="display:none;visibility:hidden"`은 벤더 스니펫 표준 형식이라 그대로 유지
- `npm run build:dev` 통과, 빌드된 `dist/index.html`에 GTM ID 정상 보간 확인

### consolidation 결정 요청
gtag 직접 설치를 GTM으로 완전 흡수할지(2단계 진행 여부)는 리뷰어/운영 판단이 필요합니다.
