### PR TITLE
[docs] create-pr 본문 작성 원칙 추가 — 쉬운 용어·간결

### DIFF
--- a/backend/.claude/skills/create-pr/SKILL.md
+++ b/backend/.claude/skills/create-pr/SKILL.md
@@ -25,6 +25,14 @@ allowed-tools: Read, Bash, Glob
 - 라벨: 항상 `BE` + type별 1개 — feat `✨feat` / fix `🐞bug` / refactor `🛠️refactor` / chore `⚙️chore` / docs `📝docs` / test `🧪 test`. 우선순위(`p-*`)는 `$ARGUMENTS`에 있을 때만 추가
 - Assignee: `gh api user --jq '.login'` 결과로 자동 지정
 
+## 작성 원칙 (본문 공통)
+
+리뷰어가 빠르게 이해하는 것을 최우선으로, 쉬운 용어와 간결한 문장으로 작성한다.
+
+- **쉬운 용어**: 전문 용어·영어 약어(point of use, redundant, hermetic, drift 등)를 피하고 풀어서 쓴다. 꼭 필요한 기술 용어는 한 줄 풀이를 붙인다.
+- **간결함**: 한 항목은 1~2문장. "무엇을 왜 바꿨는지"를 먼저 적는다.
+- **결정·트레이드오프는 이유와 함께**: 리뷰어가 되묻지 않아도 알 수 있게 적는다.
+
 ## 템플릿 작성
 
 `.github/pull_request_template.md` 섹션을 유지하고 채운다.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (base: **be/dev**)

# 🔥 연관 이슈

- close #1490

# 🚀 작업 내용

`create-pr` 스킬에 PR 본문 작성 원칙이 없어, 작성자마다 본문의 용어 난이도·길이가 달랐습니다. 리뷰어가 쉽게 이해하도록 원칙을 명문화했습니다.

1. `backend/.claude/skills/create-pr/SKILL.md`에 "작성 원칙(본문 공통)" 섹션을 추가했습니다.
   - 쉬운 용어로 쓰기 (전문 용어·영어 약어 풀어쓰기)
   - 간결하게 쓰기 (한 항목 1~2문장)
   - 결정·트레이드오프는 이유와 함께 적기

# 💬 리뷰 중점사항

- FE `create-pr` 커맨드에도 같은 원칙을 반영한 PR(#1489, → fe/dev)과 한 쌍입니다. 두 PR의 문구는 동일하게 맞췄습니다.
- markdownlint 통과 확인했습니다 (0 error).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Pull Request 작성 가이드에 새로운 작성 원칙 섹션을 추가했습니다. 리뷰어의 이해를 우선하는 명확한 커뮤니케이션 방식(간단한 용어, 간결한 문장, 의사결정 근거 포함)을 제시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->