### PR TITLE
fix(ci-fix): 존재하지 않는 체크런 대신 Actions 런 로그에서 실패 테스트 추출 (#1521)

### DIFF
--- a/backend/.claude/skills/ci-fix/SKILL.md
+++ b/backend/.claude/skills/ci-fix/SKILL.md
@@ -7,18 +7,19 @@ allowed-tools: Read, Glob, Grep, Write, Edit, Bash, Agent
 
 # ci-fix
 
-PR 번호를 받아 GitHub CI "Backend Test Results" 체크의 실패 테스트를 자동으로 감지하고 수정한다.
+PR 번호를 받아 GitHub Actions `backend-ci.yml` 런 로그에서 실패한 테스트를 자동으로 감지하고 수정한다.
 
 ## Step 1–2: 실패 테스트 추출
 
-`fetch-failures.sh`로 PR 상태 확인 및 실패 목록을 가져온다:
+`fetch-failures.sh`로 PR 상태 확인 및 실패 목록을 가져온다. 이 스크립트는 PR head 브랜치의 최근 `backend-ci.yml` 런 로그(gradle JUnit 출력)를 직접 파싱한다 — dorny "Backend Test Results" 체크런은 생성되지 않으므로 의존하지 않는다(#1521):
 
 ```bash
 bash .claude/skills/ci-fix/fetch-failures.sh <PR번호>
 ```
 
 - "CI가 통과 상태입니다" 출력 시 종료한다
-- 출력이 비어 있으면 "Annotations에서 실패 정보를 가져올 수 없습니다. 로그를 직접 확인해주세요."를 출력하고 종료한다
+- "CI가 아직 실행 중입니다" 출력 시 완료를 기다렸다가 재시도한다
+- "테스트 실패 라인을 찾지 못했습니다" 출력 시(컴파일·인프라 등 테스트 외 실패) 함께 출력된 로그 마지막 부분으로 원인을 판단한다
 
 ## Step 3: 실패 목록 정리
 

--- a/backend/.claude/skills/ci-fix/fetch-failures.sh
+++ b/backend/.claude/skills/ci-fix/fetch-failures.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 # Usage: bash fetch-failures.sh <PR번호>
+#
+# PR head 브랜치의 최근 backend-ci.yml 런에서 실패한 테스트를 추출한다.
+#
+# 배경(#1521): dorny/test-reporter는 결과를 job summary에만 쓰고 "Backend Test Results"
+# 체크런을 생성하지 않는다(성공·실패 런 모두 없음). 또 job summary(step summary) 텍스트는
+# 공개 REST API로 가져올 수 없다. 따라서 체크런 annotation이 아니라 GitHub Actions
+# 런 로그의 gradle JUnit 출력을 직접 파싱한다.
 set -euo pipefail
 
 PR=${1:-$(gh pr view --json number -q .number 2>/dev/null || true)}
@@ -8,54 +15,68 @@ if [ -z "$PR" ]; then
   exit 1
 fi
 
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-HEAD_SHA=$(gh pr view "$PR" --json headRefOid -q .headRefOid)
+BRANCH=$(gh pr view "$PR" --json headRefName -q .headRefName)
 
-CHECK_RUN_ID=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-  --jq '[.check_runs[] | select(.name == "Backend Test Results")] | first | .id')
+# PR head 브랜치의 가장 최근 backend-ci.yml 런 (id/상태/결론)
+RUN_INFO=$(gh run list --branch "$BRANCH" --workflow backend-ci.yml --limit 1 \
+  --json databaseId,status,conclusion \
+  --jq '.[0] | "\(.databaseId)\t\(.status)\t\(.conclusion)"' 2>/dev/null || true)
+IFS=$'\t' read -r RUN_ID STATUS CONCLUSION <<< "${RUN_INFO:-}"
 
-if [ -z "$CHECK_RUN_ID" ] || [ "$CHECK_RUN_ID" = "null" ]; then
-  echo "Backend Test Results 체크를 찾을 수 없습니다." >&2
+if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
+  echo "backend-ci.yml 런을 찾을 수 없습니다. PR에 백엔드 CI가 실행됐는지 확인해주세요." >&2
   exit 1
 fi
 
-CONCLUSION=$(gh api "repos/${REPO}/check-runs/${CHECK_RUN_ID}" --jq '.conclusion')
+if [ "$STATUS" != "completed" ]; then
+  echo "CI가 아직 실행 중입니다 (status: ${STATUS}). 완료 후 다시 시도하세요." >&2
+  exit 1
+fi
 
 if [ "$CONCLUSION" = "success" ]; then
   echo "CI가 통과 상태입니다 (conclusion: success)"
   exit 0
-elif [ "$CONCLUSION" = "null" ] || [ -z "$CONCLUSION" ]; then
-  echo "CI 상태: 아직 완료되지 않은 상태입니다." >&2
+fi
+
+if [ "$CONCLUSION" != "failure" ]; then
+  echo "CI 결론: ${CONCLUSION} — 실패가 아닙니다 (취소·스킵 등). 재실행이 필요할 수 있습니다." >&2
   exit 1
-elif [ "$CONCLUSION" != "failure" ]; then
-  echo "CI 상태: ${CONCLUSION} — 실패가 아닙니다." >&2
+fi
+
+# 실패한 스텝 로그에서 gradle JUnit 실패를 파싱한다.
+# 로그 각 줄은 "<job>\t<step>\t<ISO timestamp> <message>" 형식이라 timestamp까지 벗겨낸다.
+# gradle 출력 형식:
+#   <Suite> > <testMethod>() FAILED
+#       <exception> at <File>.java:<line>
+#   NNN tests completed, M failed
+LOG=$(gh run view "${RUN_ID}" --log-failed 2>/dev/null || true)
+
+if [ -z "$LOG" ]; then
+  echo "런 로그를 가져오지 못했습니다 (만료되었거나 접근 불가). 웹에서 직접 확인해주세요:" >&2
+  gh run view "${RUN_ID}" --json url --jq '.url' >&2 || true
   exit 1
 fi
 
-ANNOTATIONS=$(gh api --paginate "repos/${REPO}/check-runs/${CHECK_RUN_ID}/annotations" \
-  --jq '.[] | select(.annotation_level == "failure") | "\(.title)\n  경로: \(.path):\(.start_line)\n  메시지: \(.message)\n"')
+PARSED=$(printf '%s\n' "$LOG" | awk '
+    { line=$0; sub(/^.*[0-9][0-9]:[0-9][0-9]:[0-9][0-9][.][0-9]+Z /, "", line) }
+    # 테스트 메서드 실패만("()" 포함). "> Task :game:test FAILED" 같은 gradle 태스크 줄은 제외.
+    line ~ /> .+\(\) FAILED$/ { sub(/ FAILED$/, "", line); n++; test[n]=line; next }
+    n>0 && cause[n]=="" && line ~ / at .+\.java:[0-9]+/ { sub(/^[ \t]+/, "", line); cause[n]=line; next }
+    line ~ /[0-9]+ tests completed, [0-9]+ failed/ { summary=line }
+    END {
+      for (i=1;i<=n;i++) {
+        printf "[실패 %d] %s\n", i, test[i]
+        if (cause[i]!="") printf "  원인: %s\n", cause[i]
+      }
+      if (summary!="") printf "\n집계: %s\n", summary
+      if (n==0) print "__NO_FAILED_TESTS__"
+    }')
 
-if [ -n "$ANNOTATIONS" ]; then
-  echo "$ANNOTATIONS"
+if [ "$PARSED" = "__NO_FAILED_TESTS__" ]; then
+  echo "테스트 실패 라인을 찾지 못했습니다 (컴파일·인프라 등 테스트 외 실패일 수 있음)." >&2
+  echo "실패 스텝 로그 마지막 부분:" >&2
+  printf '%s\n' "$LOG" | tail -30 >&2
   exit 0
 fi
 
-# annotations 없음 → CI 런 로그 폴백
-BRANCH=$(gh pr view "$PR" --json headRefName -q .headRefName)
-RUN_ID=$(gh run list --branch "$BRANCH" \
-  --workflow backend-ci.yml --limit 1 --json databaseId -q '.[0].databaseId' || true)
-
-if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-  echo "Annotations에서 실패 정보를 가져올 수 없습니다. 로그를 직접 확인해주세요."
-  exit 0
-fi
-
-LOG_LINES=$(gh run view "${RUN_ID}" --log-failed 2>/dev/null \
-  | grep -E "(FAILED|MethodSource|expected:|but was:)" || true)
-
-if [ -z "$LOG_LINES" ]; then
-  echo "Annotations에서 실패 정보를 가져올 수 없습니다. 로그를 직접 확인해주세요."
-  exit 0
-fi
-
-echo "$LOG_LINES" | head -80
+echo "$PARSED"


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (`dev`)

# 🔥 연관 이슈

- close #1521

# 🚀 작업 내용

1. `fetch-failures.sh` 재작성 — `/ci-fix`가 실패 테스트를 감지하지 못하던 문제 해결
   - **원인**: 스크립트가 `Backend Test Results` 체크런을 먼저 찾고 없으면 즉시 종료해, 하단의 run-log 폴백에 도달하지 못함. dorny/test-reporter는 결과를 job summary에만 쓰고 이 체크런을 생성하지 않음(성공·실패 런 모두 없음을 확인). job summary 텍스트는 공개 REST API로도 못 가져옴.
   - **해결**: `backend-ci.yml` 런의 `status`/`conclusion`을 조회해 실행중·성공·실패를 분기하고, 실패 시 `--log-failed` 로그의 gradle JUnit 출력을 awk로 파싱해 `<Suite> > <test>() FAILED` + 다음 줄 예외·위치 + 집계를 추출.
2. 파싱 함정 처리 — macOS BSD sed의 `\t` 미인식(awk 내부에서 타임스탬프 기준 프리픽스 제거), `> Task :game:test FAILED`(gradle 태스크 실패) 제외 위해 `()` 있는 테스트 메서드만 매칭, 테스트 외 실패는 로그 tail로 안내.
3. `SKILL.md` Step 1–2를 새 동작에 맞게 갱신.

# 💬 리뷰 중점사항

- 실제 검증: 실패 PR #1518 → 실패 테스트(`BlindTimerGameIntegrationTest`)·위치·집계 정상 추출 / 성공 PR #1520 → "CI가 통과 상태입니다". `bash -n`·markdownlint 통과.
- awk의 실패 라인 파싱 정규식(`> .+\(\) FAILED$`, ` at .+\.java:[0-9]+`)이 다른 실패 유형(파라미터화 테스트 등)에서도 견고한지 검토 요청.
