### PR TITLE
[refactor] 닉네임 검열 다중 모델 폴백 (429·404 대응)

### DIFF
--- a/backend/admin/src/test/resources/application-test.yml
+++ b/backend/admin/src/test/resources/application-test.yml
@@ -6,7 +6,8 @@ spring:
 
 nickname-audit:
   gemini-api-key: test-key
-  model: gemini-test
+  models:
+    - gemini-test
   flagged-threshold: 0.85
   batch-size: 10
   feedback-injection-threshold: 20

--- a/backend/app/src/main/resources/config/service.yml
+++ b/backend/app/src/main/resources/config/service.yml
@@ -33,7 +33,10 @@ report:
 
 nickname-audit:
   gemini-api-key: ${GEMINI_API_KEY}   # local/test 프로파일에서는 NoOpNicknameAuditor가 대신 동작
-  model: gemini-3.5-flash
+  models:                              # 우선순위 순 폴백: 한 모델이 429(요청 한도)면 다음 모델로 전환
+    - gemini-3-flash                   # 1순위
+    - gemini-3.5-flash                 # 2순위
+    - gemini-2.5-flash                 # 최후 폴백
   flagged-threshold: 0.85
   batch-size: 100                      # API 호출 1회당 처리량 (RPM 5 기준 100개씩 5회 = 500개/min)
   feedback-injection-threshold: 20

--- a/backend/game/src/test/resources/application-test.yml
+++ b/backend/game/src/test/resources/application-test.yml
@@ -26,7 +26,8 @@ roulette:
 # :profanity 빈(ProfanityChecker 구현체)이 컨텍스트에 포함되므로 필요하다
 nickname-audit:
   gemini-api-key: test-key
-  model: gemini-test
+  models:
+    - gemini-test
   flagged-threshold: 0.85
   batch-size: 10
   feedback-injection-threshold: 20

