### PR TITLE
[chore] api-mcp self-healing 런처 도입 (.mcp.json → launch.mjs)

### DIFF
--- a/backend/.mcp.json
+++ b/backend/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "api": {
       "command": "node",
-      "args": ["../tools/api-mcp/dist/server.js"],
+      "args": ["../tools/api-mcp/scripts/launch.mjs"],
       "env": {
         "API_MCP_CATALOG_URL": "http://localhost:8080/dev/ws-catalog"
       }

--- a/tools/api-mcp/eslint.config.js
+++ b/tools/api-mcp/eslint.config.js
@@ -4,7 +4,7 @@ import prettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'eslint.config.js'],
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'eslint.config.js', 'scripts/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,

--- a/tools/api-mcp/scripts/launch.mjs
+++ b/tools/api-mcp/scripts/launch.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+ * api-mcp self-healing launcher.
+ *
+ * `.mcp.json` 이 빌드 산출물(dist/server.js)을 직접 가리키면, node_modules·dist 가
+ * gitignore 되어 있어 클론/클린마다 사라져 "Connection closed" 로 죽는다.
+ * 이 런처는 실행 시점에 의존성 설치·빌드를 보장한 뒤 서버를 같은 프로세스에서
+ * import 로 띄워 stdio(JSON-RPC) 를 그대로 넘긴다.
+ *
+ * ★ stdout 규율: 이 파일과 npm 자식 프로세스는 절대 stdout 에 쓰지 않는다.
+ *   npm 출력은 fd 2(stderr) 로 돌린다. stdout 으로 새면 MCP JSON-RPC 가 깨진다.
+ */
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function npm(args) {
+  // 자식 stdout -> 부모 fd 2(stderr). stdin 무시, stderr 상속.
+  const r = spawnSync('npm', args, {
+    cwd: root,
+    stdio: ['ignore', 2, 'inherit'],
+    shell: true,
+  });
+  if (r.status !== 0) {
+    process.stderr.write(`api-mcp launcher: 'npm ${args.join(' ')}' 실패 (exit ${r.status})\n`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+const depMarker = join(root, 'node_modules', '@modelcontextprotocol');
+const distEntry = join(root, 'dist', 'server.js');
+
+// node_modules 가 비었거나 부분 설치된 상태(@modelcontextprotocol 부재)면 재설치.
+// npm ci/install 의 `prepare` 훅이 build 까지 돌려 dist 도 함께 생성된다.
+if (!existsSync(depMarker)) {
+  npm(existsSync(join(root, 'package-lock.json')) ? ['ci'] : ['install']);
+}
+// deps 는 있는데 dist 만 없는 경우(예: 빌드만 날아감) 대비.
+if (!existsSync(distEntry)) {
+  npm(['run', 'build']);
+}
+
+await import(pathToFileURL(distEntry).href);


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev) — `be/dev`

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. `tools/api-mcp/scripts/launch.mjs` 추가 — api-mcp self-healing 런처. 실행 시점에 `node_modules`·`dist` 유무를 확인해 없으면 `npm ci/install`(+`prepare` 빌드) 또는 `npm run build`로 복구한 뒤, 서버를 같은 프로세스에서 `import`해 stdio(JSON-RPC)를 그대로 넘긴다.
2. `backend/.mcp.json` 수정 — api 서버 진입점을 빌드 산출물 직접 참조(`../tools/api-mcp/dist/server.js`)에서 런처(`../tools/api-mcp/scripts/launch.mjs`)로 변경.

# 💬 리뷰 중점사항

- **배경:** `.mcp.json`이 `dist/server.js`를 직접 가리켰는데, `node_modules`·`dist`가 gitignore라 클론/클린마다 사라져 MCP가 "Connection closed"로 죽었다. 런처가 실행 시점에 의존성·빌드를 보장해 이 문제를 제거한다.
- **stdout 규율:** 런처와 npm 자식 프로세스는 stdout에 절대 쓰지 않는다(npm 출력은 fd 2/stderr로 리다이렉트). stdout으로 새면 MCP JSON-RPC 프레이밍이 깨지므로 이 규율이 핵심이다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 서버 런처를 새로운 스크립트 기반으로 업데이트했습니다.
  * 런처가 실행 시 필요한 의존성 설치 및 빌드를 자동으로 처리하는 자가 복구 기능을 추가했습니다.
  * ESLint 검사 제외 목록을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->