### PR TITLE
[chore] backend-ci Testcontainers reuse 죽은 설정 제거

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -93,11 +93,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # 모듈별 test JVM이 같은 MySQL/Valkey 컨테이너를 재사용하도록 활성화 (ADR-0013)
-      # 모듈별 독립 DB(zzol_test_<module>)·Redis DB 인덱스 격리로 병렬 실행 시에도 안전하다
-      - name: Enable Testcontainers reuse
-        run: echo "testcontainers.reuse.enable=true" > ~/.testcontainers.properties
-
       - name: Run Tests
         run: ./gradlew test --build-cache --no-daemon
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 → **base: `main`** (`.github/workflows/` 파일은 main 소관이라 be/dev가 아닌 main을 타깃)

# 🔥 연관 이슈

- close #1513

# 🚀 작업 내용

1. `backend-ci.yml`의 `Enable Testcontainers reuse` 스텝과 관련 주석 제거 (5줄 삭제)
   - 이 스텝은 `testcontainers.reuse.enable=true` 플래그만 켰는데, 컨테이너 재사용은 이 플래그와 **컨테이너의 `.withReuse(true)` 호출이 둘 다** 있어야 작동한다. `TestContainerSupport`의 mysql·valkey에는 `.withReuse(true)`가 없어(전 저장소 0건) 어떤 컨테이너도 재사용에 참여하지 않았다 → **효과 없는(no-op) 설정**이었다.

# 💬 리뷰 중점사항

- **동작 변화 없음**: 재사용은 `.withReuse(true)` 부재로 원래부터 무효였으므로, 이 스텝을 지워도 CI 테스트 실행 방식은 그대로다(모듈=JVM별 독립 컨테이너, 물리 격리).
- **왜 지우나 (오해 제거)**: 삭제한 주석은 "모듈별 test JVM이 같은 컨테이너를 재사용(ADR-0013)"이라고 적혀 있었으나, 이는 재사용을 끄고 JVM별 독립 컨테이너(물리 격리)로 확정한 **#1402 결정과 모순**된다. 남겨두면 다음 사람이 "CI는 컨테이너를 공유한다"고 오해할 위험이 있다.
- **안전성 확인**: `~/.testcontainers.properties`를 참조하는 다른 스텝이 없음을 확인했다(grep 0건). YAML 파싱도 검증 완료.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 백엔드 테스트 실행 흐름이 정리되어, 테스트 환경 설정 주입 단계가 제거되었습니다.
  * CI에서 테스트 실행 방식이 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->