### PR TITLE
[feat] 대시보드에 스피드터치(1to25)·뇌피셜 초시계 TOP 플레이어 추가

### DIFF
--- a/backend/admin/src/main/java/coffeeshout/dashboard/application/DashboardService.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/application/DashboardService.java
@@ -1,9 +1,11 @@
 package coffeeshout.dashboard.application;
 
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
 import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import coffeeshout.dashboard.domain.repository.DashboardStatisticsRepository;
 import java.time.Clock;
@@ -58,6 +60,20 @@ public class DashboardService {
         final LocalDateTime endOfMonth = getEndOfMonth();
 
         return dashboardStatisticsRepository.findBlockStackingTopPlayers(startOfMonth, endOfMonth, TOP_PLAYER_LIMIT);
+    }
+
+    public List<SpeedTouchTopPlayerResponse> getSpeedTouchTopPlayers() {
+        final LocalDateTime startOfMonth = getStartOfMonth();
+        final LocalDateTime endOfMonth = getEndOfMonth();
+
+        return dashboardStatisticsRepository.findSpeedTouchTopPlayers(startOfMonth, endOfMonth, TOP_PLAYER_LIMIT);
+    }
+
+    public List<BlindTimerTopPlayerResponse> getBlindTimerTopPlayers() {
+        final LocalDateTime startOfMonth = getStartOfMonth();
+        final LocalDateTime endOfMonth = getEndOfMonth();
+
+        return dashboardStatisticsRepository.findBlindTimerTopPlayers(startOfMonth, endOfMonth, TOP_PLAYER_LIMIT);
     }
 
     private LocalDateTime getStartOfMonth() {

--- a/backend/admin/src/main/java/coffeeshout/dashboard/domain/BlindTimerTopPlayerResponse.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/domain/BlindTimerTopPlayerResponse.java
@@ -1,0 +1,7 @@
+package coffeeshout.dashboard.domain;
+
+public record BlindTimerTopPlayerResponse(
+        String playerName,
+        long bestErrorMillis
+) {
+}

--- a/backend/admin/src/main/java/coffeeshout/dashboard/domain/SpeedTouchTopPlayerResponse.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/domain/SpeedTouchTopPlayerResponse.java
@@ -1,0 +1,7 @@
+package coffeeshout.dashboard.domain;
+
+public record SpeedTouchTopPlayerResponse(
+        String playerName,
+        long bestTime
+) {
+}

--- a/backend/admin/src/main/java/coffeeshout/dashboard/domain/repository/DashboardStatisticsRepository.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/domain/repository/DashboardStatisticsRepository.java
@@ -1,9 +1,11 @@
 package coffeeshout.dashboard.domain.repository;
 
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
 import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,6 +34,18 @@ public interface DashboardStatisticsRepository {
     );
 
     List<BlockStackingTopPlayerResponse> findBlockStackingTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    );
