### PR TITLE
[fix] @RedisLock aspect 미로드 수정 — @ConditionalOnBean 평가 순서로 멱등성 방어 무력화 + 통합 테스트 공백 보강

### DIFF
--- a/backend/infra/src/main/java/coffeeshout/global/lock/RedisLockAspect.java
+++ b/backend/infra/src/main/java/coffeeshout/global/lock/RedisLockAspect.java
@@ -11,7 +11,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -30,7 +30,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE) // 트랜잭션보다 먼저 실행
 @RequiredArgsConstructor
-@ConditionalOnBean(RedissonClient.class)
+// RedissonClient 빈 생성 조건(RedissonConfig)과 동일한 프로퍼티로 게이팅한다.
+// @ConditionalOnBean은 @Bean 등록보다 먼저 평가돼 애스펙트가 조용히 빠지는 함정이 있다(LlmBudgetConfig 주석 참조)
+@ConditionalOnProperty(name = "redisson.enabled", havingValue = "true", matchIfMissing = true)
 public class RedisLockAspect {
 
     private final RedissonClient redissonClient;

--- a/backend/infra/src/test/java/coffeeshout/fixture/RedisLockedTaskFake.java
+++ b/backend/infra/src/test/java/coffeeshout/fixture/RedisLockedTaskFake.java
@@ -1,0 +1,87 @@
+package coffeeshout.fixture;
+
+import coffeeshout.global.lock.RedisLock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @RedisLock 애스펙트 검증용 락 대상 작업.
+ * <p>
+ * 실행 횟수를 세고, holdNextExecution()이 호출된 상태면 메서드 안에서(락을 보유한 채로) 대기해
+ * 테스트가 동시성 시나리오의 타이밍을 결정론적으로 제어할 수 있게 한다.
+ */
+public class RedisLockedTaskFake {
+
+    public static final String LOCK_PREFIX = "test:lock:";
+    public static final String DONE_PREFIX = "test:done:";
+
+    private final AtomicInteger executionCount = new AtomicInteger();
+    private volatile CountDownLatch enteredLatch = new CountDownLatch(1);
+    private volatile CountDownLatch holdLatch;
+
+    @RedisLock(key = "#eventId", lockPrefix = LOCK_PREFIX, donePrefix = DONE_PREFIX)
+    public String execute(String eventId) {
+        executionCount.incrementAndGet();
+        awaitHoldIfSet();
+        return eventId;
+    }
+
+    @RedisLock(key = "#eventId", lockPrefix = LOCK_PREFIX, donePrefix = DONE_PREFIX, waitTime = 3000)
+    public String executeWithLockWait(String eventId) {
+        executionCount.incrementAndGet();
+        awaitHoldIfSet();
+        return eventId;
+    }
+
+    @RedisLock(key = "#eventId", lockPrefix = LOCK_PREFIX, donePrefix = DONE_PREFIX)
+    public String executeFailing(String eventId) {
+        executionCount.incrementAndGet();
+        throw new IllegalStateException("의도된 실패");
+    }
+
+    public void reset() {
+        executionCount.set(0);
+        enteredLatch = new CountDownLatch(1);
+        holdLatch = null;
+    }
+
+    /**
+     * 다음 실행을 메서드 내부(락 보유 상태)에서 releaseHeldExecution() 호출까지 붙잡아 둔다.
+     */
+    public void holdNextExecution() {
+        holdLatch = new CountDownLatch(1);
+    }
+
+    public void releaseHeldExecution() {
+        final CountDownLatch latch = holdLatch;
+        if (latch != null) {
+            latch.countDown();
+        }
+    }
+
+    /**
+     * 어떤 스레드가 메서드 본문에 진입할 때까지 대기한다 (락 보유 확정 시점).
+     */
+    public boolean awaitEntered(long timeout, TimeUnit unit) throws InterruptedException {
+        return enteredLatch.await(timeout, unit);
+    }
+
+    public int executionCount() {
+        return executionCount.get();
+    }
+
+    private void awaitHoldIfSet() {
+        enteredLatch.countDown();
+        final CountDownLatch latch = holdLatch;
+        if (latch == null) {
+            return;
+        }
+        try {
+            // leaseTime(기본 5초) 만료 전에 반드시 풀리도록 상한을 둔다
+            latch.await(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockAspectIntegrationTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockAspectIntegrationTest.java
@@ -1,0 +1,176 @@
+package coffeeshout.global.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import coffeeshout.InfraModuleIntegrationTest;
+import coffeeshout.fixture.RedisLockedTaskFake;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * RedisLockAspect 통합 테스트.
+ * <p>
+ * Mockito 단위 테스트는 AOP 프록시를 우회하므로 애스펙트 동작을 검증할 수 없다.
+ * 실제 Spring 컨텍스트 + Valkey TestContainer 위에서 락·done 마킹·이중 체크를 검증한다.
+ */
+@Import(RedisLockTestConfig.class)
+class RedisLockAspectIntegrationTest extends InfraModuleIntegrationTest {
+
+    @Autowired
+    private RedisLockedTaskFake task;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired(required = false)
+    private RedisLockAspect aspect;
+
+    @Autowired(required = false)
+    private org.redisson.api.RedissonClient redissonClient;
+
+    @Test
+    void 애스펙트_빈이_컨텍스트에_로드된다() {
+        assertSoftly(softly -> {
+            softly.assertThat(redissonClient).as("RedissonClient 빈").isNotNull();
+            softly.assertThat(aspect).as("RedisLockAspect 빈").isNotNull();
+        });
+    }
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        task.reset();
+        executor = Executors.newFixedThreadPool(4);
+    }
+
+    @AfterEach
+    void tearDown() {
+        task.releaseHeldExecution();
+        executor.shutdownNow();
+    }
+
+    @Nested
+    class 같은_키로_다시_호출되면 {
+
+        @Test
+        void 이미_처리된_이벤트는_실행하지_않고_null을_반환한다() {
+            // given
+            final String first = task.execute("evt-1");
+
+            // when
+            final String second = task.execute("evt-1");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(first).isEqualTo("evt-1");
+                softly.assertThat(second).isNull();
+                softly.assertThat(task.executionCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 처리_완료_마킹이_TTL과_함께_저장된다() {
+            // when
+            task.execute("evt-2");
+
+            // then
+            final String doneKey = RedisLockedTaskFake.DONE_PREFIX + "evt-2";
+            assertSoftly(softly -> {
+                softly.assertThat(redisTemplate.hasKey(doneKey)).isTrue();
+                softly.assertThat(redisTemplate.getExpire(doneKey, TimeUnit.MILLISECONDS)).isPositive();
+            });
+        }
+
+        @Test
+        void 다른_키는_서로_간섭하지_않고_각각_실행된다() {
+            // when
+            task.execute("evt-3");
+            task.execute("evt-4");
+
+            // then
+            assertThat(task.executionCount()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class 동시에_같은_키로_진입하면 {
+
+        @Test
+        void 락_보유_중이면_대기_없는_호출은_즉시_스킵된다() throws Exception {
+            // given — 첫 스레드가 락을 보유한 채 메서드 안에서 대기
+            task.holdNextExecution();
+            final Future<String> holder = executor.submit(() -> task.execute("evt-5"));
+            assertThat(task.awaitEntered(3, TimeUnit.SECONDS)).isTrue();
+
+            // when — waitTime=0 이므로 락 획득 실패 즉시 포기
+            final String contender = task.execute("evt-5");
+            task.releaseHeldExecution();
+
+            // then
+            final String holderResult = holder.get(3, TimeUnit.SECONDS);
+            assertSoftly(softly -> {
+                softly.assertThat(contender).isNull();
+                softly.assertThat(holderResult).isEqualTo("evt-5");
+                softly.assertThat(task.executionCount()).isEqualTo(1);
+            });
+        }
+
+        @Test
+        void 락_대기_후_진입해도_이중_체크가_중복_실행을_차단한다() throws Exception {
+            // given — 첫 스레드가 락을 보유한 채 메서드 안에서 대기
+            task.holdNextExecution();
+            final Future<String> holder = executor.submit(() -> task.execute("evt-6"));
+            assertThat(task.awaitEntered(3, TimeUnit.SECONDS)).isTrue();
+
+            // when — waitTime=3000 이므로 락이 풀릴 때까지 대기 후 진입,
+            // 1차 체크는 이미 통과한 뒤라 락 획득 후 2차 체크(done)가 유일한 방어선이다
+            final Future<String> waiter = executor.submit(() -> task.executeWithLockWait("evt-6"));
+            task.releaseHeldExecution();
+
+            // then
+            final String holderResult = holder.get(3, TimeUnit.SECONDS);
+            final String waiterResult = waiter.get(5, TimeUnit.SECONDS);
+            assertSoftly(softly -> {
+                softly.assertThat(holderResult).isEqualTo("evt-6");
+                softly.assertThat(waiterResult).isNull();
+                softly.assertThat(task.executionCount()).isEqualTo(1);
+            });
+        }
+    }
+
+    @Nested
+    class 실행이_실패하면 {
+
+        @Test
+        void done_마킹이_없어_같은_키로_재시도할_수_있다() {
+            // given — 첫 실행이 예외로 실패
+            assertThatThrownBy(() -> task.executeFailing("evt-7"))
+                    .isInstanceOf(IllegalStateException.class);
+
+            // then — 실패한 실행은 done으로 마킹되지 않는다 (재시도 여지 보존)
+            final boolean markedAfterFailure = redisTemplate.hasKey(RedisLockedTaskFake.DONE_PREFIX + "evt-7");
+
+            // when — 같은 키로 재시도하면 실행된다
+            final String retry = task.execute("evt-7");
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(markedAfterFailure).isFalse();
+                softly.assertThat(retry).isEqualTo("evt-7");
+                softly.assertThat(task.executionCount()).isEqualTo(2);
+            });
+        }
+    }
+}

--- a/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockAspectTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockAspectTest.java
@@ -1,0 +1,25 @@
+package coffeeshout.global.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * RedisLockAspect 선언부 회귀 가드.
+ * <p>
+ * 애스펙트가 @Transactional(기본 Ordered.LOWEST_PRECEDENCE)보다 먼저 실행되어야
+ * 중복 이벤트가 트랜잭션(DB 커넥션) 획득 전에 걸러진다. 이 순서가 바뀌면
+ * 기능은 그대로 동작하는 것처럼 보이지만 커넥션 낭비 방지 효과가 사라진다.
+ */
+class RedisLockAspectTest {
+
+    @Test
+    void 트랜잭션보다_먼저_실행되도록_최우선_순위로_선언되어_있다() {
+        final Order order = RedisLockAspect.class.getAnnotation(Order.class);
+
+        assertThat(order).isNotNull();
+        assertThat(order.value()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+    }
+}

--- a/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockTestConfig.java
+++ b/backend/infra/src/test/java/coffeeshout/global/lock/RedisLockTestConfig.java
@@ -1,0 +1,19 @@
+package coffeeshout.global.lock;
+
+import coffeeshout.fixture.RedisLockedTaskFake;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @RedisLock이 붙은 락 대상 빈을 컨텍스트에 등록한다.
+ * 부모 클래스에 @SpringBootTest가 선언된 구조에서는 테스트 클래스 내부 @TestConfiguration이
+ * 자동 감지되지 않으므로 독립 파일로 분리한다 (docs/conventions-test.md).
+ */
+@TestConfiguration
+public class RedisLockTestConfig {
+
+    @Bean
+    public RedisLockedTaskFake redisLockedTaskFake() {
+        return new RedisLockedTaskFake();
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (be/dev)

# 🔥 연관 이슈

- close #이슈번호

# 🚀 작업 내용
🚨 빠진 테스트를 보충하던 중, 프로덕션 코드가 잘못된 걸 발견했어용
## 1. 버그: `@RedisLock` 애스펙트가 컨텍스트에 로드되지 않음 (프로덕션 영향)

`RedisLockAspect`의 `@ConditionalOnBean(RedissonClient.class)`은 `@Bean`으로 정의된 RedissonClient가 **등록되기 전에 평가**되어 항상 실패하고, 애스펙트가 조용히 컨텍스트에서 빠진다. 진단 테스트로 "동일 컨텍스트에 RedissonClient 빈은 존재 + 애스펙트만 부재"를 확정했다.

- 이 어노테이션은 멀티모듈 전환(#1276)에서 추가됨 → **그 이후 운영에서 `@RedisLock` 멱등성  방어가 no-op이었을 가능성이 높다** (이벤트 중복 소비 방어 없음)
- 무증상이었던 이유: ① 멱등 모듈은 이상 상황(consumer 재전달)에만 발동하는 안전망이라 평시 겉보기 동일 ② 사용처 테스트가 전부 Mockito 단위 테스트라 AOP 프록시가 적용되지 않아 애스펙트 유무와 무관하게 통과
- 같은 함정이 `zzolbot/LlmBudgetConfig.java` 주석에 이미 문서화되어 있었으나 `RedisLockAspect`만 수정을 비껴갔다

## 2. 수정: RedissonClient 빈 생성 조건과 동일한 프로퍼티 조건으로 교체 (1줄)

`@ConditionalOnBean(RedissonClient.class)`
→ `@ConditionalOnProperty(name = "redisson.enabled", havingValue = "true", matchIfMissing = true)`

`RedissonConfig`의 RedissonClient `@Bean` 조건과 문자 그대로 동일 — 프로퍼티 조건은 Environment 기반이라 빈 등록 순서와 무관하고, 애스펙트와 클라이언트가 항상 함께 로드되거나 함께 빠진다.

## 3. 테스트 공백 보강: `RedisLockAspect` 직접 테스트 0건 → 8건

| 파일 | 내용 |
|---|---|
| `RedisLockAspectIntegrationTest` | 빈 로드 가드(재발 방지) / 중복 호출 스킵+null 반환 / done 마킹+TTL / 키 격리 / 락 경합 시 즉시 스킵(waitTime=0) / **락 대기 후 이중 체크 차단**(waitTime>0) / 실행 실패 시 done 미마킹으로 재시도 가능 |
| `RedisLockAspectTest` | `@Order(HIGHEST_PRECEDENCE)` 회귀 가드 (@Transactional 선행 = DB 커넥션 낭비 차단 보장) |
| `RedisLockedTaskFake` | 락 대상 픽스처 — CountDownLatch로 동시성 타이밍을 결정론적으로 제어 (Thread.sleep 없음) |
| `RedisLockTestConfig` | 픽스처 빈 등록용 독립 `@TestConfiguration` (내부 선언 미감지 함정 회피) |

## 검증

- 수정 전: 통합 테스트 6건 실패 (애스펙트 미적용 상태를 정확히 검출)
- 수정 후: 락 테스트 8건 전부 통과
- 전체 회귀: `./gradlew test` 전 모듈(11개) BUILD SUCCESSFUL, failure/error 0건
- 2차 효과 점검: 실제 `@RedisLock` 적용 4곳 모두 `key = "#event.eventId()"`(UUID 유일 키)라
  락 재활성화로 정상 호출이 억제될 위험 없음

# 💬 리뷰 중점사항

1. **조건 교체의 타당성** — `@ConditionalOnBean`을 유지하면서 해결하는 대안(애스펙트를 `RedissonConfig`의 `@Bean`으로 이동)도 있으나, 게이팅 의도가 "Redisson이 켜진 환경"이므로 프로퍼티 조건이 의도를 더 직접 표현한다고 판단했다. 이견 환영.
2. **배포 후 확인 필요** — 운영 Redis에 `event:done:*` 키가 생기기 시작하는지 확인하면 애스펙트 활성화를 즉시 검증할 수 있다. (현재 운영에 이 키가 전무하다면 그 자체가 "그동안 꺼져 있었다"는 증거)
3. `RedisLockAspectIntegrationTest`는 `@Import` 때문에 별도 Spring 컨텍스트를 생성한다
   (캐시 미공유). 컨텍스트 캐시를 우선한다면 픽스처 빈을 공유 config로 올리는 대안이 있다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 중복 처리 방지 기능의 동작 범위가 확장되어, 동일 요청은 한 번만 처리되도록 안정성이 향상되었습니다.
  * 처리 완료 상태가 더 명확하게 관리되어, 재처리 여부 판단이 개선되었습니다.

* **버그 수정**
  * 잠금 기능이 특정 설정값에 따라 더 일관되게 활성화/비활성화되도록 수정했습니다.
  * 동시 요청 및 실패 후 재시도 시 중복 실행 문제가 발생하지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->