### PR TITLE
[fix] prod OAuth 로그인 장애 핫픽스 — internal-proxies /24→사설 대역 전체

### DIFF
--- a/backend/app/src/main/resources/application-prod.yml
+++ b/backend/app/src/main/resources/application-prod.yml
@@ -33,4 +33,8 @@ springdoc:
 server:
   tomcat:
     remoteip:
-      internal-proxies: "172\\.20\\.0\\.\\d{1,3}"
+      # zzol-network 는 172.20.0.0/16 이라 nginx IP 가 172.20.0.x 밖으로 재할당될 수 있다.
+      # 좁은 /24 로 잡으면 X-Forwarded-Proto 가 무시돼 {baseUrl} 이 http 로 떨어지고
+      # OAuth redirect_uri(https) 불일치로 카카오 KOE006·구글 로그인이 실패한다(#1537).
+      # dev 와 동일하게 사설 대역(RFC1918) 전체를 신뢰한다.
+      internal-proxies: "127\\.0\\.0\\.1|10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.(1[6-9]|2[0-9]|3[0-1])\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}"


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 확인 — base: `be/prod` (프로덕션 핫픽스)

# 🔥 연관 이슈

- close #1537

# 🚀 작업 내용

1. `application-prod.yml`의 `server.tomcat.remoteip.internal-proxies`를 `172\.20\.0\.\d{1,3}`(172.20.0.0/**24**)에서 dev와 동일한 사설 대역(RFC1918) 전체로 확장 (커밋 1개, 파일 1개).

# 💬 리뷰 중점사항

**프로덕션 장애 핫픽스입니다.** prod에서 카카오 로그인이 KOE006, 구글 로그인도 함께 실패 중입니다.

**원인**: 카카오·구글에 보내는 redirect_uri는 Spring Security의 `{baseUrl}/login/oauth2/code/{registrationId}` 템플릿이고, `{baseUrl}`은 요청 scheme·host로 결정됩니다. nginx 뒤 prod에서 `X-Forwarded-Proto: https`를 Tomcat이 신뢰하려면 프록시 IP가 `internal-proxies`에 매치돼야 하는데, 이 정규식이 `172.20.0.0/24`만 커버합니다. 실제 `zzol-network`는 **172.20.0.0/16**이라(서버 `docker network inspect`로 확인) 컨테이너 IP가 `172.20.0.x`를 벗어나면 forwarded 헤더가 무시되고 `{baseUrl}`이 `http`로 떨어져 redirect_uri 불일치 → 전 provider 로그인 실패. dev는 이미 사설 대역 전체를 신뢰해 정상입니다.

**해결**: prod 신뢰 대역을 dev와 동일하게 맞춰 컨테이너 IP 재할당에도 견고하게 만듭니다.

**참고**:
- 이 핫픽스는 `dev`에도 동일 내용이 PR #1538로 반영돼 있습니다(sync 유지). 본 PR은 backend-cd 배포 대상인 `be/prod`에 최소 변경만 반영하기 위한 것입니다.
- 병행 확인(코드 밖): 카카오·구글 콘솔에 `https://api.zzol.site/login/oauth2/code/{kakao,google}` 정확 등록 여부.