+
+    List<SpeedTouchTopPlayerResponse> findSpeedTouchTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    );
+
+    List<BlindTimerTopPlayerResponse> findBlindTimerTopPlayers(
             LocalDateTime startDate,
             LocalDateTime endDate,
             int limit

--- a/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
@@ -1,9 +1,11 @@
 package coffeeshout.dashboard.infra.persistence;
 
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
 import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import coffeeshout.dashboard.domain.repository.DashboardStatisticsRepository;
 import coffeeshout.minigame.domain.MiniGameType;
@@ -194,5 +196,117 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                 .orderBy(MINI_GAME_RESULT.score.max().desc())
                 .limit(limit)
                 .fetch();
+    }
+
+    @Override
+    public List<SpeedTouchTopPlayerResponse> findSpeedTouchTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    ) {
+        // 완주 점수는 완주 시간(ms). DNF는 SpeedTouchScore에서 DNF_BASE(1_000_000_000) - progress로
+        // 10^9 부근 값이므로, 이 경계 미만(실제 완주 기록)만 집계해 미완주 기록을 TOP에서 제외한다.
+        final long finishScoreCeiling = 1_000_000L;
+
+        // 1단계: player_id로 GROUP BY하여 최단 완주 시간 집계 (JOIN 없이) — RacingGame과 동일 패턴
+        final List<Tuple> aggregations = queryFactory
+                .select(
+                        MINI_GAME_RESULT.player.id,
+                        MINI_GAME_RESULT.score.min()
+                )
+                .from(MINI_GAME_RESULT)
+                .where(
+                        MINI_GAME_RESULT.miniGameType.eq(MiniGameType.SPEED_TOUCH),
+                        MINI_GAME_RESULT.createdAt.between(startDate, endDate),
+                        MINI_GAME_RESULT.score.lt(finishScoreCeiling)
+                )
+                .groupBy(MINI_GAME_RESULT.player.id)
+                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
+                .limit(limit)
+                .fetch();
+
+        if (aggregations.isEmpty()) {
+            return List.of();
+        }
+
+        // 2단계: player_id 목록으로 player_name 조회
+        final List<Long> playerIds = aggregations.stream()
+                .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
+                .toList();
+
+        final Map<Long, String> playerNameMap = queryFactory
+                .select(PLAYER.id, PLAYER.playerName)
+                .from(PLAYER)
+                .where(PLAYER.id.in(playerIds))
+                .fetch()
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        tuple -> tuple.get(PLAYER.id),
+                        tuple -> tuple.get(PLAYER.playerName)
+                ));
+
+        // 3단계: 집계 결과와 player_name 매핑
+        return aggregations.stream()
+                .map(tuple -> new SpeedTouchTopPlayerResponse(
+                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
+                        tuple.get(MINI_GAME_RESULT.score.min())
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<BlindTimerTopPlayerResponse> findBlindTimerTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    ) {
+        // 점수는 목표 시간과의 오차(ms, 작을수록 가까움). 타임아웃은 BlindTimerScore에서 TIMEOUT_PENALTY(999_999_999)로
+        // 항상 꼴등 그룹이므로, 이 경계 미만(정상 STOP, 최대 오차 약 20초)만 집계해 타임아웃 기록을 TOP에서 제외한다.
+        final long normalStopScoreCeiling = 1_000_000L;
+
+        // 1단계: player_id로 GROUP BY하여 최소 오차 집계 (JOIN 없이) — RacingGame과 동일 패턴
+        final List<Tuple> aggregations = queryFactory
+                .select(
+                        MINI_GAME_RESULT.player.id,
+                        MINI_GAME_RESULT.score.min()
+                )
+                .from(MINI_GAME_RESULT)
+                .where(
+                        MINI_GAME_RESULT.miniGameType.eq(MiniGameType.BLIND_TIMER),
+                        MINI_GAME_RESULT.createdAt.between(startDate, endDate),
+                        MINI_GAME_RESULT.score.lt(normalStopScoreCeiling)
+                )
+                .groupBy(MINI_GAME_RESULT.player.id)
+                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
+                .limit(limit)
+                .fetch();
+
+        if (aggregations.isEmpty()) {
+            return List.of();
+        }
+
+        // 2단계: player_id 목록으로 player_name 조회
+        final List<Long> playerIds = aggregations.stream()
+                .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
+                .toList();
+
+        final Map<Long, String> playerNameMap = queryFactory
+                .select(PLAYER.id, PLAYER.playerName)
+                .from(PLAYER)
+                .where(PLAYER.id.in(playerIds))
+                .fetch()
+                .stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        tuple -> tuple.get(PLAYER.id),
+                        tuple -> tuple.get(PLAYER.playerName)
+                ));
+
+        // 3단계: 집계 결과와 player_name 매핑
+        return aggregations.stream()
+                .map(tuple -> new BlindTimerTopPlayerResponse(
+                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
+                        tuple.get(MINI_GAME_RESULT.score.min())
+                ))
+                .toList();
     }
 }

--- a/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/infra/persistence/QueryDslDashboardStatisticsRepository.java
@@ -17,11 +17,14 @@ import coffeeshout.room.infra.persistence.QRouletteResultEntity;
 import coffeeshout.user.infra.persistence.QUserEntity;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -129,49 +132,54 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
             LocalDateTime endDate,
             int limit
     ) {
-        // 1단계: player_id로 GROUP BY하여 집계 (JOIN 없이)
-        final List<Tuple> aggregations = queryFactory
-                .select(
-                        MINI_GAME_RESULT.player.id,
-                        MINI_GAME_RESULT.score.min()
-                )
-                .from(MINI_GAME_RESULT)
-                .where(
-                        MINI_GAME_RESULT.miniGameType.eq(MiniGameType.RACING_GAME),
-                        MINI_GAME_RESULT.createdAt.between(startDate, endDate)
-                )
-                .groupBy(MINI_GAME_RESULT.player.id)
-                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
-                .limit(limit)
-                .fetch();
+        return findTopPlayersByMinScore(
+                MiniGameType.RACING_GAME,
+                startDate,
+                endDate,
+                limit,
+                null,
+                RacingGameTopPlayerResponse::new
+        );
+    }
 
