### PR TITLE
[fix] 닉네임 재등록 시 중복 키 충돌로 인한 검열 스케줄러 전체 실패 수정 (#1467)

### DIFF
--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -58,8 +58,11 @@ public class ProfanityAuditService {
             log.debug("운영자 허용 닉네임 — 검열 등록 생략: {}", nickname);
             return;
         }
-        if (auditRepository.existsByNicknameAndStatus(nickname, NicknameAuditStatus.UNAUDITED)) {
-            log.debug("이미 UNAUDITED 상태로 등록된 닉네임: {}", nickname);
+        if (auditRepository.existsByNickname(nickname)) {
+            // 상태 무관으로 검사한다. 유니크 제약이 (player_name, status)라 이미 검열된(CLEAN 등)
+            // 닉네임에 대해 UNAUDITED만 검사하면 새 UNAUDITED 중복이 생기고, 다음 검열 시
+            // 기존 상태로 승격되며 유니크 충돌이 발생한다 (issue #1467).
+            log.debug("이미 등록된 닉네임 — 검열 등록 생략: {}", nickname);
             return;
         }
         auditRepository.save(new NicknameAudit(nickname));

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
@@ -26,5 +26,7 @@ public interface NicknameAuditRepository {
 
     Set<String> findNicknamesByStatus(NicknameAuditStatus status);
 
+    boolean existsByNickname(String nickname);
+
     boolean existsByNicknameAndStatus(String nickname, NicknameAuditStatus status);
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -42,7 +42,7 @@ class ProfanityAuditServiceTest {
 
         @Test
         void 새로운_닉네임은_UNAUDITED_상태로_저장된다() {
-            given(auditRepository.existsByNicknameAndStatus("새닉네임", NicknameAuditStatus.UNAUDITED))
+            given(auditRepository.existsByNickname("새닉네임"))
                     .willReturn(false);
 
             service.register("새닉네임");
@@ -51,19 +51,20 @@ class ProfanityAuditServiceTest {
         }
 
         @Test
-        void 이미_UNAUDITED_상태인_닉네임은_중복_저장되지_않는다() {
-            given(auditRepository.existsByNicknameAndStatus("이미등록된닉네임", NicknameAuditStatus.UNAUDITED))
+        void 이미_등록된_닉네임은_재등록해도_중복_저장되지_않는다() {
+            // issue #1467 재현: 이미 검열된(CLEAN 등) 닉네임이 재등장하면, 상태 무관 검사가 없으면
+            // 새 UNAUDITED 중복이 생기고 다음 검열 시 (player_name, status) 유니크 충돌이 발생한다.
+            // 상태와 무관하게 이미 존재하면 저장하지 않아야 한다.
+            given(auditRepository.existsByNickname("이미검열된닉네임"))
                     .willReturn(true);
 
-            service.register("이미등록된닉네임");
+            service.register("이미검열된닉네임");
 
             then(auditRepository).should(never()).save(any());
         }
 
         @Test
         void 운영자_허용_닉네임은_검열_등록이_생략된다() {
-            given(auditRepository.existsByNicknameAndStatus("허용닉네임", NicknameAuditStatus.UNAUDITED))
-                    .willReturn(false);
             given(profanityWordManagementService.isOperatorAllowed("허용닉네임"))
                     .willReturn(true);
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- close #1467

# 🚀 작업 내용

1. `NicknameAuditRepository`에 `existsByNickname(String)` 추가 (Spring Data 메서드명 파생 쿼리)
2. `ProfanityAuditService.register()`의 중복 방지를 **상태 무관**으로 변경
   - 기존: `existsByNicknameAndStatus(nickname, UNAUDITED)` — UNAUDITED 상태만 검사
   - 변경: `existsByNickname(nickname)` — 이미 등록된 닉네임은 상태와 무관하게 재등록하지 않음
3. 재현 테스트 추가: 이미 등록(검열)된 닉네임 재등록 시 `save`가 호출되지 않음 검증

# 🐞 원인

유니크 제약이 `(player_name, status)`라 같은 닉네임이 여러 상태로 공존 가능하다.

1. 닉네임 최초 제출 → `(name, UNAUDITED)` 저장
2. 스케줄러 검열 → `(name, CLEAN)` 승격
3. 같은 닉네임 재등장 → `existsByNicknameAndStatus(name, UNAUDITED)` == false → **새 `(name, UNAUDITED)` 중복 생성**
4. 다음 스케줄러가 이 UNAUDITED를 CLEAN으로 승격 → 기존 `(name, CLEAN)`과 유니크 충돌 → `Duplicate entry '...-CLEAN'`

`ProfanityAuditBatchProcessor.process()`가 배치를 한 트랜잭션으로 `saveAll`하고 배치 조회가 `createdAt ASC`라, 막힌 행이 매번 첫 배치에 들어와 **배치 전체가 영구 롤백**되고 UNAUDITED 적체가 누적된다.

# 💬 리뷰 중점사항

- `register()`의 dedup을 상태 무관으로 바꾼 의미 변경이 의도대로인지 (이미 검열된 닉네임은 재검열하지 않음)
- 후속 작업(이 PR 범위 밖, 이슈에 기록):
  - **운영**: prod 포이즌 UNAUDITED 행(`귝`=150, `오신혁`=163) 1회성 정리 — 코드 배포만으론 기존 stuck 행이 자가 복구되지 않음
  - **구조**: 유니크 제약을 `(player_name)` 단독으로 변경하면 UNAUDITED→CLEAN이 in-place 갱신이 되어 충돌이 구조적으로 불가능 + 동시 `register()` 경합(AFTER_COMMIT 리스너 + 랭킹 수집기)도 차단. 단 기존 중복 dedup + 스키마 마이그레이션 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 닉네임 중복 등록 검사 로직을 개선했습니다. 이제 모든 상태의 등록된 닉네임에 대한 중복을 방지하도록 변경되었습니다.

* **Tests**
  * 닉네임 중복 검사 관련 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->