### PR TITLE
[Feat] 내기 게임 SEO 정적 랜딩 페이지(bet-games.html) 추가

### DIFF
--- a/frontend/public/bet-games.html
+++ b/frontend/public/bet-games.html
@@ -1,0 +1,454 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+    <title>내기 게임 사이트 쫄(ZZOL) | 커피 내기·점심 내기 미니게임</title>
+    <meta
+      name="description"
+      content="설치 없이 바로 즐기는 모바일 내기 게임 사이트 쫄(ZZOL). 커피 내기, 점심 메뉴, 당번 정하기를 사다리·블록쌓기·카드 등 미니게임으로 결정하세요. QR코드로 친구를 초대하고 룰렛으로 당첨자를 정합니다."
+    />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.zzol.site/bet-games.html" />
+    <meta property="og:title" content="내기 게임 사이트 쫄(ZZOL) | 커피 내기·점심 내기 미니게임" />
+    <meta
+      property="og:description"
+      content="설치 없이 바로 즐기는 모바일 내기 게임 사이트. 커피 내기·점심 내기·당번 정하기를 미니게임으로 결정하세요."
+    />
+    <meta property="og:image" content="https://www.zzol.site/logo/og_image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="쫄 (ZZOL)" />
+    <meta property="og:locale" content="ko_KR" />
+
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta name="theme-color" content="#F53E41" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="내기 게임 사이트 쫄(ZZOL) | 커피 내기·점심 내기 미니게임" />
+    <meta
+      name="twitter:description"
+      content="설치 없이 바로 즐기는 모바일 내기 게임 사이트. 커피 내기·점심 내기를 미니게임으로 결정하세요."
+    />
+    <meta name="twitter:image" content="https://www.zzol.site/logo/og_image.png" />
+
+    <link rel="canonical" href="https://www.zzol.site/bet-games.html" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "쫄 (ZZOL) — 내기 게임 사이트",
+        "url": "https://www.zzol.site/bet-games.html",
+        "description": "커피 내기, 점심 내기, 당번 정하기를 미니게임으로 결정하는 모바일 내기 게임 사이트. QR코드로 방에 입장하고 미니게임 결과로 룰렛 당첨 확률을 정합니다.",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Web",
+        "inLanguage": "ko",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "KRW" },
+        "featureList": [
+          "커피 내기·점심 내기·당번 정하기를 미니게임으로 결정",
+          "QR코드로 친구 초대 후 즉시 시작",
+          "사다리·블록쌓기·카드 등 6종 미니게임",
+          "미니게임 결과로 룰렛 당첨 확률 조정",
+          "설치 없이 모바일 브라우저에서 바로 플레이"
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "쫄 홈", "item": "https://www.zzol.site/" },
+          { "@type": "ListItem", "position": 2, "name": "내기 게임" }
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "쫄(ZZOL) 내기 게임은 무료인가요?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "네, 쫄은 무료입니다. 앱 설치 없이 모바일 브라우저에서 바로 플레이할 수 있습니다."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "커피 내기는 어떻게 하나요?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "방을 만들고 QR코드나 초대코드로 친구를 모은 뒤, 사다리·블록쌓기 같은 미니게임을 즐기면 결과에 따라 룰렛 당첨 확률이 정해집니다. 마지막 룰렛으로 커피값을 낼 사람을 뽑습니다."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "어떤 미니게임이 있나요?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "카드게임, 레이싱게임, 1 to 25(스피드터치), 뇌피셜 초시계, 블록 쌓기, 사다리 게임 6종을 제공합니다."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <style>
+      @font-face {
+        font-family: 'Pretendard Variable';
+        src: url('/fonts/PretendardVariable.woff2') format('woff2-variations');
+        font-weight: 100 900;
+        font-style: normal;
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'PartialSansKR-Regular';
+        src: url('/fonts/PartialSansKR-Regular.woff2') format('woff2');
+        font-weight: normal;
+        font-style: normal;
+        font-display: swap;
+      }
+
+      :root {
+        --red: #f53e41;
+        --red-soft: #fd6c6e;
+        --ink: #364153;
+        --ink-soft: #5a6473;
+        --bg: #fff7f7;
+        --card: #ffffff;
+        --line: #ffe0e0;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+      html {
+        -webkit-text-size-adjust: 100%;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui,
+          'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
+        line-height: 1.7;
+        -webkit-font-smoothing: antialiased;
+      }
+      a {
+        color: inherit;
+      }
+      .wrap {
+        max-width: 760px;
+        margin: 0 auto;
+        padding: 0 20px;
+      }
+
+      header.site {
+        padding: 18px 0;
+        border-bottom: 1px solid var(--line);
+      }
+      header.site .wrap {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      header.site img {
+        height: 26px;
+        width: auto;
+      }
+      header.site a {
+        text-decoration: none;
+        font-weight: 700;
+        color: var(--red);
+      }
+
+      .hero {
+        text-align: center;
+        padding: 56px 0 40px;
+      }
+      .hero h1 {
+        font-size: clamp(1.7rem, 6vw, 2.5rem);
+        line-height: 1.3;
+        margin: 0 0 16px;
+        color: var(--ink);
+        word-break: keep-all;
+      }
+      .hero h1 b {
+        color: var(--red);
+      }
+      .hero p.lead {
+        font-size: 1.05rem;
+        color: var(--ink-soft);
+        margin: 0 auto 28px;
+        max-width: 560px;
+        word-break: keep-all;
+      }
+
+      .cta {
+        display: inline-block;
+        background: var(--red);
+        color: #fff;
+        text-decoration: none;
+        font-weight: 700;
+        font-size: 1.05rem;
+        padding: 15px 34px;
+        border-radius: 999px;
+        box-shadow: 0 8px 20px rgba(245, 62, 65, 0.28);
+        transition: transform 0.15s ease;
+      }
+      .cta:hover {
+        transform: translateY(-2px);
+      }
+      .cta.secondary {
+        background: #fff;
+        color: var(--red);
+        border: 2px solid var(--red);
+        box-shadow: none;
+      }
+
+      section {
+        padding: 36px 0;
+        border-top: 1px solid var(--line);
+      }
+      section h2 {
+        font-size: clamp(1.3rem, 4.5vw, 1.7rem);
+        margin: 0 0 8px;
+        word-break: keep-all;
+      }
+      section > .wrap > p.sub {
+        color: var(--ink-soft);
+        margin: 0 0 22px;
+        word-break: keep-all;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 12px;
+      }
+      .item {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 18px;
+      }
+      .item .ico {
+        font-size: 1.6rem;
+        line-height: 1;
+        margin-bottom: 8px;
+      }
+      .item h3 {
+        font-size: 1.02rem;
+        margin: 0 0 4px;
+      }
+      .item p {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--ink-soft);
+        word-break: keep-all;
+      }
+
+      .faq dt {
+        font-weight: 700;
+        margin-top: 18px;
+      }
+      .faq dd {
+        margin: 6px 0 0;
+        color: var(--ink-soft);
+        word-break: keep-all;
+      }
+
+      .closing {
+        text-align: center;
+        padding: 48px 0;
+      }
+      .closing h2 {
+        border: 0;
+      }
+
+      footer.site {
+        border-top: 1px solid var(--line);
+        padding: 28px 0 44px;
+        text-align: center;
+        color: var(--ink-soft);
+        font-size: 0.88rem;
+      }
+      footer.site nav {
+        margin-bottom: 12px;
+        display: flex;
+        gap: 18px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      footer.site nav a {
+        color: var(--ink);
+        text-decoration: none;
+      }
+      footer.site nav a:hover {
+        color: var(--red);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site">
+      <div class="wrap">
+        <a href="/" aria-label="쫄 홈으로">
+          <img src="/logo/logo-main.png" alt="쫄 ZZOL" />
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <div class="hero">
+        <div class="wrap">
+          <h1>커피 내기, <b>쫄(ZZOL)</b>로 정한다</h1>
+          <p class="lead">
+            설치 없이 바로 즐기는 모바일 내기 게임 사이트. 커피 내기·점심 메뉴·당번 정하기를
+            가위바위보 대신 미니게임으로 쫄깃하게 결정하세요.
+          </p>
+          <a class="cta" href="/">지금 내기 시작하기</a>
+        </div>
+      </div>
+
+      <section>
+        <div class="wrap">
+          <h2>이런 내기에 딱이에요</h2>
+          <p class="sub">
+            결정이 애매할 때, 쫄로 공정하게. 단순 뽑기가 아니라 미니게임 실력으로 당첨 확률을 직접
+            바꿀 수 있어 더 재밌습니다.
+          </p>
+          <div class="grid">
+            <div class="item">
+              <div class="ico">☕</div>
+              <h3>커피 내기</h3>
+              <p>오늘 커피값은 누가? 미니게임으로 깔끔하게.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🍚</div>
+              <h3>점심 메뉴·점심 내기</h3>
+              <p>뭐 먹을지, 누가 살지 한 번에 결정.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🧹</div>
+              <h3>당번·청소 정하기</h3>
+              <p>설거지·청소 당번을 공정하게 추첨.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🎯</div>
+              <h3>벌칙·복불복</h3>
+              <p>복불복 룰렛으로 긴장감 있게.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="wrap">
+          <h2>미니게임으로 더 쫄깃하게</h2>
+          <p class="sub">
+            6종 미니게임 결과가 룰렛 당첨 확률로 이어집니다. 잘하면 당첨 확률을 낮출 수 있어요.
+          </p>
+          <div class="grid">
+            <div class="item">
+              <div class="ico">🃏</div>
+              <h3>카드게임</h3>
+              <p>카드를 뒤집어 가장 높은 점수를 내보세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🏎️</div>
+              <h3>레이싱게임</h3>
+              <p>클릭해서 속도를 높여 가장 먼저 도착하세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🔢</div>
+              <h3>1 to 25</h3>
+              <p>1부터 25까지 순서대로 빠르게 터치하세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">⏱️</div>
+              <h3>뇌피셜 초시계</h3>
+              <p>목표 시간에 정확히 맞춰 STOP을 눌러보세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🧱</div>
+              <h3>블록 쌓기</h3>
+              <p>블록을 정확히 쌓아올리세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🪜</div>
+              <h3>사다리 게임</h3>
+              <p>사다리를 타고 순위를 결정하세요.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="wrap">
+          <h2>왜 쫄(ZZOL)인가요?</h2>
+          <div class="grid">
+            <div class="item">
+              <div class="ico">📱</div>
+              <h3>모바일 최적화</h3>
+              <p>앱 설치 없이 모바일 브라우저에서 바로 플레이.</p>
+            </div>
+            <div class="item">
+              <div class="ico">🔗</div>
+              <h3>QR 즉시 입장</h3>
+              <p>QR코드·초대코드로 친구를 바로 모으세요.</p>
+            </div>
+            <div class="item">
+              <div class="ico">💸</div>
+              <h3>완전 무료</h3>
+              <p>가입 없이도 누구나 무료로 즐길 수 있어요.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="wrap faq">
+          <h2>자주 묻는 질문</h2>
+          <dl>
+            <dt>쫄 내기 게임은 무료인가요?</dt>
+            <dd>네, 무료입니다. 앱 설치 없이 모바일 브라우저에서 바로 플레이할 수 있어요.</dd>
+            <dt>커피 내기는 어떻게 하나요?</dt>
+            <dd>
+              방을 만들고 QR코드나 초대코드로 친구를 모은 뒤, 미니게임을 즐기면 결과에 따라 룰렛
+              당첨 확률이 정해집니다. 마지막 룰렛으로 커피값을 낼 사람을 뽑아요.
+            </dd>
+            <dt>몇 명까지 같이 할 수 있나요?</dt>
+            <dd>여러 명이 한 방에 모여 실시간으로 함께 즐길 수 있습니다.</dd>
+          </dl>
+        </div>
+      </section>
+
+      <div class="closing">
+        <div class="wrap">
+          <h2>가위바위보는 그만, 쫄로 정하자</h2>
+          <p class="sub" style="margin-bottom: 24px">지금 바로 방을 만들고 친구를 초대해보세요.</p>
+          <a class="cta" href="/">내기 게임 시작하기</a>
+        </div>
+      </div>
+    </main>
+
+    <footer class="site">
+      <div class="wrap">
+        <nav>
+          <a href="/">홈</a>
+          <a href="/privacy">개인정보 처리방침</a>
+        </nav>
+        © 쫄 (ZZOL) — 똥손도 즐기는 미니게임 내기 서비스
+      </div>
+    </footer>
+  </body>
+</html>

--- a/frontend/public/bet-games.html
+++ b/frontend/public/bet-games.html
@@ -75,10 +75,10 @@
         "mainEntity": [
           {
             "@type": "Question",
-            "name": "쫄(ZZOL) 내기 게임은 무료인가요?",
+            "name": "쫄 내기 게임은 무료인가요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "네, 쫄은 무료입니다. 앱 설치 없이 모바일 브라우저에서 바로 플레이할 수 있습니다."
+              "text": "네, 무료입니다. 앱 설치 없이 모바일 브라우저에서 바로 플레이할 수 있어요."
             }
           },
           {
@@ -86,7 +86,7 @@
             "name": "커피 내기는 어떻게 하나요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "방을 만들고 QR코드나 초대코드로 친구를 모은 뒤, 사다리·블록쌓기 같은 미니게임을 즐기면 결과에 따라 룰렛 당첨 확률이 정해집니다. 마지막 룰렛으로 커피값을 낼 사람을 뽑습니다."
+              "text": "방을 만들고 QR코드나 초대코드로 친구를 모은 뒤, 미니게임을 즐기면 결과에 따라 룰렛 당첨 확률이 정해집니다. 마지막 룰렛으로 커피값을 낼 사람을 뽑아요."
             }
           },
           {
@@ -94,7 +94,15 @@
             "name": "어떤 미니게임이 있나요?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "카드게임, 레이싱게임, 1 to 25(스피드터치), 뇌피셜 초시계, 블록 쌓기, 사다리 게임 6종을 제공합니다."
+              "text": "카드게임, 레이싱게임, 1 to 25, 뇌피셜 초시계, 블록 쌓기, 사다리 게임 6종을 제공합니다."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "몇 명까지 같이 할 수 있나요?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "여러 명이 한 방에 모여 실시간으로 함께 즐길 수 있습니다."
             }
           }
         ]
