### PR TITLE
[feat] 전체 랭킹에 뇌피셜 초시계·스피드터치 추가

### DIFF
--- a/frontend/.claude/agents/fe-code-reviewer.md
+++ b/frontend/.claude/agents/fe-code-reviewer.md
@@ -1,12 +1,23 @@
 ---
 name: fe-code-reviewer
-description: 프론트엔드 코드를 컴포넌트 계층, 스타일링, 훅 설계, 접근성 기준으로 독립적 시각에서 리뷰한다. ADR 준수 여부를 함께 검증하며, 수정 제안만 출력하고 프로덕션 코드는 직접 수정하지 않는다.
-model: claude-opus-4-7
+description: zzol FE 도메인 규칙(컴포넌트 계층·스타일 토큰·API 훅 컨벤션·WebSocket 컨트랙트·접근성·Storybook) 및 ADR 준수를 독립적 시각에서 감수한다. 범용 버그·중복·효율은 `/code-review` 스킬이 담당하므로 중복 지적하지 않는다. 수정 제안만 출력하고 프로덕션 코드는 직접 수정하지 않는다.
+model: claude-opus-4-8
 tools: Bash, Read, Glob, Grep
 ---
 
 당신은 **이 대화를 전혀 모르는** 시니어 프론트엔드 개발자다.
 이전 구현 맥락, 설계 의도, 논의 내용을 알지 못한다. 코드만 보고 판단한다.
+
+## 검토 범위 (중요)
+
+이 에이전트는 **zzol FE 도메인 규칙과 ADR 준수**에만 집중한다. `/code-review` 스킬이 이미 담당하는 영역은 **중복으로 지적하지 않는다**.
+
+| 도구 | 담당 영역 |
+| --- | --- |
+| `/code-review` (내장 스킬) | 범용 버그(정확성), 중복·단순화·효율, 일반 React/TS 정확성(메모이제이션 남용·`key` 인덱스·`useEffect` 의존성·`any`/`as` 등). effort 단계·`ultra`(클라우드 멀티에이전트)·`--comment`(PR 인라인)·`--fix`(자동수정) 지원 |
+| **이 에이전트** | 컴포넌트 계층, 스타일 토큰·Emotion 패턴, API 훅 컨벤션, WebSocket 컨트랙트(MCP 카탈로그 대조), 접근성, Storybook, ADR 충돌 — `/code-review`가 알 수 없는 **프로젝트 고유 규칙** |
+
+권장 순서: **버그·정리는 `/code-review`**, 그다음 **본 에이전트로 컨벤션·ADR 감수**. 둘의 출력이 겹치면 본 에이전트는 프로젝트 고유 규칙 위반만 남긴다.
 
 ## 작업 순서
 
@@ -57,13 +68,11 @@ tools: Bash, Read, Glob, Grep
 - [ ] 상수가 UPPER_SNAKE_CASE인가
 - [ ] Emotion styled 컴포넌트 Props 타입에 `$` 접두사가 붙은 transient prop을 사용하는가 (`$variant`, `$isLoading`)
 
-### React 설계 원칙
+### React 설계 (컨벤션)
 
-- [ ] 단일 책임 원칙을 지키는가 (하나의 컴포넌트가 너무 많은 역할을 하지 않는가)
-- [ ] 커스텀 훅으로 분리할 수 있는 로직이 컴포넌트 내부에 인라인으로 있지 않은가
-- [ ] `useCallback`, `useMemo`가 실제로 필요한 경우에만 사용되는가 (불필요한 메모이제이션 금지)
-- [ ] `key` prop에 배열 인덱스 대신 고유 식별자를 사용하는가
-- [ ] `useEffect` 의존성 배열이 올바른가 (누락 또는 불필요한 의존성)
+> 메모이제이션 남용·`key` 인덱스·`useEffect` 의존성 누락 등 **범용 정확성은 `/code-review` 담당**. 여기선 프로젝트 구조·컨벤션만 본다.
+
+- [ ] 단일 책임 — 컴포넌트가 과한 역할을 지지 않고, 분리 가능한 로직이 커스텀 훅으로 빠졌는가 (FE 슬라이스 구조)
 - [ ] 이벤트 핸들러 이름이 `handle` 접두사로 시작하는가 (`handleClick`, `handleSubmit`)
 
 ### 상태 관리
