### PR TITLE
[docs] zzolbot dev 웹훅 8890 수동 e2e 검증 절차 추가

### DIFF
--- a/backend/docs/adr/0032-zzolbot-as-alertmanager-receiver.md
+++ b/backend/docs/adr/0032-zzolbot-as-alertmanager-receiver.md
@@ -141,6 +141,25 @@ echo "$TOKEN"
 - **도달성**: `docker exec alertmanager wget -qO- http://nginx:8889/internal/zzolbot/alerts/webhook` → 토큰 없이는 **401**(차단 확인). Alertmanager가 실제 보낼 때만 200.
 - **엔드투엔드**: dev 웹훅 검증은 **nginx:8890**(`dev-service.inc` → dev 활성 색)으로 보낸다 — `docker exec`로 8890에 테스트 페이로드를 쏴 dev-app 보강 → Slack 도착을 확인한다. **8889(prod)로 dev 테스트를 보내지 않는다**(dev 테스트가 prod-app 404를 누적시켜 내부 IP를 차단한 사고: [postmortem 0003](../postmortem/0003-internal-ip-block-dev-webhook.md)). 실제 Alertmanager firing e2e는 prod 경로(8889)로 확인한다.
 
+#### dev 수동 e2e 검증 절차
+
+dev-app 컨테이너 안에서 nginx:8890으로 POST한다. 인증·라우팅이 통과하면 컨트롤러가 즉시 `200`(빈 본문)으로 ack하고, `alerts[]`가 비어 있지 않으면 가상 스레드로 보강(LLM·Loki·Slack)이 돈다.
+
+```bash
+docker exec dev-app-blue sh -c 'wget -S -qO- \
+  --header="Authorization: Bearer $ZZOL_BOT_ALERT_WEBHOOK_TOKEN" \
+  --header="Content-Type: application/json" \
+  --post-data="{\"status\":\"firing\",\"alerts\":[{\"status\":\"firing\",\"fingerprint\":\"test-001\",\"labels\":{\"alertname\":\"WebhookSmokeTest\",\"severity\":\"warning\"},\"annotations\":{\"summary\":\"manual-e2e-test\"}}]}" \
+  http://nginx:8890/internal/zzolbot/alerts/webhook 2>&1 | grep "HTTP/"'
+```
+
+성공이면 `HTTP/1.1 200`. 이어서 `docker logs --tail 80 dev-app-blue | grep -iE "zzolbot|enrich"`로 보강 처리를 확인한다(dev `ZZOL_BOT_SLACK_WEBHOOK_URL`이 설정돼 있으면 공통 Slack 채널로 발화).
+
+흔한 함정 둘(실제 검증 중 겪음):
+
+- **토큰은 컨테이너 내부 env로 확장한다.** `sh -c '... Bearer $ZZOL_BOT_ALERT_WEBHOOK_TOKEN ...'`처럼 **작은따옴표**로 감싸 dev-app 안에서 풀리게 한다. 호스트 셸의 `$TOKEN`을 쓰면(대개 미설정) 빈 토큰이 들어가 **401**. 인증 토큰은 dev-app env `ZZOL_BOT_ALERT_WEBHOOK_TOKEN`만 관여하며, alertmanager의 `secrets/zzolbot_webhook_token` 파일은 이 수동 테스트와 무관하다(alertmanager가 직접 보낼 때만 사용).
+- **`--post-data` JSON은 한 줄로.** 문자열 값 안에 줄바꿈이 끼면(터미널 줄바꿈 포함) Jackson이 raw 제어문자를 거부해 **400**. 한 줄로 붙여넣고 한글 등으로 줄이 접히지 않게 한다.
+
 ### 4. 롤백
 
 앱·트래픽 영향 최소: alertmanager `zzolbot-enrich` 제거 + `docker kill -s HUP alertmanager`, nginx `internal.conf` 제거 + 재생성(또는 `network disconnect`), loki ruler 블록 주석 + 재시작. Java(폴링 제거 포함)는 커밋 revert.

--- a/backend/docs/postmortem/0003-internal-ip-block-dev-webhook.md
+++ b/backend/docs/postmortem/0003-internal-ip-block-dev-webhook.md
@@ -39,7 +39,7 @@ dev 환경의 zzol-bot 웹훅 수신기를 수동 테스트하려 했으나, ngi
 
 - 탐지: dev 웹훅 수동 테스트 중 내부 트래픽 403 발생으로 인지.
 - 완화: `prod-redis`에서 `block:ip:*`·`block:404:*` 키(`block:*`)를 SCAN 기반으로 삭제. 어드민 해제 API도 시도했으나 호출 출처(`api.zzol.site`)가 CORS 허용 목록에 없어 거절됨.
-- 근본 수정: 미진행 — 아래 재발 방지 액션으로 단일 PR에서 처리 예정.
+- 근본 수정: 이슈 #1493 / PR #1494로 처리(nginx 8890 dev 리스너 분리 + 내부 IP 화이트리스트 복구 + 어드민 CORS). dev 웹훅 경로는 8890 e2e로 검증 완료 — 절차·함정은 [ADR-0032](../adr/0032-zzolbot-as-alertmanager-receiver.md)의 "배포 후 검증 › dev 수동 e2e 검증 절차" 참조.
 
 ## 재발 방지 액션
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (fe/dev, be/dev)

# 🔥 연관 이슈

- #1493 (문서 후속 보강 — 본 이슈 close는 #1494에서 처리됨)

# 🚀 작업 내용

PR #1494(머지 완료)로 추가한 nginx 8890 dev 리스너의 **수동 e2e 검증 절차**를 문서화한다. 실제 dev 서버에서 검증(200 ack + 로그 보강 확인)하며 겪은 내용 기반.

1. **ADR-0032 "배포 후 검증"** — dev-app 컨테이너 안에서 `nginx:8890`으로 POST하는 `docker exec` 절차 + 함정 둘:
   - 토큰은 **컨테이너 내부 env로 확장**(`sh -c '... Bearer $ZZOL_BOT_ALERT_WEBHOOK_TOKEN ...'`). 호스트 셸 `$TOKEN`(대개 미설정)을 쓰면 빈 토큰 → **401**.
   - `--post-data` JSON은 **한 줄**로. 문자열 값 안 줄바꿈 → Jackson이 raw 제어문자 거부 → **400**.
2. **postmortem 0003 대응** — 근본 수정(#1494)과 위 검증 절차로의 교차참조 한 줄.

# 💬 리뷰 중점사항

- 문서 전용(코드 무변경).
- 검증 *방법*은 운영 레퍼런스(ADR-0032)에, 사고 *복기*는 postmortem에 두는 장르 분리 유지 — postmortem엔 절차 전문 대신 교차참조 한 줄만.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * dev 웹훅 수동 검증 절차 및 테스트 방법에 대한 상세 가이드 추가
  * 내부 IP 필터링 관련 수정 완료 및 검증 확인 기록 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->