--- a/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/config/NicknameAuditProperties.java
@@ -3,7 +3,9 @@ package coffeeshout.profanity.config;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -11,7 +13,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "nickname-audit")
 public record NicknameAuditProperties(
         String geminiApiKey,
-        @NotBlank String model,
+        @NotEmpty List<@NotBlank String> models,    // 우선순위 순 폴백: 첫 모델 → 요청 한도(429) 시 다음 모델
         @DecimalMin("0.0") @DecimalMax("1.0") double flaggedThreshold,
         @Positive int batchSize,
         @Positive int feedbackInjectionThreshold

--- a/backend/profanity/src/main/java/coffeeshout/profanity/domain/audit/NicknameAuditErrorCode.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/domain/audit/NicknameAuditErrorCode.java
@@ -12,7 +12,8 @@ public enum NicknameAuditErrorCode implements ErrorCode {
     AI_EMPTY_RESPONSE("AUDIT_002", "닉네임 검열 AI가 빈 응답을 반환했습니다.", 500),
     AI_RESPONSE_PARSE_FAILED("AUDIT_003", "닉네임 검열 AI 응답 파싱에 실패했습니다.", 500),
     PROMPT_BUILD_FAILED("AUDIT_004", "닉네임 검열 프롬프트 생성에 실패했습니다.", 500),
-    AUDIT_NOT_FOUND("AUDIT_005", "검열 항목을 찾을 수 없습니다.", 404);
+    AUDIT_NOT_FOUND("AUDIT_005", "검열 항목을 찾을 수 없습니다.", 404),
+    AI_RATE_LIMIT_EXHAUSTED("AUDIT_006", "모든 Gemini 모델의 요청 한도를 초과했습니다.", 503);
 
     private final String code;
     private final String message;

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/GeminiNicknameAuditor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/GeminiNicknameAuditor.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
+import com.google.genai.errors.ApiException;
 import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
@@ -94,28 +95,76 @@ public class GeminiNicknameAuditor implements NicknameAuditor {
     @RateLimiter(name = "geminiAudit")
     public List<NicknameAuditResult> audit(List<String> nicknames) {
         final String userMessage = buildUserMessage(nicknames);
-
-        final GenerateContentResponse response;
-        try {
-            response = apiCallTimer.recordCallable(() ->
-                    geminiClient.models.generateContent(
-                            properties.model(),
-                            userMessage,
-                            GenerateContentConfig.builder()
-                                    .systemInstruction(SYSTEM_INSTRUCTION)
-                                    .responseMimeType("application/json")
-                                    .responseSchema(RESPONSE_SCHEMA)
-                                    .build()
-                    ));
-        } catch (Exception e) {
-            throw new InfrastructureException(NicknameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 실패", e);
-        }
+        final GenerateContentResponse response = callWithModelFallback(userMessage);
 
         if (response == null || response.text() == null) {
             throw new InfrastructureException(NicknameAuditErrorCode.AI_EMPTY_RESPONSE, "닉네임 검열 AI가 빈 응답을 반환했습니다.");
         }
 
         return parseResults(response.text(), nicknames);
+    }
+
+    /**
+     * 모델 목록을 우선순위 순으로 호출한다. 요청 한도(429)에 걸린 모델은 건너뛰고 다음 모델로 폴백한다.
+     * 무료 등급의 RPM/RPD 한도는 프로젝트·모델 단위로 부과되므로, 모델을 바꾸면 별도 한도 버킷을 사용한다.
+     * 한도 외의 오류(400 등 결정론적 실패)는 모델을 바꿔도 동일하게 실패하므로 즉시 중단한다.
+     */
+    private GenerateContentResponse callWithModelFallback(String userMessage) {
+        final List<String> models = properties.models();
+        for (int i = 0; i < models.size(); i++) {
+            final String model = models.get(i);
+            try {
+                return apiCallTimer.recordCallable(() ->
+                        geminiClient.models.generateContent(
+                                model,
+                                userMessage,
+                                GenerateContentConfig.builder()
+                                        .systemInstruction(SYSTEM_INSTRUCTION)
+                                        .responseMimeType("application/json")
+                                        .responseSchema(RESPONSE_SCHEMA)
+                                        .build()
+                        ));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new InfrastructureException(NicknameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 중 인터럽트", e);
+            } catch (Exception e) {
+                if (!shouldFallback(e)) {
+                    throw new InfrastructureException(NicknameAuditErrorCode.AI_CALL_FAILED, "닉네임 검열 AI 호출 실패", e);
+                }
+                if (i == models.size() - 1) {
+                    throw new InfrastructureException(NicknameAuditErrorCode.AI_RATE_LIMIT_EXHAUSTED, "모든 Gemini 모델 호출 실패(요청 한도 또는 모델 없음)", e);
+                }
+                log.warn("[NicknameAudit] 모델 {} 호출 불가(429/404), 폴백 → {}", model, models.get(i + 1));
+            }
+        }
+        throw new InfrastructureException(NicknameAuditErrorCode.AI_RATE_LIMIT_EXHAUSTED, "모든 Gemini 모델 호출 실패(요청 한도 또는 모델 없음)");
+    }
+
+    /**
+     * 다음 모델로 폴백해야 하는 오류인지 판별한다.
+     * <ul>
+     *   <li>429(RESOURCE_EXHAUSTED): 요청 한도 초과 — 다른 모델은 별도 한도 버킷을 가진다</li>
+     *   <li>404(NOT_FOUND): 모델이 없거나 미제공 — 모델 단위 문제이므로 다음 모델을 시도한다</li>
+     * </ul>
+     * 그 외(400 등 전역·결정론적 오류, 5xx)는 모델을 바꿔도 동일하게 실패하므로 폴백하지 않는다.
+     * 우선 SDK의 {@link ApiException#code()}로 식별하고, 래핑 등으로 타입을 잃은 경우 메시지로 보조 판별한다.
+     */
+    boolean shouldFallback(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof ApiException apiException && (apiException.code() == 429 || apiException.code() == 404)) {
+                return true;
+            }
+            final String message = t.getMessage();
+            if (message != null && (
+                    message.contains("RESOURCE_EXHAUSTED")
+                            || message.contains("Too Many Requests")
+                            || message.contains("rateLimitExceeded")
+                            || message.contains("Quota exceeded")
+                            || message.contains("NOT_FOUND"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String buildUserMessage(List<String> nicknames) {

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -31,7 +31,7 @@ class ProfanityAuditServiceTest {
         profanityWordManagementService = mock(ProfanityWordManagementService.class);
 
         final NicknameAuditProperties properties = new NicknameAuditProperties(
-                "api-key", "gemini-2.0-flash", 0.8, 10, 5
+                "api-key", List.of("gemini-2.0-flash"), 0.8, 10, 5
         );
         service = new ProfanityAuditService(auditRepository, batchProcessor, profanityWordManagementService, properties, new SimpleMeterRegistry());
         service.initMetrics();

--- a/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditPropertiesBindingTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/config/NicknameAuditPropertiesBindingTest.java
@@ -1,0 +1,44 @@
+package coffeeshout.profanity.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class NicknameAuditPropertiesBindingTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(PropertiesConfig.class);
+
+    @Test
+    void models_리스트가_순서대로_바인딩된다() {
+        runner.withPropertyValues(
+                        "nickname-audit.gemini-api-key=k",
+                        "nickname-audit.models[0]=gemini-3-flash",
+                        "nickname-audit.models[1]=gemini-3.5-flash",
+                        "nickname-audit.models[2]=gemini-2.5-flash",
+                        "nickname-audit.flagged-threshold=0.85",
+                        "nickname-audit.batch-size=100",
+                        "nickname-audit.feedback-injection-threshold=20")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(NicknameAuditProperties.class).models())
+                            .containsExactly("gemini-3-flash", "gemini-3.5-flash", "gemini-2.5-flash");
+                });
+    }
+
+    @Test
+    void models가_비어있으면_NotEmpty_검증으로_기동이_실패한다() {
+        runner.withPropertyValues(
+                        "nickname-audit.gemini-api-key=k",
+                        "nickname-audit.flagged-threshold=0.85",
+                        "nickname-audit.batch-size=100",
+                        "nickname-audit.feedback-injection-threshold=20")
+                .run(context -> assertThat(context).hasFailed());
+    }
+
+    @EnableConfigurationProperties(NicknameAuditProperties.class)
+    static class PropertiesConfig {
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorConnectivityTest.java
@@ -19,13 +19,13 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
 
-@Disabled("gemini-3.5-flash 모델 연결 확인용 수동 테스트 — 확인 후 삭제")
+@Disabled("폴백 모델 목록(gemini-3-flash, gemini-3.5-flash, gemini-2.5-flash) 연결·200 응답 확인용 수동 테스트 — 실제 GEMINI_API_KEY 필요")
 class GeminiNicknameAuditorConnectivityTest {
 
     private static final String API_KEY = System.getenv("GEMINI_API_KEY");
     private static final NicknameAuditProperties PROPERTIES = new NicknameAuditProperties(
             API_KEY,
-            "gemini-3.5-flash",
+            List.of("gemini-3-flash", "gemini-3.5-flash", "gemini-2.5-flash"),
             0.85,
             100,
             20

--- a/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/infra/GeminiNicknameAuditorTest.java
@@ -1,0 +1,159 @@
+package coffeeshout.profanity.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import coffeeshout.global.exception.custom.InfrastructureException;
+import coffeeshout.profanity.application.port.NicknameFeedbackRepository;
+import coffeeshout.profanity.config.NicknameAuditProperties;
+import coffeeshout.profanity.domain.audit.NicknameAuditErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.Models;
+import com.google.genai.errors.ApiException;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GeminiNicknameAuditorTest {
+
+    private static final List<String> MODELS = List.of("model-1", "model-2", "model-3");
+
+    private Models models;
+    private GeminiNicknameAuditor auditor;
+
+    @BeforeEach
+    void setUp() {
+        final Client client = mock(Client.class);
+        models = mock(Models.class);
+        ReflectionTestUtils.setField(client, "models", models);
+
+        final NicknameFeedbackRepository feedbackRepository = mock(NicknameFeedbackRepository.class);
+        final NicknameAuditPromptTemplate promptTemplate = mock(NicknameAuditPromptTemplate.class);
+        given(feedbackRepository.findRecentFeedbacks(any())).willReturn(List.of());
+        given(promptTemplate.buildUserMessage(any(), any())).willReturn("PROMPT");
+
+        final NicknameAuditProperties properties =
+                new NicknameAuditProperties("api-key", MODELS, 0.85, 100, 20);
+
+        auditor = new GeminiNicknameAuditor(
+                client, new ObjectMapper(), properties,
+                feedbackRepository, promptTemplate, new SimpleMeterRegistry());
+    }
+
+    private static ApiException rateLimit() {
+        return new ApiException(429, "RESOURCE_EXHAUSTED", "Quota exceeded");
+    }
+
+    @Nested
+    class 모델_폴백 {
+
+        @Test
+        void 첫_모델이_429면_다음_모델로_폴백한다() throws Exception {
+            final GenerateContentResponse ok = mock(GenerateContentResponse.class);
+            given(ok.text()).willReturn("[]");
+            given(models.generateContent(eq("model-1"), anyString(), any(GenerateContentConfig.class)))
+                    .willThrow(rateLimit());
+            given(models.generateContent(eq("model-2"), anyString(), any(GenerateContentConfig.class)))
+                    .willReturn(ok);
+
+            auditor.audit(List.of("닉네임"));
+
+            verify(models).generateContent(eq("model-1"), anyString(), any(GenerateContentConfig.class));
+            verify(models).generateContent(eq("model-2"), anyString(), any(GenerateContentConfig.class));
+            verify(models, never()).generateContent(eq("model-3"), anyString(), any(GenerateContentConfig.class));
+        }
+
+        @Test
+        void 첫_모델이_404면_다음_모델로_폴백한다() throws Exception {
+            final GenerateContentResponse ok = mock(GenerateContentResponse.class);
+            given(ok.text()).willReturn("[]");
+            given(models.generateContent(eq("model-1"), anyString(), any(GenerateContentConfig.class)))
+                    .willThrow(new ApiException(404, "NOT_FOUND", "model not found"));
+            given(models.generateContent(eq("model-2"), anyString(), any(GenerateContentConfig.class)))
+                    .willReturn(ok);
+
+            auditor.audit(List.of("닉네임"));
+
+            verify(models).generateContent(eq("model-1"), anyString(), any(GenerateContentConfig.class));
+            verify(models).generateContent(eq("model-2"), anyString(), any(GenerateContentConfig.class));
+        }
+
+        @Test
+        void 한도_초과가_아닌_오류는_폴백하지_않고_즉시_실패한다() throws Exception {
+            given(models.generateContent(eq("model-1"), anyString(), any(GenerateContentConfig.class)))
+                    .willThrow(new ApiException(400, "INVALID_ARGUMENT", "bad request"));
+
+            assertThatThrownBy(() -> auditor.audit(List.of("닉네임")))
+                    .isInstanceOf(InfrastructureException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", NicknameAuditErrorCode.AI_CALL_FAILED);
+
+            verify(models, never()).generateContent(eq("model-2"), anyString(), any(GenerateContentConfig.class));
+        }
+
+        @Test
+        void 모든_모델이_429면_한도_소진_예외를_던진다() throws Exception {
+            given(models.generateContent(anyString(), anyString(), any(GenerateContentConfig.class)))
+                    .willThrow(rateLimit());
+
+            assertThatThrownBy(() -> auditor.audit(List.of("닉네임")))
+                    .isInstanceOf(InfrastructureException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", NicknameAuditErrorCode.AI_RATE_LIMIT_EXHAUSTED);
+
+            verify(models, times(3)).generateContent(anyString(), anyString(), any(GenerateContentConfig.class));
+        }
+    }
+
+    @Nested
+    class 폴백_대상_판별 {
+
+        @Test
+        void ApiException_코드가_429면_폴백_대상이다() {
+            assertThat(auditor.shouldFallback(rateLimit())).isTrue();
+        }
+
+        @Test
+        void ApiException_코드가_404면_폴백_대상이다() {
+            assertThat(auditor.shouldFallback(new ApiException(404, "NOT_FOUND", "model not found"))).isTrue();
+        }
+
+        @Test
+        void 그_외_상태코드의_ApiException은_폴백하지_않는다() {
+            assertThat(auditor.shouldFallback(new ApiException(400, "INVALID_ARGUMENT", "bad"))).isFalse();
+        }
+
+        @Test
+        void 원인_체인에_숨은_429도_판별한다() {
+            final Throwable wrapped = new RuntimeException("wrap", rateLimit());
+            assertThat(auditor.shouldFallback(wrapped)).isTrue();
+        }
+
+        @Test
+        void RESOURCE_EXHAUSTED_메시지면_타입이_달라도_판별한다() {
+            assertThat(auditor.shouldFallback(new RuntimeException("RESOURCE_EXHAUSTED: quota"))).isTrue();
+        }
+
+        @Test
+        void NOT_FOUND_메시지면_타입이_달라도_판별한다() {
+            assertThat(auditor.shouldFallback(new RuntimeException("models/gemini-x is NOT_FOUND"))).isTrue();
+        }
+
+        @Test
+        void 무관한_예외는_폴백하지_않는다() {
+            assertThat(auditor.shouldFallback(new RuntimeException("connection reset"))).isFalse();
+        }
+    }
+}

--- a/backend/profanity/src/test/resources/application-test.yml
+++ b/backend/profanity/src/test/resources/application-test.yml
@@ -4,7 +4,8 @@ spring:
 
 nickname-audit:
   gemini-api-key: test-key
-  model: gemini-test
+  models:
+    - gemini-test
   flagged-threshold: 0.85
   batch-size: 10
   feedback-injection-threshold: 20

--- a/backend/room/src/test/resources/application-test.yml
+++ b/backend/room/src/test/resources/application-test.yml
@@ -22,7 +22,8 @@ roulette:
 
 nickname-audit:
   gemini-api-key: test-key
-  model: gemini-test
+  models:
+    - gemini-test
   flagged-threshold: 0.85
   batch-size: 10
   feedback-injection-threshold: 20


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- close #1465

# 🚀 작업 내용

Gemini 닉네임 검열(`profanity` 모듈)에 **다중 모델 폴백**을 추가했습니다. 무료 등급의 요청 한도(RPM/RPD)는 `PerProjectPerModel`로 부과되므로, 한 모델이 한도에 걸리면 한도 버킷이 다른 다음 모델로 폴백합니다.

1. `NicknameAuditProperties`: `model`(String) → `models`(`@NotEmpty List<@NotBlank String>`, 우선순위 순)
2. `GeminiNicknameAuditor.callWithModelFallback`: 모델 순회, 폴백 대상 오류면 다음 모델로 전환
3. `shouldFallback`: **429(요청 한도)·404(모델 없음/미제공)**면 폴백, 그 외(400 등 결정론적 오류·5xx)는 즉시 실패. SDK `ApiException.code()` 우선 판별 + 래핑 대비 메시지 보조
4. `NicknameAuditErrorCode.AI_RATE_LIMIT_EXHAUSTED`(503) 추가
5. `service.yml` 모델 목록: `gemini-3-flash` → `gemini-3.5-flash` → `gemini-2.5-flash`
6. 폴백 호출에서도 `responseSchema`·`systemInstruction` 유지
7. 테스트: 폴백 오케스트레이션/판별(`GeminiNicknameAuditorTest`), yaml List 바인딩+`@NotEmpty`(`NicknameAuditPropertiesBindingTest`)

> 기존 #1191 / PR #1192(옛 `room` 모듈 구조)를 현재 `profanity` 멀티모듈로 재구현했습니다.

# 💬 리뷰 중점사항

- `shouldFallback`의 429/404 판별 정확성(과탐·미탐), 폴백 루프 제어흐름(원인 예외 전파)
- 단일 `@RateLimiter(geminiAudit)`가 폴백(한 번에 한 모델)과 양립하는지
- **남은 작업(머지 전 권장):** 1순위 `gemini-3-flash`가 실제 200을 주는지 라이브 검증 필요. 404 폴백이 있어 오타여도 전체 장애는 안 나지만, 1순위가 조용히 우회되지 않도록 확인 필요(`GeminiNicknameAuditorConnectivityTest` `@Disabled` 해제 + 실 키).