@@ -97,14 +106,6 @@ WebSocket 구독·발행 코드(`useWebSocketSubscription`, `send`)를 검토할
 - [ ] 하드코딩된 타이포그래피 대신 `theme.typography.*` 토큰을 사용하는가
 - [ ] 인라인 스타일(`style={{}}`)을 피하고 Emotion styled 컴포넌트를 사용하는가
 - [ ] 매직 넘버(근거 없는 px 값 등)가 없는가 — 디자인 토큰 또는 named constant 사용
-
-### TypeScript
-
-- [ ] `any` 타입 사용을 피하는가
-- [ ] Props 타입이 명시적으로 정의되어 있는가 (`type Props = { ... }`)
-- [ ] 옵셔널 Props에 기본값이 있는가
-- [ ] 타입 단언(`as`)을 과도하게 사용하지 않는가
-- [ ] 이벤트 핸들러 타입이 구체적인가 (`React.ChangeEvent<HTMLInputElement>` 등)
 
 ### 접근성 (a11y)
 
@@ -142,7 +143,7 @@ WebSocket 구독·발행 코드(`useWebSocketSubscription`, `send`)를 검토할
 **네이밍**
 - ✅/❌ 항목명: 설명
 
-**React 설계 원칙**
+**React 설계 (컨벤션)**
 - ✅/❌ 항목명: 설명
 
 **상태 관리**
@@ -156,9 +157,6 @@ WebSocket 구독·발행 코드(`useWebSocketSubscription`, `send`)를 검토할
 
 **스타일링**
 - ✅/❌ 항목명: 설명 (`.styled.ts` 없으면 생략)
-
-**TypeScript**
-- ✅/❌ 항목명: 설명
 
 **접근성**
 - ✅/❌ 항목명: 설명

--- a/frontend/.mcp.json
+++ b/frontend/.mcp.json
@@ -6,6 +6,13 @@
       "env": {
         "WS_MCP_CATALOG_URL": "http://localhost:8080/dev/ws-catalog"
       }
+    },
+    "api": {
+      "command": "node",
+      "args": ["../tools/api-mcp/scripts/launch.mjs"],
+      "env": {
+        "API_MCP_CATALOG_URL": "http://localhost:8080/dev/ws-catalog"
+      }
     }
   }
 }

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -75,7 +75,18 @@ BE 의 `GET /dev/ws-catalog` 에 모든 토픽/큐/send destination 의 path·pa
 
 | 에이전트 | 설명 |
 | --- | --- |
-| `fe-code-reviewer` | 컴포넌트 계층·스타일링·훅 설계·접근성 기준 독립 코드 리뷰. 항상 `run_in_background: true`로 실행 |
+| `fe-code-reviewer` | zzol FE 고유 규칙(컴포넌트 계층·스타일 토큰·API 훅·WebSocket 컨트랙트·a11y·Storybook·ADR) 감수. 범용 버그·중복·효율은 다루지 않음. 항상 `run_in_background: true`로 실행 |
+
+#### 코드 리뷰 = 두 도구 병행
+
+"코드 리뷰해줘" 같은 요청은 **두 도구를 함께** 돌린다. 역할이 다르므로 한쪽만으로는 부족하다.
+
+| 도구 | 담당 | 호출 |
+| --- | --- | --- |
+| `/code-review` (내장 스킬) | 범용 버그(정확성)·중복·단순화·효율, 일반 React/TS 정확성. effort·`ultra`(클라우드)·`--comment`·`--fix` 지원 | Skill 툴 |
+| `fe-code-reviewer` (에이전트) | zzol FE 고유 규칙·ADR 준수 (`/code-review`가 모르는 영역) | Agent 툴, `run_in_background: true` |
+
+실행 패턴: `fe-code-reviewer`를 백그라운드로 먼저 띄우고 `/code-review`를 돌린 뒤, 두 결과를 합쳐 보고한다. (자세한 분업은 `.claude/agents/fe-code-reviewer.md` "검토 범위" 참조)
 
 ## 커맨드
 

--- a/frontend/src/features/home/components/RankingTab/rankingIcons.tsx
+++ b/frontend/src/features/home/components/RankingTab/rankingIcons.tsx
@@ -58,6 +58,33 @@ export const GamepadIcon = () => (
   </svg>
 );
 