-        if (aggregations.isEmpty()) {
-            return List.of();
-        }
+    @Override
+    public List<SpeedTouchTopPlayerResponse> findSpeedTouchTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    ) {
+        // 완주 점수는 완주 시간(ms). DNF는 SpeedTouchScore에서 DNF_BASE(1_000_000_000) - progress로
+        // 10^9 부근 값이므로, 이 경계 미만(실제 완주 기록)만 집계해 미완주 기록을 TOP에서 제외한다.
+        final long finishScoreCeiling = 1_000_000L;
 
-        // 2단계: player_id 목록으로 player_name 조회
-        final List<Long> playerIds = aggregations.stream()
-                .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
-                .toList();
+        return findTopPlayersByMinScore(
+                MiniGameType.SPEED_TOUCH,
+                startDate,
+                endDate,
+                limit,
+                MINI_GAME_RESULT.score.lt(finishScoreCeiling),
+                SpeedTouchTopPlayerResponse::new
+        );
+    }
 
-        final Map<Long, String> playerNameMap = queryFactory
-                .select(PLAYER.id, PLAYER.playerName)
-                .from(PLAYER)
-                .where(PLAYER.id.in(playerIds))
-                .fetch()
-                .stream()
-                .collect(java.util.stream.Collectors.toMap(
-                        tuple -> tuple.get(PLAYER.id),
-                        tuple -> tuple.get(PLAYER.playerName)
-                ));
+    @Override
+    public List<BlindTimerTopPlayerResponse> findBlindTimerTopPlayers(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int limit
+    ) {
+        // 점수는 목표 시간과의 오차(ms, 작을수록 가까움). 타임아웃은 BlindTimerScore에서 TIMEOUT_PENALTY(999_999_999)로
+        // 항상 꼴등 그룹이므로, 이 경계 미만(정상 STOP, 최대 오차 약 20초)만 집계해 타임아웃 기록을 TOP에서 제외한다.
+        final long normalStopScoreCeiling = 1_000_000L;
 
-        // 3단계: 집계 결과와 player_name 매핑
-        return aggregations.stream()
-                .map(tuple -> new RacingGameTopPlayerResponse(
-                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
-                        tuple.get(MINI_GAME_RESULT.score.min())
-                ))
-                .toList();
+        return findTopPlayersByMinScore(
+                MiniGameType.BLIND_TIMER,
+                startDate,
+                endDate,
+                limit,
+                MINI_GAME_RESULT.score.lt(normalStopScoreCeiling),
+                BlindTimerTopPlayerResponse::new
+        );
     }
 
     @Override
@@ -198,17 +206,21 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                 .fetch();
     }
 
