### PR TITLE
[chore] 백엔드 테스트 시간 가시화(Build Scan)·결과 리포트(dorny) + 워커 수 근거

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -119,7 +119,7 @@ jobs:
       # 실패 스택트레이스 인라인). 표기 시간은 JUnit XML 합계라 wall-clock이 아니다 —
       # 실제 경과는 Build Scan 참조.
       - name: Publish Test Results
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: Backend Test Results

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -95,6 +95,13 @@ jobs:
           # 캐시를 단방향으로 읽기만 하므로 sibling PR이나 배포 빌드(be/dev·be/prod)로
           # 역전파되지 않는다. 10GB LRU 압박은 v6 기본 cache-cleanup(on-success)이 완화.
           cache-read-only: false
+          # Build Scan 발행 — 실제 wall-clock·병렬 타임라인·모듈/테스트별 시간을
+          # scans.gradle.com 리치 리포트로(빌드 로그·job summary에 링크). 프로젝트에
+          # Develocity 플러그인이 없어도 액션이 주입하며 ToS를 자동 동의한다.
+          # 합계(테스트 리포트)로는 안 보이던 "8분이 어디서 났나"를 여기서 본다.
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -104,36 +111,20 @@ jobs:
       - name: Enable Testcontainers reuse
         run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
 
-      # wall-clock(실제 경과)을 측정해 job summary에 남긴다. "Backend Test Results"
-      # 체크의 시간은 13개 모듈 테스트 시간의 합계라 wall-clock과 다르다(병렬 분산 전).
-      # --profile 로 모듈/태스크별 시간 분해 리포트를 생성한다.
+      # 시간 분석(wall-clock·병렬 타임라인·모듈별)은 Setup Gradle의 Build Scan으로 본다.
       - name: Run Tests