+export const StopwatchIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* 상단 버튼 */}
+    <rect x="8.5" y="1.5" width="3" height="2" rx="0.5" fill="#10B981" />
+    <rect x="9" y="3" width="2" height="1.5" fill="#10B981" />
+    {/* 본체 */}
+    <circle cx="10" cy="12" r="6.5" fill="#34D399" />
+    <circle cx="10" cy="12" r="4.8" fill="#ECFDF5" />
+    {/* 시침 */}
+    <path d="M10 12V8.6" stroke="#065F46" strokeWidth="1.3" strokeLinecap="round" />
+    <path d="M10 12l2.4 1.4" stroke="#065F46" strokeWidth="1.3" strokeLinecap="round" />
+    <circle cx="10" cy="12" r="0.9" fill="#065F46" />
+  </svg>
+);
+
+export const TouchIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {/* 터치 물결 */}
+    <path d="M4 5a5 5 0 0 1 8 0" stroke="#60A5FA" strokeWidth="1.3" strokeLinecap="round" />
+    {/* 손가락 */}
+    <path
+      d="M8 7.5a1.2 1.2 0 0 1 2.4 0v3.5l1.2.3a2 2 0 0 1 1.5 1.6l.4 2.3a2 2 0 0 1-2 2.4H10a3 3 0 0 1-2.5-1.3L5.2 13a1.3 1.3 0 0 1 1.8-1.8l1 .8V7.5z"
+      fill="#3B82F6"
+    />
+  </svg>
+);
+
 export const RacingCarIcon = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
     {/* 차체 */}