-    @Override
-    public List<SpeedTouchTopPlayerResponse> findSpeedTouchTopPlayers(
+    /**
+     * 최단/최소 점수가 우수한 미니게임의 TOP 플레이어를 조회한다(RacingGame·SpeedTouch·BlindTimer 공통).
+     * player_id로 집계 후 별도 쿼리로 이름을 매핑하는 2-스텝 방식으로, 집계 단계의 JOIN을 피한다.
+     *
+     * @param scoreFilter 점수 경계 등 추가 필터(없으면 null — QueryDSL이 null 조건을 무시한다)
+     * @param mapper      (playerName, bestScore) → 응답 DTO 생성자
+     */
+    private <T> List<T> findTopPlayersByMinScore(
+            MiniGameType miniGameType,
             LocalDateTime startDate,
             LocalDateTime endDate,
-            int limit
+            int limit,
+            BooleanExpression scoreFilter,
+            BiFunction<String, Long, T> mapper
     ) {
-        // 완주 점수는 완주 시간(ms). DNF는 SpeedTouchScore에서 DNF_BASE(1_000_000_000) - progress로
-        // 10^9 부근 값이므로, 이 경계 미만(실제 완주 기록)만 집계해 미완주 기록을 TOP에서 제외한다.
-        final long finishScoreCeiling = 1_000_000L;
-
-        // 1단계: player_id로 GROUP BY하여 최단 완주 시간 집계 (JOIN 없이) — RacingGame과 동일 패턴
         final List<Tuple> aggregations = queryFactory
                 .select(
                         MINI_GAME_RESULT.player.id,
@@ -216,9 +228,9 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
                 )
                 .from(MINI_GAME_RESULT)
                 .where(
-                        MINI_GAME_RESULT.miniGameType.eq(MiniGameType.SPEED_TOUCH),
+                        MINI_GAME_RESULT.miniGameType.eq(miniGameType),
                         MINI_GAME_RESULT.createdAt.between(startDate, endDate),
-                        MINI_GAME_RESULT.score.lt(finishScoreCeiling)
+                        scoreFilter
                 )
                 .groupBy(MINI_GAME_RESULT.player.id)
                 .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
@@ -229,84 +241,30 @@ public class QueryDslDashboardStatisticsRepository implements DashboardStatistic
             return List.of();
         }
 
-        // 2단계: player_id 목록으로 player_name 조회
         final List<Long> playerIds = aggregations.stream()
                 .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
                 .toList();
 
-        final Map<Long, String> playerNameMap = queryFactory
-                .select(PLAYER.id, PLAYER.playerName)
-                .from(PLAYER)
-                .where(PLAYER.id.in(playerIds))
-                .fetch()
-                .stream()
-                .collect(java.util.stream.Collectors.toMap(
-                        tuple -> tuple.get(PLAYER.id),
-                        tuple -> tuple.get(PLAYER.playerName)
-                ));
+        final Map<Long, String> playerNameMap = findPlayerNames(playerIds);
 
-        // 3단계: 집계 결과와 player_name 매핑
         return aggregations.stream()
-                .map(tuple -> new SpeedTouchTopPlayerResponse(
+                .map(tuple -> mapper.apply(
                         playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
                         tuple.get(MINI_GAME_RESULT.score.min())
                 ))
                 .toList();
     }
 
-    @Override
-    public List<BlindTimerTopPlayerResponse> findBlindTimerTopPlayers(
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            int limit
-    ) {
-        // 점수는 목표 시간과의 오차(ms, 작을수록 가까움). 타임아웃은 BlindTimerScore에서 TIMEOUT_PENALTY(999_999_999)로
-        // 항상 꼴등 그룹이므로, 이 경계 미만(정상 STOP, 최대 오차 약 20초)만 집계해 타임아웃 기록을 TOP에서 제외한다.
-        final long normalStopScoreCeiling = 1_000_000L;
-
-        // 1단계: player_id로 GROUP BY하여 최소 오차 집계 (JOIN 없이) — RacingGame과 동일 패턴
-        final List<Tuple> aggregations = queryFactory
-                .select(
-                        MINI_GAME_RESULT.player.id,
-                        MINI_GAME_RESULT.score.min()
-                )
-                .from(MINI_GAME_RESULT)
-                .where(
-                        MINI_GAME_RESULT.miniGameType.eq(MiniGameType.BLIND_TIMER),
-                        MINI_GAME_RESULT.createdAt.between(startDate, endDate),
-                        MINI_GAME_RESULT.score.lt(normalStopScoreCeiling)
-                )
-                .groupBy(MINI_GAME_RESULT.player.id)
-                .orderBy(MINI_GAME_RESULT.score.min().asc(), MINI_GAME_RESULT.player.id.asc())
-                .limit(limit)
-                .fetch();
-
-        if (aggregations.isEmpty()) {
-            return List.of();
-        }
-
-        // 2단계: player_id 목록으로 player_name 조회
-        final List<Long> playerIds = aggregations.stream()
-                .map(tuple -> tuple.get(MINI_GAME_RESULT.player.id))
-                .toList();
-
-        final Map<Long, String> playerNameMap = queryFactory
+    private Map<Long, String> findPlayerNames(List<Long> playerIds) {
+        return queryFactory
                 .select(PLAYER.id, PLAYER.playerName)
                 .from(PLAYER)
                 .where(PLAYER.id.in(playerIds))
                 .fetch()
                 .stream()
-                .collect(java.util.stream.Collectors.toMap(
+                .collect(Collectors.toMap(
                         tuple -> tuple.get(PLAYER.id),
                         tuple -> tuple.get(PLAYER.playerName)
                 ));
-
-        // 3단계: 집계 결과와 player_name 매핑
-        return aggregations.stream()
-                .map(tuple -> new BlindTimerTopPlayerResponse(
-                        playerNameMap.get(tuple.get(MINI_GAME_RESULT.player.id)),
-                        tuple.get(MINI_GAME_RESULT.score.min())
-                ))
-                .toList();
     }
 }

--- a/backend/admin/src/main/java/coffeeshout/dashboard/ui/DashboardApi.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/ui/DashboardApi.java
@@ -1,9 +1,11 @@
 package coffeeshout.dashboard.ui;
 
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
 import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,4 +29,10 @@ public interface DashboardApi {
 
     @Operation(summary = "블록 쌓기 TOP 플레이어 조회", description = "이번 달 블록 쌓기 게임 최고 층수 기준 상위 5명을 조회합니다.")
     ResponseEntity<List<BlockStackingTopPlayerResponse>> getBlockStackingTopPlayers();
+
+    @Operation(summary = "스피드터치 TOP 플레이어 조회", description = "이번 달 스피드터치(1to25) 최단 완주 시간 기준 상위 5명을 조회합니다.")
+    ResponseEntity<List<SpeedTouchTopPlayerResponse>> getSpeedTouchTopPlayers();
+
+    @Operation(summary = "뇌피셜 초시계 TOP 플레이어 조회", description = "이번 달 블라인드타이머 목표 시간과의 오차가 가장 작은 상위 5명을 조회합니다.")
+    ResponseEntity<List<BlindTimerTopPlayerResponse>> getBlindTimerTopPlayers();
 }

--- a/backend/admin/src/main/java/coffeeshout/dashboard/ui/DashboardController.java
+++ b/backend/admin/src/main/java/coffeeshout/dashboard/ui/DashboardController.java
@@ -1,10 +1,12 @@
 package coffeeshout.dashboard.ui;
 
 import coffeeshout.dashboard.application.DashboardService;
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
 import coffeeshout.dashboard.domain.RacingGameTopPlayerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -43,5 +45,15 @@ public class DashboardController implements DashboardApi {
     @GetMapping("/block-stacking-top-players")
     public ResponseEntity<List<BlockStackingTopPlayerResponse>> getBlockStackingTopPlayers() {
         return ResponseEntity.ok(dashboardService.getBlockStackingTopPlayers());
+    }
+
+    @GetMapping("/speed-touch-top-players")
+    public ResponseEntity<List<SpeedTouchTopPlayerResponse>> getSpeedTouchTopPlayers() {
+        return ResponseEntity.ok(dashboardService.getSpeedTouchTopPlayers());
+    }
+
+    @GetMapping("/blind-timer-top-players")
+    public ResponseEntity<List<BlindTimerTopPlayerResponse>> getBlindTimerTopPlayers() {
+        return ResponseEntity.ok(dashboardService.getBlindTimerTopPlayers());
     }
 }

--- a/backend/admin/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
+++ b/backend/admin/src/test/java/coffeeshout/dashboard/application/DashboardServiceTest.java
@@ -3,9 +3,12 @@ package coffeeshout.dashboard.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import coffeeshout.blindtimer.domain.BlindTimerScore;
+import coffeeshout.dashboard.domain.BlindTimerTopPlayerResponse;
 import coffeeshout.dashboard.domain.BlockStackingTopPlayerResponse;
 import coffeeshout.dashboard.domain.GamePlayCountResponse;
 import coffeeshout.dashboard.domain.LowestProbabilityWinnerResponse;
+import coffeeshout.dashboard.domain.SpeedTouchTopPlayerResponse;
 import coffeeshout.dashboard.domain.TopWinnerResponse;
 import coffeeshout.AdminModuleServiceTest;
 import coffeeshout.minigame.domain.MiniGameType;
@@ -20,6 +23,7 @@ import coffeeshout.room.infra.persistence.RoomEntity;
 import coffeeshout.room.infra.persistence.RoomJpaRepository;
 import coffeeshout.room.infra.persistence.RouletteResultEntity;
 import coffeeshout.room.infra.persistence.RouletteResultJpaRepository;
+import coffeeshout.speedtouch.domain.SpeedTouchScore;
 import coffeeshout.user.infra.persistence.UserEntity;
 import coffeeshout.user.infra.persistence.UserJpaRepository;
 import java.util.List;
@@ -517,6 +521,213 @@ class DashboardServiceTest extends AdminModuleServiceTest {
                 softly.assertThat(result).hasSize(1);
                 softly.assertThat(result.getFirst().playerName()).isEqualTo("철수");
             });
+        }
+    }
+
+    @Nested
+    @DisplayName("getSpeedTouchTopPlayers 테스트")
+    class GetSpeedTouchTopPlayersTest {
+
+        @Test
+        void 이번달_스피드터치_최단_완주시간_기준_오름차순으로_조회한다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("STAA"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.SPEED_TOUCH)
+            );
+
+            final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
+            final PlayerEntity 영희 = playerJpaRepository.save(new PlayerEntity(room, "영희", PlayerType.GUEST));
+            final PlayerEntity 민수 = playerJpaRepository.save(new PlayerEntity(room, "민수", PlayerType.GUEST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수, 1, 1000L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 영희, 2, 2000L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 민수, 3, 3000L));
+
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(3);
+                softly.assertThat(result.get(0).playerName()).isEqualTo("철수");
+                softly.assertThat(result.get(0).bestTime()).isEqualTo(1000L);
+                softly.assertThat(result.get(2).playerName()).isEqualTo("민수");
+            });
+        }
+
+        @Test
+        void 미완주_DNF_기록은_집계에서_제외된다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("STBB"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.SPEED_TOUCH)
+            );
+            final PlayerEntity 완주자 = playerJpaRepository.save(new PlayerEntity(room, "완주자", PlayerType.HOST));
+            final PlayerEntity 미완주자 = playerJpaRepository.save(new PlayerEntity(room, "미완주자", PlayerType.GUEST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 완주자, 1, 4000L));
+            // DNF 점수는 도메인 정의(SpeedTouchScore.ofDnf)에서 생성해 경계값이 실제 정의와 회귀로 묶이게 한다
+            miniGameResultJpaRepository.save(
+                    new MiniGameResultEntity(miniGame, 미완주자, 2, SpeedTouchScore.ofDnf(2).getValue()));
+
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.getFirst().playerName()).isEqualTo("완주자");
+                softly.assertThat(result.getFirst().bestTime()).isEqualTo(4000L);
+            });
+        }
+
+        @Test
+        void 같은_플레이어의_여러_기록은_최단_시간으로_집계된다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("STCC"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.SPEED_TOUCH)
+            );
+            final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수, 1, 5000L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수, 1, 2000L));
+
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.getFirst().bestTime()).isEqualTo(2000L);
+            });
+        }
+
+        @Test
+        void 다섯명_초과이면_상위_5명만_반환한다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("STDD"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.SPEED_TOUCH)
+            );
+
+            for (int i = 1; i <= 7; i++) {
+                final PlayerEntity player = playerJpaRepository.save(
+                        new PlayerEntity(room, "플레이어" + i, PlayerType.GUEST)
+                );
+                miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, player, i, (long) i * 1000));
+            }
+
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(5);
+                softly.assertThat(result.getFirst().bestTime()).isEqualTo(1000L);
+            });
+        }
+
+        @Test
+        void 다른_게임_타입의_결과는_포함하지_않는다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("STEE"));
+            final MiniGameEntity speedTouch = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.SPEED_TOUCH)
+            );
+            final MiniGameEntity racing = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.RACING_GAME)
+            );
+
+            final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
+            final PlayerEntity 영희 = playerJpaRepository.save(new PlayerEntity(room, "영희", PlayerType.GUEST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(speedTouch, 철수, 1, 1500L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(racing, 영희, 1, 500L));
+
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.getFirst().playerName()).isEqualTo("철수");
+            });
+        }
+
+        @Test
+        void 이번달_스피드터치_기록이_없으면_빈_리스트를_반환한다() {
+            // when
+            final List<SpeedTouchTopPlayerResponse> result = dashboardService.getSpeedTouchTopPlayers();
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getBlindTimerTopPlayers 테스트")
+    class GetBlindTimerTopPlayersTest {
+
+        @Test
+        void 이번달_목표시간과의_오차가_작은_순으로_오름차순_조회한다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("BTAA"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.BLIND_TIMER)
+            );
+            final PlayerEntity 철수 = playerJpaRepository.save(new PlayerEntity(room, "철수", PlayerType.HOST));
+            final PlayerEntity 영희 = playerJpaRepository.save(new PlayerEntity(room, "영희", PlayerType.GUEST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 철수, 1, 120L));
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 영희, 2, 800L));
+
+            // when
+            final List<BlindTimerTopPlayerResponse> result = dashboardService.getBlindTimerTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result.get(0).playerName()).isEqualTo("철수");
+                softly.assertThat(result.get(0).bestErrorMillis()).isEqualTo(120L);
+                softly.assertThat(result.get(1).playerName()).isEqualTo("영희");
+            });
+        }
+
+        @Test
+        void 타임아웃_기록은_집계에서_제외된다() {
+            // given
+            final RoomEntity room = roomJpaRepository.save(new RoomEntity("BTBB"));
+            final MiniGameEntity miniGame = miniGameJpaRepository.save(
+                    new MiniGameEntity(room, MiniGameType.BLIND_TIMER)
+            );
+            final PlayerEntity 정상 = playerJpaRepository.save(new PlayerEntity(room, "정상", PlayerType.HOST));
+            final PlayerEntity 타임아웃 = playerJpaRepository.save(new PlayerEntity(room, "타임아웃", PlayerType.GUEST));
+
+            miniGameResultJpaRepository.save(new MiniGameResultEntity(miniGame, 정상, 1, 3000L));
+            // 타임아웃 점수는 도메인 정의(BlindTimerScore.ofTimeout)에서 생성해 경계값이 실제 정의와 회귀로 묶이게 한다
+            miniGameResultJpaRepository.save(
+                    new MiniGameResultEntity(miniGame, 타임아웃, 2, BlindTimerScore.ofTimeout().getValue()));
+
+            // when
+            final List<BlindTimerTopPlayerResponse> result = dashboardService.getBlindTimerTopPlayers();
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(1);
+                softly.assertThat(result.getFirst().playerName()).isEqualTo("정상");
+                softly.assertThat(result.getFirst().bestErrorMillis()).isEqualTo(3000L);
+            });
+        }
+
+        @Test
+        void 이번달_블라인드타이머_기록이_없으면_빈_리스트를_반환한다() {
+            // when
+            final List<BlindTimerTopPlayerResponse> result = dashboardService.getBlindTimerTopPlayers();
+
+            // then
+            assertThat(result).isEmpty();
         }
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- close #1462