-        run: |
-          start=$(date +%s)
-          ./gradlew test jacocoTestReport --build-cache --no-daemon --profile && rc=0 || rc=$?
-          elapsed=$(( $(date +%s) - start ))
-          {
-            echo "### ⏱ 백엔드 테스트 시간"
-            printf -- "- **실제 경과(wall-clock)**: %dm %ds\n" $((elapsed/60)) $((elapsed%60))
-            echo "- 참고: \"Backend Test Results\" 체크의 시간은 13개 모듈 테스트 시간의 **합계**(병렬 분산 전)이며 wall-clock이 아니다."
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit $rc
+        run: ./gradlew test jacocoTestReport --build-cache --no-daemon
 
-      # 모듈/태스크별 wall-clock 분해 리포트(병목 식별용). 실패해도 업로드한다.
-      - name: Upload Gradle profile report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle-test-profile
-          path: backend/build/reports/profile/profile-*.html
-          if-no-files-found: ignore
-
+      # 테스트 결과는 dorny/test-reporter로 Checks 탭에 표시(스위트/테스트 드릴다운,
+      # 실패 스택트레이스 인라인). 표기 시간은 JUnit XML 합계라 wall-clock이 아니다 —
+      # 실제 경과는 Build Scan 참조.
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: dorny/test-reporter@v2
         if: always()
         with:
-          files: backend/*/build/test-results/test/*.xml
-          check_name: "Backend Test Results"
+          name: Backend Test Results
+          path: backend/*/build/test-results/test/*.xml
+          reporter: java-junit
 
       - name: Report Coverage
         if: github.event_name == 'pull_request'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -40,7 +40,8 @@ permissions:
 jobs:
   ci-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 실측 wall-clock ~8분(4-vCPU 러너에서 모듈 병렬). 여유로 15분.
+    timeout-minutes: 15
     # output을 상위 워크플로우로 전달
     outputs:
       environment: ${{ steps.set-env.outputs.environment }}
@@ -103,8 +104,29 @@ jobs:
       - name: Enable Testcontainers reuse
         run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
 
+      # wall-clock(실제 경과)을 측정해 job summary에 남긴다. "Backend Test Results"
+      # 체크의 시간은 13개 모듈 테스트 시간의 합계라 wall-clock과 다르다(병렬 분산 전).
+      # --profile 로 모듈/태스크별 시간 분해 리포트를 생성한다.
       - name: Run Tests
-        run: ./gradlew test jacocoTestReport --build-cache --no-daemon
+        run: |
+          start=$(date +%s)
+          ./gradlew test jacocoTestReport --build-cache --no-daemon --profile && rc=0 || rc=$?
+          elapsed=$(( $(date +%s) - start ))
+          {
+            echo "### ⏱ 백엔드 테스트 시간"
+            printf -- "- **실제 경과(wall-clock)**: %dm %ds\n" $((elapsed/60)) $((elapsed%60))
+            echo "- 참고: \"Backend Test Results\" 체크의 시간은 13개 모듈 테스트 시간의 **합계**(병렬 분산 전)이며 wall-clock이 아니다."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
+
+      # 모듈/태스크별 wall-clock 분해 리포트(병목 식별용). 실패해도 업로드한다.
+      - name: Upload Gradle profile report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-test-profile
+          path: backend/build/reports/profile/profile-*.html
+          if-no-files-found: ignore
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,6 +1,11 @@
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.configureondemand=true
+# 공개 레포 ubuntu-latest 표준 러너 = 4 vCPU / 16 GB.
+# workers.max는 코어 수에 맞춘 4가 상한이다. 더 올리면 모듈 fork당
+# (test JVM + MySQL/Valkey 컨테이너) 메모리가 16GB를 넘겨 OOM·flaky 위험
+# (ADR-0013, postmortem 0001/0002). 병렬도 부족이 아니라 모듈 의존 그래프·
+# 테스트 쏠림(:game·:room)이 wall-clock 병목이다.
 org.gradle.workers.max=4
 org.gradle.jvmargs=-Xmx4g
 org.gradle.caching=true


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- 없음

# 🚀 작업 내용

"Backend Test Results" 체크가 **23분**으로 뜨지만 실제 파이프라인 경과는 **약 8분**이라 혼란이 있었다. 원인은 버그가 아니라 (1) JUnit 리포터가 13개 모듈의 per-suite 시간을 **합산** 표기하고(어떤 JUnit 리포터로 바꿔도 동일 — wall-clock은 XML에 없음), (2) 모듈 테스트가 병렬 실행돼 **wall-clock = 합계 ÷ 유효병렬도(~2.9x)**이기 때문이다. 그래서 "시간"과 "결과"를 각각 맞는 도구로 분리한다.

1. **시간 분석 → Gradle Build Scan** (`backend-ci.yml`, `gradle/actions/setup-gradle`의 `build-scan-publish`). 모든 gradle 실행에 scan을 게시(ToS 자동 동의, 프로젝트에 Develocity 플러그인 없어도 액션이 주입)해 **실제 wall-clock·병렬 타임라인·모듈/테스트별 시간**을 클릭 리포트로 본다. 빌드 로그·job summary에 링크. → "8분이 어디서 났나"(꼬리 모듈 `:game`·`:room`)를 정량 확인.
2. **테스트 결과 → dorny/test-reporter** (EnricoMi 대체). Checks 탭에 스위트/테스트 드릴다운 + 실패 스택트레이스 인라인. (표기 시간은 여전히 JUnit 합계 — 실제 경과는 Build Scan 참조.)
3. **`timeout-minutes` 10 → 15** (실측 8분과 빠듯).
4. **`gradle.properties` — `workers.max=4` 유지 + 근거 주석**: 공개 레포 `ubuntu-latest` 표준 러너가 **4 vCPU / 16 GB**라 워커 4가 코어 수에 맞는 상한. 더 올리면 모듈 fork당 (test JVM + MySQL/Valkey 컨테이너) 메모리가 16GB를 넘겨 OOM·flaky 위험(ADR-0013, postmortem 0001/0002). 병렬도 부족이 아니라 모듈 의존 그래프·테스트 쏠림이 wall-clock 병목.

> 참고: 초기 커밋은 커스텀 wall-clock job summary + `--profile` 아티팩트 방식이었으나, 표준 도구인 Build Scan으로 대체하며 제거했다(상위호환).

# 💬 리뷰 중점사항

- **Build Scan은 빌드 데이터를 `scans.gradle.com`(Gradle 호스팅, 외부)에 게시**합니다. 공개 OSS라 일반적이지만 정책상 외부 게시가 곤란하면 self-host Develocity로 전환해야 합니다 — 확인 부탁드립니다.
- **워커 수는 의도적으로 4 유지.** 4-vCPU 러너에 이미 정합이고 상향은 메모리 초과·flaky 재발 위험이라 근거를 주석으로 코드화했습니다.
- 실제 시간 *단축*(8분→더)이 목표가 되면 다음 후보는 **matrix 샤딩**(잡 N개 분산, 무료) 또는 Develocity Test Distribution입니다 — 본 PR 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hty26o1Hk7S1pighKqPnn4)_