--- a/frontend/src/features/home/config/dashboardMock.ts
+++ b/frontend/src/features/home/config/dashboardMock.ts
@@ -4,6 +4,8 @@ import type {
   GamePlayCount,
   BlockStackingTopPlayer,
   RacingGameTopPlayer,
+  BlindTimerTopPlayer,
+  SpeedTouchTopPlayer,
 } from '@/types/dashBoard';
 
 export const MOCK_TOP_WINNERS: TopWinner[] = [
@@ -42,4 +44,20 @@ export const MOCK_RACING_GAME_TOP_PLAYERS: RacingGameTopPlayer[] = [
   { playerName: '광속', bestTime: 381 },
   { playerName: '빠름주의', bestTime: 412 },
   { playerName: '달려라', bestTime: 443 },
+];
+
+export const MOCK_BLIND_TIMER_TOP_PLAYERS: BlindTimerTopPlayer[] = [
+  { playerName: '체감시계', bestErrorMillis: 80 },
+  { playerName: '뇌피셜장인', bestErrorMillis: 150 },
+  { playerName: '느낌적인느낌', bestErrorMillis: 230 },
+  { playerName: '시간감각', bestErrorMillis: 360 },
+  { playerName: '대충맞춤', bestErrorMillis: 470 },
+];
+
+export const MOCK_SPEED_TOUCH_TOP_PLAYERS: SpeedTouchTopPlayer[] = [
+  { playerName: '터치왕', bestTime: 18230 },
+  { playerName: '손가락폭풍', bestTime: 19840 },
+  { playerName: '0.1초컷', bestTime: 21470 },
+  { playerName: '눈보다손', bestTime: 23910 },
+  { playerName: '연타고수', bestTime: 26350 },
 ];

--- a/frontend/src/features/home/config/rankingConfigs.ts
+++ b/frontend/src/features/home/config/rankingConfigs.ts
@@ -1,7 +1,22 @@
 import type { ComponentType } from 'react';
-import type { BlockStackingTopPlayer, RacingGameTopPlayer } from '@/types/dashBoard';
-import { BlocksIcon, RacingCarIcon } from '../components/RankingTab/rankingIcons';
-import { MOCK_BLOCK_STACKING_TOP_PLAYERS, MOCK_RACING_GAME_TOP_PLAYERS } from './dashboardMock';
+import type {
+  BlockStackingTopPlayer,
+  RacingGameTopPlayer,
+  BlindTimerTopPlayer,
+  SpeedTouchTopPlayer,
+} from '@/types/dashBoard';
+import {
+  BlocksIcon,
+  RacingCarIcon,
+  StopwatchIcon,
+  TouchIcon,
+} from '../components/RankingTab/rankingIcons';
+import {
+  MOCK_BLOCK_STACKING_TOP_PLAYERS,
+  MOCK_RACING_GAME_TOP_PLAYERS,
+  MOCK_BLIND_TIMER_TOP_PLAYERS,
+  MOCK_SPEED_TOUCH_TOP_PLAYERS,
+} from './dashboardMock';
 
 export type RankingItem = {
   rank: number;
@@ -18,6 +33,9 @@ export type RankingCategory = {
   transformData: (raw: unknown) => RankingItem[];
   mockRaw?: unknown;
 };
+
+/** 밀리초를 소수점 2자리 초로 변환한다 (예: 18230 → 18.23). */
+const millisToSeconds = (millis: number) => Math.round(millis / 10) / 100;
 
 export const RANKING_CATEGORIES: RankingCategory[] = [
   {
@@ -44,7 +62,35 @@ export const RANKING_CATEGORIES: RankingCategory[] = [
       (raw as RacingGameTopPlayer[]).map((p, i) => ({
         rank: i + 1,
         name: p.playerName,
-        count: Math.round(p.bestTime / 10) / 100,
+        count: millisToSeconds(p.bestTime),
+        unit: '초',
+      })),
+  },
+  {
+    key: 'blind-timer-top-players',
+    label: '뇌피셜 초시계 최소 오차',
+    icon: StopwatchIcon,
+    endpoint: '/dashboard/blind-timer-top-players',
+    mockRaw: MOCK_BLIND_TIMER_TOP_PLAYERS,
+    transformData: (raw) =>
+      (raw as BlindTimerTopPlayer[]).map((p, i) => ({
+        rank: i + 1,
+        name: p.playerName,
+        count: millisToSeconds(p.bestErrorMillis),
+        unit: '초',
+      })),
+  },
+  {
+    key: 'speed-touch-top-players',
+    label: '스피드터치 최단 기록',
+    icon: TouchIcon,
+    endpoint: '/dashboard/speed-touch-top-players',
+    mockRaw: MOCK_SPEED_TOUCH_TOP_PLAYERS,
+    transformData: (raw) =>
+      (raw as SpeedTouchTopPlayer[]).map((p, i) => ({
+        rank: i + 1,
+        name: p.playerName,
+        count: millisToSeconds(p.bestTime),
         unit: '초',
       })),
   },

--- a/frontend/src/types/dashBoard.ts
+++ b/frontend/src/types/dashBoard.ts
@@ -23,3 +23,13 @@ export type RacingGameTopPlayer = {
   playerName: string;
   bestTime: number;
 };
+
+export type BlindTimerTopPlayer = {
+  playerName: string;
+  bestErrorMillis: number;
+};
+
+export type SpeedTouchTopPlayer = {
+  playerName: string;
+  bestTime: number;
+};


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev)

# 🔥 연관 이슈

- 없음 (BE 대시보드 엔드포인트 추가에 따른 FE 연동)

# 🚀 작업 내용

1. 홈 **"전체 랭킹"** 아코디언에 두 카테고리 추가
   - **뇌피셜 초시계 최소 오차** — `GET /dashboard/blind-timer-top-players` (`bestErrorMillis`, 목표시간 오차 ms·작을수록 상위)
   - **스피드터치 최단 기록** — `GET /dashboard/speed-touch-top-players` (`bestTime`, 완주시간 ms·작을수록 상위)
   - 타입(`BlindTimerTopPlayer`/`SpeedTouchTopPlayer`)·mock·SVG 아이콘(`StopwatchIcon`/`TouchIcon`)·`RANKING_CATEGORIES` 등록
2. ms→초 변환을 `millisToSeconds` 헬퍼로 추출해 racing 포함 **3곳 중복 제거**
3. (chore) 코드 리뷰 분업 정리 — `fe-code-reviewer` 슬림화(범용 항목 제거, model 4.8) + CLAUDE.md "두 도구 병행" 규칙

# 💬 리뷰 중점사항

- 값 표기: 둘 다 `초` 단위(`Math.round(ms/10)/100`). BlindTimer는 "오차", SpeedTouch는 "완주시간"이라 라벨로 구분.
- BE가 타임아웃 기록을 쿼리에서 제외(`score < 1_000_000`)하므로 FE는 sentinel 방어 불필요함을 확인.
- 아이콘 SVG의 hex 리터럴은 기존 `rankingIcons.tsx` 전체와 동일 패턴이라 이번 변경 범위에서 제외(파일 전체 토큰화는 별도 이슈 권장).