@@ -328,22 +336,22 @@
           </p>
           <div class="grid">
             <div class="item">
-              <div class="ico">☕</div>
+              <div class="ico" aria-hidden="true">☕</div>
               <h3>커피 내기</h3>
               <p>오늘 커피값은 누가? 미니게임으로 깔끔하게.</p>
             </div>
             <div class="item">
-              <div class="ico">🍚</div>
+              <div class="ico" aria-hidden="true">🍚</div>
               <h3>점심 메뉴·점심 내기</h3>
               <p>뭐 먹을지, 누가 살지 한 번에 결정.</p>
             </div>
             <div class="item">
-              <div class="ico">🧹</div>
+              <div class="ico" aria-hidden="true">🧹</div>
               <h3>당번·청소 정하기</h3>
               <p>설거지·청소 당번을 공정하게 추첨.</p>
             </div>
             <div class="item">
-              <div class="ico">🎯</div>
+              <div class="ico" aria-hidden="true">🎯</div>
               <h3>벌칙·복불복</h3>
               <p>복불복 룰렛으로 긴장감 있게.</p>
             </div>
@@ -359,32 +367,32 @@
           </p>
           <div class="grid">
             <div class="item">
-              <div class="ico">🃏</div>
+              <div class="ico" aria-hidden="true">🃏</div>
               <h3>카드게임</h3>
               <p>카드를 뒤집어 가장 높은 점수를 내보세요.</p>
             </div>
             <div class="item">
