### PR TITLE
[chore] .claude/worktrees/ gitignore 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -40,6 +40,7 @@ out/
 
 ### Claude Code ###
 .claude/settings.local.json
+.claude/worktrees/
 
 ### Docker ###
 # Environment files


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev) — `be/dev`

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

1. `backend/.gitignore`의 `### Claude Code ###` 섹션에 `.claude/worktrees/` 추가 — Claude Code 에이전트가 생성하는 워크트리 체크아웃(`backend/.claude/worktrees/`)이 추적되지 않도록 무시한다.

# 💬 리뷰 중점사항

- 기존 `.claude/settings.local.json`과 동일한 섹션에 둬, 에이전트 산출물 무시 규칙을 한곳에 모았다.
- `git check-ignore`로 `backend/.claude/worktrees/`가 무시되고 `git status`의 untracked 목록에서 사라지는 것을 확인했다.
