### PR TITLE
[fix] 닉네임 검열 스케줄러 유니크 충돌로 인한 UNAUDITED 큐 영구 적체 해결

### DIFF
--- a/backend/app/src/main/resources/db/migration/V38__dedupe_unaudited_player_name_audit.sql
+++ b/backend/app/src/main/resources/db/migration/V38__dedupe_unaudited_player_name_audit.sql
@@ -1,0 +1,11 @@
+-- #1519: #1467 fix 배포 이전에 생성된 잔존 중복 데이터 정리.
+-- 같은 player_name이 (UNAUDITED)와 이미 검열된(terminal) 상태로 공존하면, 스케줄러가 UNAUDITED를
+-- terminal 상태로 승격하는 순간 uq_player_name_audit_name_status(player_name, status)에 충돌한다.
+-- 배치 전체가 롤백되고 문제 행이 UNAUDITED로 남아 매 스케줄 tick마다 재크래시 → 큐 영구 적체.
+-- 이미 검열 완료된 terminal 행이 권위 있는 판정을 보유하므로, 중복된 UNAUDITED 행을 제거한다.
+DELETE u
+FROM player_name_audit u
+         INNER JOIN player_name_audit t
+                    ON t.player_name = u.player_name
+                        AND t.status <> 'UNAUDITED'
+WHERE u.status = 'UNAUDITED';

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -11,6 +11,7 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -60,8 +61,26 @@ public class ProfanityAuditBatchProcessor {
                 .collect(Collectors.toMap(NicknameAuditResult::nickname, Function.identity(), (a, b) -> a));
 
         transactionTemplate.executeWithoutResult(status -> {
-            batch.forEach(entity -> applyResult(entity, resultMap.get(entity.getNickname())));
-            auditRepository.saveAll(batch);
+            final List<NicknameAudit> toPromote = new ArrayList<>();
+            final List<NicknameAudit> redundant = new ArrayList<>();
+            for (NicknameAudit entity : batch) {
+                final NicknameAuditResult result = resultMap.get(entity.getNickname());
+                // 이미 같은 (닉네임, 승격 대상 상태) 행이 있으면 이 UNAUDITED는 #1467 fix 이전에 생긴
+                // 잔존 중복 재등록이다. 그대로 승격하면 uq_player_name_audit_name_status에 충돌해
+                // 배치 전체가 롤백되고, 문제 행이 UNAUDITED로 남아 매 스케줄 tick마다 재크래시한다.
+                // 승격 대신 제거해 큐를 비운다 — 기존 terminal 행이 권위 있는 판정을 이미 보유하므로 손실이 없다.
+                if (result != null && auditRepository.existsByNicknameAndStatus(entity.getNickname(), result.status())) {
+                    redundant.add(entity);
+                    continue;
+                }
+                applyResult(entity, result);
+                toPromote.add(entity);
+            }
+            auditRepository.saveAll(toPromote);
+            if (!redundant.isEmpty()) {
+                auditRepository.deleteAll(redundant);
+                log.warn("이미 검열된 닉네임의 잔존 UNAUDITED {}건 제거 (중복 재등록)", redundant.size());
+            }
         });
 
         return batch.size();

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -63,13 +63,15 @@ public class ProfanityAuditBatchProcessor {
         transactionTemplate.executeWithoutResult(status -> {
             final List<NicknameAudit> toPromote = new ArrayList<>();
             final List<NicknameAudit> redundant = new ArrayList<>();
-            for (NicknameAudit entity : batch) {
+            for (final NicknameAudit entity : batch) {
                 final NicknameAuditResult result = resultMap.get(entity.getNickname());
-                // 이미 같은 (닉네임, 승격 대상 상태) 행이 있으면 이 UNAUDITED는 #1467 fix 이전에 생긴
-                // 잔존 중복 재등록이다. 그대로 승격하면 uq_player_name_audit_name_status에 충돌해
-                // 배치 전체가 롤백되고, 문제 행이 UNAUDITED로 남아 매 스케줄 tick마다 재크래시한다.
-                // 승격 대신 제거해 큐를 비운다 — 기존 terminal 행이 권위 있는 판정을 이미 보유하므로 손실이 없다.
-                if (result != null && auditRepository.existsByNicknameAndStatus(entity.getNickname(), result.status())) {
+                // 같은 닉네임의 검열 완료(terminal) 행이 이미 있으면 이 UNAUDITED는 #1467 fix 이전에 생긴
+                // 잔존 중복 재등록이다(register의 "이름당 1행" 불변식 위반). 승격하면 대상 상태가 같을 때
+                // uq_player_name_audit_name_status에 충돌해 배치 전체가 롤백되고 매 tick 재크래시하며,
+                // 다를 때는 (예: 기존 CLEAN + 신규 FLAGGED) 모순된 감사 이력과 autoBlock 오발동을 남긴다.
+                // 어느 쪽이든 승격 대신 제거한다 — 기존 terminal 행이 권위 있는 판정을 이미 보유한다.
+                if (result != null
+                        && auditRepository.existsByNicknameAndStatusNot(entity.getNickname(), NicknameAuditStatus.UNAUDITED)) {
                     redundant.add(entity);
                     continue;
                 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessor.java
@@ -14,6 +14,7 @@ import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -61,6 +62,9 @@ public class ProfanityAuditBatchProcessor {
                 .collect(Collectors.toMap(NicknameAuditResult::nickname, Function.identity(), (a, b) -> a));
 
         transactionTemplate.executeWithoutResult(status -> {
+            // 배치 닉네임 중 이미 검열 완료(terminal) 행을 가진 것들을 한 번에 조회한다 (건별 조회 N+1 회피).
+            final Set<String> nicknamesWithTerminal = auditRepository.findNicknamesWithTerminalStatus(nicknames);
+
             final List<NicknameAudit> toPromote = new ArrayList<>();
             final List<NicknameAudit> redundant = new ArrayList<>();
             for (final NicknameAudit entity : batch) {
@@ -70,8 +74,7 @@ public class ProfanityAuditBatchProcessor {
                 // uq_player_name_audit_name_status에 충돌해 배치 전체가 롤백되고 매 tick 재크래시하며,
                 // 다를 때는 (예: 기존 CLEAN + 신규 FLAGGED) 모순된 감사 이력과 autoBlock 오발동을 남긴다.
                 // 어느 쪽이든 승격 대신 제거한다 — 기존 terminal 행이 권위 있는 판정을 이미 보유한다.
-                if (result != null
-                        && auditRepository.existsByNicknameAndStatusNot(entity.getNickname(), NicknameAuditStatus.UNAUDITED)) {
+                if (result != null && nicknamesWithTerminal.contains(entity.getNickname())) {
                     redundant.add(entity);
                     continue;
                 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
@@ -14,6 +14,8 @@ public interface NicknameAuditRepository {
 
     List<NicknameAudit> saveAll(Iterable<NicknameAudit> entities);
 
+    void deleteAll(Iterable<NicknameAudit> entities);
+
     Optional<NicknameAudit> findById(Long id);
 
     long countByStatusAndAuditedAtIsNull(NicknameAuditStatus status);

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
@@ -2,6 +2,7 @@ package coffeeshout.profanity.application.port;
 
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -32,5 +33,9 @@ public interface NicknameAuditRepository {
 
     boolean existsByNicknameAndStatus(String nickname, NicknameAuditStatus status);
 
-    boolean existsByNicknameAndStatusNot(String nickname, NicknameAuditStatus status);
+    /**
+     * 주어진 닉네임들 중 이미 검열 완료된(UNAUDITED가 아닌 terminal) 행을 가진 닉네임 집합을 반환한다.
+     * 배치 승격 시 잔존 중복 UNAUDITED를 건별 조회 없이 한 번에 판별하기 위한 벌크 조회다.
+     */
+    Set<String> findNicknamesWithTerminalStatus(Collection<String> nicknames);
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
@@ -31,4 +31,6 @@ public interface NicknameAuditRepository {
     boolean existsByNickname(String nickname);
 
     boolean existsByNicknameAndStatus(String nickname, NicknameAuditStatus status);
+
+    boolean existsByNicknameAndStatusNot(String nickname, NicknameAuditStatus status);
 }

--- a/backend/profanity/src/main/java/coffeeshout/profanity/domain/audit/NicknameAudit.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/domain/audit/NicknameAudit.java
@@ -8,13 +8,20 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "player_name_audit") // :room에서 이전 시 기존 테이블 유지 — 스키마 마이그레이션 없이 호환
+@Table(
+        name = "player_name_audit", // :room에서 이전 시 기존 테이블 유지 — 스키마 마이그레이션 없이 호환
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_player_name_audit_name_status",
+                columnNames = {"player_name", "status"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NicknameAudit {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/persistence/audit/NicknameAuditJpaRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/persistence/audit/NicknameAuditJpaRepository.java
@@ -3,6 +3,7 @@ package coffeeshout.profanity.infra.persistence.audit;
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import java.util.Collection;
 import java.util.Set;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -13,4 +14,10 @@ public interface NicknameAuditJpaRepository extends Repository<NicknameAudit, Lo
     @Override
     @Query("SELECT DISTINCT n.nickname FROM NicknameAudit n WHERE n.status = :status")
     Set<String> findNicknamesByStatus(@Param("status") NicknameAuditStatus status);
+
+    @Override
+    @Query("SELECT DISTINCT n.nickname FROM NicknameAudit n "
+            + "WHERE n.nickname IN :nicknames "
+            + "AND n.status <> coffeeshout.profanity.domain.audit.NicknameAuditStatus.UNAUDITED")
+    Set<String> findNicknamesWithTerminalStatus(@Param("nicknames") Collection<String> nicknames);
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -184,4 +184,39 @@ class ProfanityAuditBatchProcessorTest {
             assertThat(processed).isEqualTo(2);
         }
     }
+
+    @Nested
+    class 잔존_UNAUDITED_중복_제거 {
+
+        @Test
+        void 이미_terminal_행이_있는_닉네임의_UNAUDITED는_승격_대신_제거된다() {
+            // #1467 fix 이전 잔존 데이터: (host, CLEAN)이 이미 존재하는 상태에서 (host, UNAUDITED) 승격 시도.
+            final NicknameAudit residual = new NicknameAudit("host");
+            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
+                    new NicknameAuditResult("host", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
+            ));
+            given(auditRepository.existsByNicknameAndStatus("host", NicknameAuditStatus.CLEAN)).willReturn(true);
+
+            processor.process(List.of(residual));
+
+            then(auditRepository).should().deleteAll(List.of(residual));
+            then(auditRepository).should().saveAll(List.of());
+            assertThat(residual.getStatus()).isEqualTo(NicknameAuditStatus.UNAUDITED);
+        }
+
+        @Test
+        void terminal_충돌이_없는_닉네임은_정상_승격된다() {
+            final NicknameAudit fresh = new NicknameAudit("용감한호랑이");
+            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
+                    new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
+            ));
+            given(auditRepository.existsByNicknameAndStatus("용감한호랑이", NicknameAuditStatus.CLEAN)).willReturn(false);
+
+            processor.process(List.of(fresh));
+
+            then(auditRepository).should().saveAll(List.of(fresh));
+            then(auditRepository).should(never()).deleteAll(any());
+            assertThat(fresh.getStatus()).isEqualTo(NicknameAuditStatus.CLEAN);
+        }
+    }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -195,7 +195,7 @@ class ProfanityAuditBatchProcessorTest {
             given(nicknameAuditor.audit(anyList())).willReturn(List.of(
                     new NicknameAuditResult("host", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
             ));
-            given(auditRepository.existsByNicknameAndStatus("host", NicknameAuditStatus.CLEAN)).willReturn(true);
+            given(auditRepository.existsByNicknameAndStatusNot("host", NicknameAuditStatus.UNAUDITED)).willReturn(true);
 
             processor.process(List.of(residual));
 
@@ -205,12 +205,30 @@ class ProfanityAuditBatchProcessorTest {
         }
 
         @Test
-        void terminal_충돌이_없는_닉네임은_정상_승격된다() {
+        void 기존_terminal과_다른_상태로_재판정돼도_모순_행_없이_제거되고_autoBlock도_발동하지_않는다() {
+            // 기존 (host, CLEAN)이 있는데 이번 AI 결과가 FLAGGED인 경우. 상태가 달라 유니크 충돌은 없지만,
+            // 승격하면 (host, CLEAN)+(host, FLAGGED) 모순 공존 + autoBlock 오발동이 생긴다. 제거가 정답이다.
+            final NicknameAudit residual = new NicknameAudit("host");
+            given(nicknameAuditor.audit(anyList())).willReturn(List.of(
+                    new NicknameAuditResult("host", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "재판정")
+            ));
+            given(auditRepository.existsByNicknameAndStatusNot("host", NicknameAuditStatus.UNAUDITED)).willReturn(true);
+
+            processor.process(List.of(residual));
+
+            then(auditRepository).should().deleteAll(List.of(residual));
+            then(profanityWordManagementService).should(never()).add(any(), any(), any());
+            then(eventPublisher).should(never()).publishEvent(any());
+            assertThat(residual.getStatus()).isEqualTo(NicknameAuditStatus.UNAUDITED);
+        }
+
+        @Test
+        void terminal_트윈이_없는_닉네임은_정상_승격된다() {
             final NicknameAudit fresh = new NicknameAudit("용감한호랑이");
             given(nicknameAuditor.audit(anyList())).willReturn(List.of(
                     new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
             ));
-            given(auditRepository.existsByNicknameAndStatus("용감한호랑이", NicknameAuditStatus.CLEAN)).willReturn(false);
+            given(auditRepository.existsByNicknameAndStatusNot("용감한호랑이", NicknameAuditStatus.UNAUDITED)).willReturn(false);
 
             processor.process(List.of(fresh));
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditBatchProcessorTest.java
@@ -21,6 +21,7 @@ import coffeeshout.profanity.domain.audit.NicknameAuditor;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -195,7 +196,7 @@ class ProfanityAuditBatchProcessorTest {
             given(nicknameAuditor.audit(anyList())).willReturn(List.of(
                     new NicknameAuditResult("host", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
             ));
-            given(auditRepository.existsByNicknameAndStatusNot("host", NicknameAuditStatus.UNAUDITED)).willReturn(true);
+            given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of("host"));
 
             processor.process(List.of(residual));
 
@@ -212,7 +213,7 @@ class ProfanityAuditBatchProcessorTest {
             given(nicknameAuditor.audit(anyList())).willReturn(List.of(
                     new NicknameAuditResult("host", NicknameAuditStatus.FLAGGED, AiConfidence.of(0.95), "재판정")
             ));
-            given(auditRepository.existsByNicknameAndStatusNot("host", NicknameAuditStatus.UNAUDITED)).willReturn(true);
+            given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of("host"));
 
             processor.process(List.of(residual));
 
@@ -228,7 +229,7 @@ class ProfanityAuditBatchProcessorTest {
             given(nicknameAuditor.audit(anyList())).willReturn(List.of(
                     new NicknameAuditResult("용감한호랑이", NicknameAuditStatus.CLEAN, AiConfidence.of(0.99), "일반")
             ));
-            given(auditRepository.existsByNicknameAndStatusNot("용감한호랑이", NicknameAuditStatus.UNAUDITED)).willReturn(false);
+            given(auditRepository.findNicknamesWithTerminalStatus(anyList())).willReturn(Set.of());
 
             processor.process(List.of(fresh));
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceDuplicateKeyIntegrationTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceDuplicateKeyIntegrationTest.java
@@ -1,0 +1,45 @@
+package coffeeshout.profanity.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coffeeshout.profanity.domain.audit.AiConfidence;
+import coffeeshout.profanity.domain.audit.NicknameAudit;
+import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.infra.persistence.audit.NicknameAuditJpaRepository;
+import coffeeshout.support.IntegrationTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * 스케줄러가 잔존 UNAUDITED 행을 검열할 때 유니크 제약({@code uq_player_name_audit_name_status})에
+ * 충돌해 배치 전체가 롤백되며 큐가 영구히 적체되던 장애의 회귀 테스트.
+ *
+ * <p>비트랜잭션 베이스({@link IntegrationTestSupport})를 상속해 실제 commit 시점에 제약이 검증되도록 한다.
+ * @Transactional 롤백 베이스에서는 flush가 지연돼 제약 위반이 재현되지 않는다.
+ */
+class ProfanityAuditServiceDuplicateKeyIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ProfanityAuditService service;
+
+    @Autowired
+    private NicknameAuditJpaRepository auditRepository;
+
+    @Test
+    void 이미_CLEAN인_닉네임의_잔존_UNAUDITED를_검열해도_유니크_충돌_없이_큐가_비워진다() {
+        // #1467 fix 이전에 생성된 잔존 데이터 재현: 같은 닉네임이 (CLEAN)과 (UNAUDITED)로 공존한다.
+        // uq_player_name_audit_name_status는 (player_name, status)라 status가 달라 둘 다 insert된다.
+        final NicknameAudit alreadyClean = new NicknameAudit("host");
+        alreadyClean.complete(NicknameAuditStatus.CLEAN, AiConfidence.UNKNOWN, "기존 검열 완료");
+        auditRepository.save(alreadyClean);
+        auditRepository.save(new NicknameAudit("host")); // 잔존 UNAUDITED 중복
+
+        // NoOpNicknameAuditor(test 프로파일)가 CLEAN을 반환 → UNAUDITED 'host'를 CLEAN으로 승격 시도.
+        // 기존 (host, CLEAN)과 충돌하므로, 승격 대신 중복 재등록으로 인지해 제거하고 예외 없이 큐를 비워야 한다.
+        assertThatCode(service::auditPending).doesNotThrowAnyException();
+
+        assertThat(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED)).isZero();
+        assertThat(auditRepository.findNicknamesByStatus(NicknameAuditStatus.CLEAN)).containsOnly("host");
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (base: `dev`)

# 🔥 연관 이슈

- close #1519

# 🚀 작업 내용

닉네임 AI 검열 스케줄러가 매 실행마다 `Duplicate entry 'host-CLEAN'` 예외를 던지며 UNAUDITED 큐가 영구히 쌓이던 장애를 해결합니다.

**무엇이 문제였나**
같은 닉네임이 `(host, UNAUDITED)`와 `(host, CLEAN)`으로 동시에 존재하는 잔존 데이터가 있으면, 스케줄러가 UNAUDITED 행을 CLEAN으로 승격하는 순간 유니크 제약 `uq_player_name_audit_name_status (player_name, status)`에 충돌합니다. 이 공존 데이터는 #1467(재등록 중복 차단) 배포 **이전**에 만들어진 것으로, #1467은 신규 발생만 막고 잔존 데이터는 정리하지 않았습니다.

더해서 `process()`가 배치 전체를 단일 트랜잭션으로 저장하기 때문에, 한 행의 충돌이 배치 전체를 롤백시킵니다. 문제 행은 UNAUDITED로 남아 매 스케줄 실행마다 다시 선택되고 다시 크래시 → 큐가 절대 비워지지 않고 같은 배치의 정상 닉네임도 영영 처리되지 못했습니다.

**작업 내용**

1. `ProfanityAuditBatchProcessor` — 이미 검열 완료된(terminal) 행이 존재하는 닉네임의 잔존 UNAUDITED는 승격 대신 제거합니다. 기존 terminal 행이 이미 권위 있는 판정을 갖고 있어 데이터 손실이 없고, 크래시 루프가 끊깁니다.
2. `V38__dedupe_unaudited_player_name_audit.sql` — 운영 DB에 남아 있는 잔존 중복 UNAUDITED 행을 일괄 정리합니다. (V29의 dedup 패턴과 동일)
3. `NicknameAudit` 엔티티 `@Table`에 유니크 제약을 선언 — 지금까지 이 제약은 Flyway(V29)에만 있고 엔티티에는 없어서, `ddl-auto=create`로 도는 테스트 스키마에는 제약이 존재하지 않았습니다. 그래서 이 버그를 잡을 테스트가 구조적으로 불가능했습니다. 실제 스키마와 정합을 맞춰 재현·회귀 테스트가 가능해집니다.
4. 재현 통합 테스트(`ProfanityAuditServiceDuplicateKeyIntegrationTest`) + 배치 처리 단위 테스트를 추가했습니다.

# 💬 리뷰 중점사항

- **제약을 좁히지 않고 데이터·코드로 해결한 이유**: `(player_name, status)` 제약은 동시 재등록 시 UNAUDITED 중복 insert를 막는 본래 역할이 있어 유지했습니다. 대신 잔존 데이터는 마이그레이션으로 정리하고, 런타임 재발은 `process()`의 self-heal(잔존 UNAUDITED 제거)로 방어합니다.
- **엔티티에 유니크 제약 선언**: 운영은 Flyway가 스키마를 관리하므로 동작 변화는 없고, 테스트 스키마(ddl-auto)에만 제약이 새로 생깁니다. 기존 profanity 테스트 전부 통과를 확인했습니다.
- **마이그레이션은 테스트에서 실행되지 않습니다**(test-base가 `flyway.enabled=false`). V38 SQL은 배포된 V29의 다중 테이블 DELETE-JOIN 패턴을 그대로 따릅니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 중복된 미검열 항목이 남아 있더라도 자동 검열 처리 중 충돌로 전체 작업이 실패하지 않도록 개선했습니다.
  * 이미 확정된 상태가 있는 항목은 불필요하게 다시 처리되지 않고 정리됩니다.
  * 같은 이름에 대해 중복 상태가 쌓이는 문제가 줄어들어, 배치 지연이나 누적 오류 가능성이 낮아졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->