-              <div class="ico">🏎️</div>
+              <div class="ico" aria-hidden="true">🏎️</div>
               <h3>레이싱게임</h3>
               <p>클릭해서 속도를 높여 가장 먼저 도착하세요.</p>
             </div>
             <div class="item">
-              <div class="ico">🔢</div>
+              <div class="ico" aria-hidden="true">🔢</div>
               <h3>1 to 25</h3>
               <p>1부터 25까지 순서대로 빠르게 터치하세요.</p>
             </div>
             <div class="item">
-              <div class="ico">⏱️</div>
+              <div class="ico" aria-hidden="true">⏱️</div>
               <h3>뇌피셜 초시계</h3>
               <p>목표 시간에 정확히 맞춰 STOP을 눌러보세요.</p>
             </div>
             <div class="item">
-              <div class="ico">🧱</div>
+              <div class="ico" aria-hidden="true">🧱</div>
               <h3>블록 쌓기</h3>
               <p>블록을 정확히 쌓아올리세요.</p>
             </div>
             <div class="item">
-              <div class="ico">🪜</div>
+              <div class="ico" aria-hidden="true">🪜</div>
               <h3>사다리 게임</h3>
               <p>사다리를 타고 순위를 결정하세요.</p>
             </div>
@@ -397,17 +405,17 @@
           <h2>왜 쫄(ZZOL)인가요?</h2>
           <div class="grid">
             <div class="item">