# 🚀 작업 내용

1. 관리자 대시보드에 게임별 TOP 플레이어 2종 추가 (이번 달 윈도우, TOP 5) — 기존 Racing/BlockStacking 패턴 미러링
   - `GET /dashboard/speed-touch-top-players` — 스피드터치(1to25) **최단 완주 시간** 오름차순
   - `GET /dashboard/blind-timer-top-players` — 뇌피셜 초시계 **목표 시간과의 오차(abs) 최소** 오름차순
2. DNF(SpeedTouch)·타임아웃(BlindTimer)은 점수 경계로 집계에서 **제외**
3. **write 경로·신규 인덱스 없음** — `mini_game_result` 읽기 전용, 기존 V4 `idx_mini_game_result_type_created (mini_game_type, created_at)` 재사용
4. `DashboardServiceTest`에 9개 테스트(정렬·DNF/타임아웃 제외·동일 플레이어 최소값·limit5·타입 격리·빈 결과). DNF/타임아웃 점수는 도메인 팩토리(`SpeedTouchScore.ofDnf`/`BlindTimerScore.ofTimeout`)로 생성해 경계 회귀 보장

# 💬 리뷰 중점사항

- **경계 상수(1_000_000L)의 도메인 결합**: 테스트를 `ofDnf()`/`ofTimeout()`로 묶어 회귀 안전망 확보. 쿼리 쪽 경계는 로컬 변수+주석 유지(값 자체는 SpeedTouchScore.DNF_BASE/BlindTimerScore.TIMEOUT_PENALTY 기준 정확).
- **QueryDSL 3-메서드 중복**(Racing/SpeedTouch/BlindTimer): 기존 패턴 일관성을 위해 공통 헬퍼 추출하지 않음(Racing은 범위 밖).
- **ADR-0024(미결) caveat**: 응답이 `playerName`만 노출 → 0024 적용 시 동명이인 행 구분 불가(기존 엔드포인트와 동일, 차단 아님).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 스피드 터치 게임 상위 플레이어 조회 기능 추가
  * 뇌피셜 초시계 게임 상위 플레이어 조회 기능 추가
  * 매월 최고 성적 기록자 순위 데이터 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->