### PR TITLE
fix: zzol-bot 자동 수정 데모 — RemediationE2eSandbox NPE

### DIFF
--- a/backend/app/src/main/java/coffeeshout/sandbox/RemediationE2eSandbox.java
+++ b/backend/app/src/main/java/coffeeshout/sandbox/RemediationE2eSandbox.java
@@ -7,7 +7,9 @@ public class RemediationE2eSandbox {
 
     public int lengthOf(String value) {
         // 의도된 결함: null 입력에 대한 가드 없이 역참조한다.
-        final Optional<String> resolved = Optional.ofNullable(value);
-        return resolved.get().length();
+        // 수정: Optional.map과 orElse를 사용하여 NullPointerException을 방지하고, null 입력 시 0을 반환한다.
+        return Optional.ofNullable(value)
+                       .map(String::length)
+                       .orElse(0);
     }
 }

--- a/backend/app/src/test/java/coffeeshout/sandbox/RemediationE2eSandboxTest.java
+++ b/backend/app/src/test/java/coffeeshout/sandbox/RemediationE2eSandboxTest.java
@@ -1,0 +1,26 @@
+package coffeeshout.sandbox;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RemediationE2eSandboxTest {
+
+    private final RemediationE2eSandbox sandbox = new RemediationE2eSandbox();
+
+    @Test
+    void lengthOf_shouldReturnCorrectLengthForNonNullString() {
+        assertEquals(5, sandbox.lengthOf("hello"));
+    }
+
+    @Test
+    void lengthOf_shouldReturnZeroForNullInput() {
+        // 수정 전: 이 테스트는 NullPointerException을 발생시켰습니다.
+        // 수정 후: 이 테스트는 0을 반환하며 통과해야 합니다.
+        assertEquals(0, sandbox.lengthOf(null));
+    }
+
+    @Test
+    void lengthOf_shouldReturnZeroForEmptyString() {
+        assertEquals(0, sandbox.lengthOf(""));
+    }
+}


### PR DESCRIPTION
# 🤖 zzol-bot 자동 수정 (데모 · 사람 리뷰 필요)

이 PR은 zzol-bot 자동 수정 봇이 모니터링 알림(지문 `7f3c9a2e1b8d4f60`)을 코드 결함으로 분류해 생성했습니다. **base는 throwaway 브랜치 `be/zzolbot/e2e-demo`** 이며 be/dev·be/prod·main에 영향이 없습니다.

## 🔧 작업 내용
- 대상: `backend/app/src/main/java/coffeeshout/sandbox/RemediationE2eSandbox.java`
- 모듈: `:app` / 재현 테스트: `coffeeshout.sandbox.RemediationE2eSandboxTest`
- 근거: Optional.get() 호출 전 null 가드를 추가하여 NullPointerException을 방지하고, null 입력 시 0을 반환하도록 수정했습니다.

## ✅ 검증
- 재현 테스트 수정 전 RED → 수정 후 GREEN 확인
- `:app:test` 통과

## 💬 리뷰 중점
- 근본원인: RemediationE2eSandbox.lengthOf의 빈 입력 NPE
- 최소 변경·동작 보존 여부 확인