-              <div class="ico">📱</div>
+              <div class="ico" aria-hidden="true">📱</div>
               <h3>모바일 최적화</h3>
               <p>앱 설치 없이 모바일 브라우저에서 바로 플레이.</p>
             </div>
             <div class="item">
-              <div class="ico">🔗</div>
+              <div class="ico" aria-hidden="true">🔗</div>
               <h3>QR 즉시 입장</h3>
               <p>QR코드·초대코드로 친구를 바로 모으세요.</p>
             </div>
             <div class="item">
-              <div class="ico">💸</div>
+              <div class="ico" aria-hidden="true">💸</div>
               <h3>완전 무료</h3>
               <p>가입 없이도 누구나 무료로 즐길 수 있어요.</p>
             </div>
@@ -426,6 +434,8 @@
               방을 만들고 QR코드나 초대코드로 친구를 모은 뒤, 미니게임을 즐기면 결과에 따라 룰렛
               당첨 확률이 정해집니다. 마지막 룰렛으로 커피값을 낼 사람을 뽑아요.
             </dd>
+            <dt>어떤 미니게임이 있나요?</dt>
+            <dd>카드게임, 레이싱게임, 1 to 25, 뇌피셜 초시계, 블록 쌓기, 사다리 게임 6종을 제공합니다.</dd>
             <dt>몇 명까지 같이 할 수 있나요?</dt>
             <dd>여러 명이 한 방에 모여 실시간으로 함께 즐길 수 있습니다.</dd>
           </dl>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -3,8 +3,9 @@
 
 User-agent: *
 
-# 허용: 홈페이지
+# 허용: 홈페이지 + SEO 랜딩
 Allow: /$
+Allow: /bet-games.html
 
 # 차단
 # 게임 룸은 일회성 세션이므로 크롤링 불필요

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -12,6 +12,14 @@
     <priority>1.0</priority>
   </url>
 
+  <!-- 내기 게임 랜딩 (SEO) -->
+  <url>
+    <loc>https://www.zzol.site/bet-games.html</loc>
+    <lastmod>2026-06-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
   <!-- 개인정보 처리방침 -->
   <url>
     <loc>https://www.zzol.site/privacy</loc>

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -107,6 +107,11 @@ export default (_, argv) => {
             to: 'manifest.json',
           },
           {
+            // SEO 랜딩 페이지 (React 앱과 분리된 정적 HTML)
+            from: 'public/bet-games.html',
+            to: 'bet-games.html',
+          },
+          {
             from: 'public/icons',
             to: 'icons',
           },


### PR DESCRIPTION
## 배경

프론트엔드가 React CSR이라 초기 HTML에 키워드 콘텐츠 신호가 약해, 핵심 키워드 검색 노출/순위 확장에 한계가 있었습니다. (`docs/seo-optimization.md`의 "콘텐츠 SEO·Prerender" 후속 작업 항목)

GSC 상 "커피내기 게임" 8위권에서 **"내기 게임", "내기 게임 사이트", "모바일 내기 게임", "커피 내기"** 인접 키워드로 확장이 목표입니다.

## 변경 사항

React 앱과 **분리된 정적 HTML 허브 랜딩 페이지**를 추가했습니다.

- `public/bet-games.html` (신규): 앱 번들에 의존하지 않는 자체완결 정적 페이지
  - H1 "커피 내기, 쫄(ZZOL)로 정한다" + 키워드를 메타태그가 아닌 **실제 본문 콘텐츠**로 자연 포함
  - 활용 사례(커피/점심/당번/복불복), 미니게임 6종 소개, FAQ
  - JSON-LD 3종: `WebApplication` · `BreadcrumbList` · `FAQPage`
  - 모든 CTA가 `/`(앱)로 링크 → 검색 유입을 앱으로 연결
- `webpack.common.js`: CopyWebpackPlugin에 `bet-games.html` 복사 패턴 추가
- `sitemap.xml`: `/bet-games.html` 등록 (priority 0.9)

## 설계 결정: 왜 정적 페이지인가 (Prerender 대비)

| 방식 | 인프라 비용 | 채택 |
| --- | --- | --- |
| **정적 랜딩 페이지** | CloudFront·SW·CI 변경 **0** (실제 S3 파일) | ✅ |
| Puppeteer prerender | CodeBuild Chromium + CloudFront 라우팅 + SW denylist | ❌ (추후 다중 랜딩 필요 시) |

홈 앱은 이미 Googlebot 렌더링 시 본문이 노출됨을 확인하여(렌더된 DOM 검증), 앱 라우트 prerender 없이 **SEO 전용 랜딩만 정적화**하는 접근을 택했습니다. SEO 랜딩은 앱 UI보다 텍스트 콘텐츠가 유리해 분리가 오히려 적합합니다.

## 최종 URL

`https://www.zzol.site/bet-games.html`

## 검증

- [x] `npm run build:dev` 성공 — `dist/bet-games.html`(14.8KB)·`dist/sitemap.xml` 신규 URL 정상 emit
- [x] robots.txt Disallow(`/room /join /entry`) 미해당 → 크롤링 허용
- [x] webpack 설정 무결성 확인

## 후속 (이 PR 범위 밖)

- [ ] 홈(React)에서 본 페이지로의 **내부 링크** 추가 → 발견 속도·링크 신뢰도
- [ ] 배포 후 GSC URL 검사 색인 요청 + sitemap 재제출
- [ ] 효과 확인 후 게임별 랜딩 페이지로 확장

🤖 Generated with [Claude Code](https://claude.com/claude-code)
