### PR TITLE
[fix] eslint-plugin-react-hooks v7 업그레이드로 인한 CI 린트 실패 해결

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "eslint-plugin-jest": "^29.15.2",
         "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "eslint-plugin-storybook": "^9.0.16",
         "globals": "^16.3.0",
@@ -11041,16 +11041,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -12490,6 +12497,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -21737,6 +21761,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-jest": "^29.15.2",
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "eslint-plugin-storybook": "^9.0.16",
     "globals": "^16.3.0",

--- a/frontend/src/apis/rest/useFetch.ts
+++ b/frontend/src/apis/rest/useFetch.ts
@@ -59,6 +59,8 @@ const useFetch = <T>(options: UseFetchOptions<T>): UseFetchReturn<T> => {
 
   useEffect(() => {
     if (enabled) {
+      // 데이터 페칭은 정당한 effect 부수효과 — 시작 시 loading/error 상태 반영이 동반된다.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchData();
     }
   }, [enabled, fetchData]);

--- a/frontend/src/apis/rest/useMutation.ts
+++ b/frontend/src/apis/rest/useMutation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from './api';
 import { ErrorDisplayMode } from './error';
 import { Method } from './apiRequest';
@@ -33,8 +33,10 @@ const useMutation = <TData = unknown, TVariables = void>(
   const onSuccessRef = useRef(onSuccess);
   const onErrorRef = useRef(onError);
 
-  onSuccessRef.current = onSuccess;
-  onErrorRef.current = onError;
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  });
 
   const mutate = useCallback(
     async (variables: TVariables): Promise<TData | undefined> => {

--- a/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
+++ b/frontend/src/apis/websocket/contexts/UserSocketProvider.tsx
@@ -44,6 +44,8 @@ export const UserSocketProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (isAuthenticated) {
+      // STOMP 연결은 정당한 effect 부수효과(client/연결 상태 setState 동반).
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       connect();
     } else {
       void disconnect();

--- a/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
+++ b/frontend/src/apis/websocket/hooks/useWebSocketSubscription.ts
@@ -19,6 +19,7 @@ export const useWebSocketSubscription = <T>(
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onDataRef = useRef(onData);
+  const trySubscribeRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     onDataRef.current = onData;
@@ -82,13 +83,17 @@ export const useWebSocketSubscription = <T>(
         retryCountRef.current += 1;
         retryTimerRef.current = setTimeout(() => {
           console.log(`⏳ ${destination} 재시도 (${retryCountRef.current}회차)...`);
-          trySubscribe();
+          trySubscribeRef.current();
         }, delay);
       } else {
         console.error(`🚫 ${destination} 구독 재시도 횟수 초과 (${MAX_RETRY_COUNT}회)`);
       }
     }
   }, [enabled, isVisible, isConnected, destination, onData, onError, sessionId, subscribe]);
+
+  useEffect(() => {
+    trySubscribeRef.current = trySubscribe;
+  }, [trySubscribe]);
 
   const doSubscribe = useCallback(() => {
     if (!sessionId) return;

--- a/frontend/src/components/@common/Portal/Portal.ts
+++ b/frontend/src/components/@common/Portal/Portal.ts
@@ -10,6 +10,8 @@ const Portal = ({ children, containerId }: Props) => {
 
   useEffect(() => {
     const targetContainer = containerId ? document.getElementById(containerId) : document.body;
+    // Portal 대상 DOM 은 마운트 이후에 확정되므로 effect 에서 설정한다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setContainer(targetContainer);
   }, [containerId]);
 

--- a/frontend/src/devtools/autoTest/components/IframePreviewToggle/IframePreviewToggle.tsx
+++ b/frontend/src/devtools/autoTest/components/IframePreviewToggle/IframePreviewToggle.tsx
@@ -65,11 +65,13 @@ const IframePreviewToggle = () => {
     resume: handleResumeTest,
   } = autoTestControls;
 
-  useEffect(() => {
-    // 경로가 바뀌면 닫아준다 (예상치 못한 잔상 방지)
+  // 경로가 바뀌면 닫아준다 (예상치 못한 잔상 방지) — 렌더 중 state 조정.
+  const [prevPathname, setPrevPathname] = useState(location.pathname);
+  if (location.pathname !== prevPathname) {
+    setPrevPathname(location.pathname);
     setOpen(false);
     setExpanded(false);
-  }, [location.pathname, setExpanded]);
+  }
 
   if (!topWindow || !isRootPath || isTouchDevice) return null;
 

--- a/frontend/src/devtools/networkDebug/hooks/useNetworkCollector.ts
+++ b/frontend/src/devtools/networkDebug/hooks/useNetworkCollector.ts
@@ -68,6 +68,7 @@ const getAllCollectors = (): NetworkCollector[] => {
 
 export const useNetworkCollector = () => {
   const [requests, setRequests] = useState<NetworkRequest[]>([]);
+  const [collectors, setCollectors] = useState<NetworkCollector[]>([]);
   const collectorsRef = useRef<NetworkCollector[]>([]);
   const unsubscribeFunctionsRef = useRef<(() => void)[]>([]);
   const initialRequestIdsRef = useRef<Set<string>>(new Set());
@@ -131,6 +132,7 @@ export const useNetworkCollector = () => {
     });
 
     collectorsRef.current = collectors;
+    setCollectors(collectors);
   }, []);
 
   useEffect(() => {
@@ -138,6 +140,8 @@ export const useNetworkCollector = () => {
 
     // 초기 collector 수집 및 구독
     const initialCollectors = getAllCollectors();
+    // 외부 시스템(collector) 구독 설정 부수효과 — 초기 요청 목록 반영이 동반된다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setupCollectors(initialCollectors);
 
     // 주기적으로 iframe 확인 (동적으로 추가되는 iframe 대응)
@@ -214,6 +218,6 @@ export const useNetworkCollector = () => {
     requests,
     clearRequests,
     refreshRequests,
-    collectors: collectorsRef.current,
+    collectors,
   };
 };

--- a/frontend/src/features/friends/contexts/FriendsProvider.tsx
+++ b/frontend/src/features/friends/contexts/FriendsProvider.tsx
@@ -35,10 +35,13 @@ export const FriendsProvider = ({ children }: PropsWithChildren) => {
   // 로그인 해제 시 상태 초기화
   useEffect(() => {
     if (!isAuthenticated) {
+      // 로그아웃 시 상태·ref 초기화 — ref 리셋이 포함되어 렌더 단계로 옮길 수 없다.
+      /* eslint-disable react-hooks/set-state-in-effect */
       setFriends([]);
       setReceivedRequests([]);
       setSentRequests([]);
       setIsFriendsLoaded(false);
+      /* eslint-enable react-hooks/set-state-in-effect */
       initialLoadDoneRef.current = false;
     }
   }, [isAuthenticated]);

--- a/frontend/src/features/home/components/DashBoard/LowestProbabilitySlide/LowestProbabilitySlide.tsx
+++ b/frontend/src/features/home/components/DashBoard/LowestProbabilitySlide/LowestProbabilitySlide.tsx
@@ -16,6 +16,8 @@ const LowestProbabilitySlide = ({ players, probability }: Props) => {
     if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
 
     if (probability === 0) {
+      // 확률 0: 이 effect 는 rAF 게이지 애니메이션 담당 — 애니메이션 없이 100%로 리셋.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDisplayPct(100.0);
       return;
     }

--- a/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
+++ b/frontend/src/features/home/components/FriendsTab/SearchPanel.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ApiError } from '@/apis/rest/error';
 import useToast from '@/components/@common/Toast/useToast';
 import { friendsApi } from '@/features/friends/api/friendsApi';
@@ -29,9 +29,12 @@ const ActionButton = ({ user, onRelationChange }: ActionProps) => {
   const [localStatus, setLocalStatus] = useState<RelationStatus>(user.relationStatus);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
+  // prop 변경 시 로컬 상태를 재동기화한다(렌더 중 state 조정 — 가드로 1회만).
+  const [prevRelationStatus, setPrevRelationStatus] = useState(user.relationStatus);
+  if (user.relationStatus !== prevRelationStatus) {
+    setPrevRelationStatus(user.relationStatus);
     setLocalStatus(user.relationStatus);
-  }, [user.relationStatus]);
+  }
 
   const incomingRequest = receivedRequests.find((r) => r.userId === user.userId);
 
@@ -171,9 +174,12 @@ type Props = {
 const SearchPanel = ({ results, loading }: Props) => {
   const [localResults, setLocalResults] = useState(results);
 
-  useEffect(() => {
+  // 검색 결과 prop 변경 시 로컬 상태를 재동기화한다(렌더 중 state 조정).
+  const [prevResults, setPrevResults] = useState(results);
+  if (results !== prevResults) {
+    setPrevResults(results);
     setLocalResults(results);
-  }, [results]);
+  }
 
   const handleRelationChange = useCallback((userId: number, status: RelationStatus) => {
     setLocalResults((prev) =>

--- a/frontend/src/features/home/components/RankingTab/RankingAccordionItem.tsx
+++ b/frontend/src/features/home/components/RankingTab/RankingAccordionItem.tsx
@@ -1,7 +1,7 @@
 import useLazyFetch from '@/apis/rest/useLazyFetch';
 import RankingItem from '@/components/@common/RankingItem/RankingItem';
 import { useMockMode } from '@/hooks/useMockMode';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { RankingCategory } from '../../config/rankingConfigs';
 import * as S from './RankingTab.styled';
 
@@ -16,10 +16,13 @@ const RankingAccordionItem = ({ category }: Props) => {
   const [items, setItems] = useState<ReturnType<RankingCategory['transformData']>>([]);
   const bodyRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  // mock 모드 전환 시 로드된 항목·열림 상태를 리셋한다(렌더 중 state 조정).
+  const [prevMockEnabled, setPrevMockEnabled] = useState(mockEnabled);
+  if (mockEnabled !== prevMockEnabled) {
+    setPrevMockEnabled(mockEnabled);
     setItems([]);
     setIsOpen(false);
-  }, [mockEnabled]);
+  }
 
   const handleTransitionEnd = () => {
     if (!isOpen || !bodyRef.current) return;

--- a/frontend/src/features/home/hooks/useFriendSearch.ts
+++ b/frontend/src/features/home/hooks/useFriendSearch.ts
@@ -39,7 +39,6 @@ export const useFriendSearch = () => {
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (!searchQuery.trim()) {
-      setSearchResults([]);
       return () => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
       };
@@ -56,6 +55,8 @@ export const useFriendSearch = () => {
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = searchMode === '유저코드' ? e.target.value.toUpperCase() : e.target.value;
     setSearchQuery(value);
+    // 입력이 비워지면 이전 검색 결과를 즉시 지운다(재입력 시 잔상 방지).
+    if (!value.trim()) setSearchResults([]);
   };
 
   const handleModeChange = (mode: SearchMode) => {

--- a/frontend/src/features/home/pages/HomePage.tsx
+++ b/frontend/src/features/home/pages/HomePage.tsx
@@ -14,7 +14,9 @@ import Splash from '../components/Splash/Splash';
 import * as S from './HomePage.styled';
 
 const HomePage = () => {
-  const [showSplash, setShowSplash] = useState(false);
+  const [showSplash, setShowSplash] = useState(
+    () => !storageManager.getItem(STORAGE_KEYS.VISITED, 'sessionStorage')
+  );
   const [activeTab, setActiveTab] = useState<HomeTabType>('home');
   const [menuInitialView, setMenuInitialView] = useState<MenuView | null>(null);
   const { clearIdentifier } = useIdentifier();
@@ -27,18 +29,16 @@ const HomePage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 메뉴 탭을 벗어나면 initialView 초기화 (다음 번 직접 진입 시 루트 메뉴로 복귀)
+  // 첫 방문 판별(위 lazy 초기화) 후 방문 기록을 남긴다 — setState 없는 순수 부수효과.
   useEffect(() => {
-    if (activeTab !== 'menu') setMenuInitialView(null);
-  }, [activeTab]);
-
-  useEffect(() => {
-    const hasVisited = storageManager.getItem(STORAGE_KEYS.VISITED, 'sessionStorage');
-    if (!hasVisited) {
-      setShowSplash(true);
-      storageManager.setItem(STORAGE_KEYS.VISITED, 'true', 'sessionStorage');
-    }
+    storageManager.setItem(STORAGE_KEYS.VISITED, 'true', 'sessionStorage');
   }, []);
+
+  // 메뉴 탭을 벗어나면 initialView 초기화 (다음 번 직접 진입 시 루트 메뉴로 복귀)
+  const handleTabChange = (tab: HomeTabType) => {
+    if (tab !== 'menu') setMenuInitialView(null);
+    setActiveTab(tab);
+  };
 
   if (showSplash) {
     return <Splash onComplete={() => setShowSplash(false)} />;
@@ -70,7 +70,7 @@ const HomePage = () => {
       </S.ScrollArea>
       <HomeBottomTab
         activeTab={activeTab}
-        onTabChange={setActiveTab}
+        onTabChange={handleTabChange}
         friendsBadgeCount={pendingReceivedCount}
       />
     </S.PageContainer>

--- a/frontend/src/features/miniGame/blindTimerGame/pages/BlindTimerGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/blindTimerGame/pages/BlindTimerGamePlayPage.tsx
@@ -3,7 +3,7 @@ import { useIdentifier } from '@/contexts/Identifier/IdentifierContext';
 import { useBlindTimerGame } from '@/contexts/BlindTimerGame/BlindTimerGameContext';
 import { useReplaceNavigate } from '@/hooks/useReplaceNavigate';
 import Layout from '@/layouts/Layout';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PrepareOverlay from '../../components/PrepareOverlay/PrepareOverlay';
 import TargetTime from '../components/TargetTime/TargetTime';
@@ -21,7 +21,7 @@ const BlindTimerGamePlayPage = () => {
   const { miniGameType } = useParams();
 
   const [isStopped, setIsStopped] = useState(false);
-  const stoppedTimeRef = useRef<number | null>(null);
+  const [stoppedTime, setStoppedTime] = useState<number | null>(null);
 
   const isPlaying = gameState === 'PLAYING';
   const { elapsedMs, isBlind, displayTime, formatTime } = useBlindTimer(
@@ -31,7 +31,7 @@ const BlindTimerGamePlayPage = () => {
 
   const handleStop = useCallback(() => {
     if (isStopped || !isPlaying) return;
-    stoppedTimeRef.current = elapsedMs;
+    setStoppedTime(elapsedMs);
     setIsStopped(true);
     sendStop();
   }, [isStopped, isPlaying, elapsedMs, sendStop]);
@@ -42,8 +42,7 @@ const BlindTimerGamePlayPage = () => {
     }
   }, [gameState, joinCode, navigate, miniGameType]);
 
-  const stoppedTimeDisplay =
-    stoppedTimeRef.current !== null ? formatTime(stoppedTimeRef.current) : null;
+  const stoppedTimeDisplay = stoppedTime !== null ? formatTime(stoppedTime) : null;
 
   return (
     <Layout>

--- a/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
@@ -4,7 +4,7 @@ import {
   FallingPiece,
   StackedBlock,
 } from '@/types/miniGame/blockStackingGame';
-import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   BLOCK_COLORS,
   BLOCK_GAP,
@@ -196,7 +196,8 @@ export const useBlockStackingGame = (
   const onBlockPlacedRef = useRef(onBlockPlaced);
   const onFailRef = useRef(onFail);
   const isLocalGameOverRef = useRef(isLocalGameOver);
-  useEffect(() => {
+  // rAF 그리기 루프가 페인트 전에 최신값을 읽어야 하므로(원래 렌더 중 동기 갱신) useLayoutEffect 로 커밋 시 동기 반영한다.
+  useLayoutEffect(() => {
     gameStateRef.current = gameState;
     soundsRef.current = sounds;
     setLocalGameOverRef.current = setLocalGameOver;

--- a/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingGame.ts
@@ -191,17 +191,19 @@ export const useBlockStackingGame = (
   // --- 2. Closure Avoidance (클로저 문제 해결) ---
   // 아래 Ref들은 handleTap이나 루프 내부에서 최신 Props/Callbacks에 접근할 수 있게 합니다.
   const gameStateRef = useRef(gameState);
-  gameStateRef.current = gameState;
   const soundsRef = useRef(sounds);
-  soundsRef.current = sounds;
   const setLocalGameOverRef = useRef(setLocalGameOver);
-  setLocalGameOverRef.current = setLocalGameOver;
   const onBlockPlacedRef = useRef(onBlockPlaced);
-  onBlockPlacedRef.current = onBlockPlaced;
   const onFailRef = useRef(onFail);
-  onFailRef.current = onFail;
   const isLocalGameOverRef = useRef(isLocalGameOver);
-  isLocalGameOverRef.current = isLocalGameOver;
+  useEffect(() => {
+    gameStateRef.current = gameState;
+    soundsRef.current = sounds;
+    setLocalGameOverRef.current = setLocalGameOver;
+    onBlockPlacedRef.current = onBlockPlaced;
+    onFailRef.current = onFail;
+    isLocalGameOverRef.current = isLocalGameOver;
+  });
 
   // --- 3. Game Actions (주요 액션 함수) ---
 

--- a/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingSounds.ts
+++ b/frontend/src/features/miniGame/blockStackingGame/hooks/useBlockStackingSounds.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type BlockStackingSounds = {
   ensureAudioContext: () => void;
@@ -44,7 +44,9 @@ export const useBlockStackingSounds = (): BlockStackingSounds => {
 
   const audioCtxRef = useRef<AudioContext | null>(null);
   const mutedRef = useRef(muted);
-  mutedRef.current = muted;
+  useEffect(() => {
+    mutedRef.current = muted;
+  });
 
   const ensureAudioContext = useCallback(() => {
     if (mutedRef.current) return;

--- a/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
+++ b/frontend/src/features/miniGame/cardGame/components/CircularProgress/CircularProgress.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import * as S from './CircularProgress.styled';
 
 type Props = {
@@ -12,23 +11,12 @@ const RADIUS = 45;
 const circumference = 2 * Math.PI * RADIUS;
 
 const CircularProgress = ({ current, total, size = '2rem', isActive = true }: Props) => {
-  const [strokeDashoffset, setStrokeDashoffset] = useState(0);
-
-  useEffect(() => {
-    if (!isActive) {
-      setStrokeDashoffset(0);
-      return;
-    }
-
-    if (total <= 0) {
-      setStrokeDashoffset(circumference);
-      return;
-    }
-
-    const progress = Math.min(1, (total - current + 1) / total);
-    const newStrokeDashoffset = circumference * progress;
-    setStrokeDashoffset(newStrokeDashoffset);
-  }, [current, total, isActive]);
+  // props에서 직접 파생한다(값 변경 시 CSS transition 으로 애니메이션됨).
+  const strokeDashoffset = !isActive
+    ? 0
+    : total <= 0
+      ? circumference
+      : circumference * Math.min(1, (total - current + 1) / total);
 
   return (
     <S.Container $size={size}>

--- a/frontend/src/features/miniGame/cardGame/hooks/useCardGameTimer.ts
+++ b/frontend/src/features/miniGame/cardGame/hooks/useCardGameTimer.ts
@@ -19,8 +19,9 @@ export const useCardGameTimer = () => {
   }, [currentTime, isTimerActive]);
 
   // 게임 상태·라운드 전환 시 타이머를 리셋한다(렌더 중 state 조정 — 가드로 전환 시 1회만).
+  // sentinel('')로 초기화해 마운트 시(예: PLAYING 상태로 재진입)에도 1회 실행되도록 한다.
   const stateKey = `${currentCardGameState}:${currentRound}`;
-  const [prevStateKey, setPrevStateKey] = useState(stateKey);
+  const [prevStateKey, setPrevStateKey] = useState('');
   if (stateKey !== prevStateKey) {
     setPrevStateKey(stateKey);
     if (currentCardGameState === 'PREPARE') {

--- a/frontend/src/features/miniGame/cardGame/hooks/useCardGameTimer.ts
+++ b/frontend/src/features/miniGame/cardGame/hooks/useCardGameTimer.ts
@@ -18,21 +18,19 @@ export const useCardGameTimer = () => {
     return () => clearTimeout(timer);
   }, [currentTime, isTimerActive]);
 
-  useEffect(() => {
-    const isPrepareState = currentCardGameState === 'PREPARE';
-    const isPlayingState = currentCardGameState === 'PLAYING';
-
-    if (isPrepareState) {
+  // 게임 상태·라운드 전환 시 타이머를 리셋한다(렌더 중 state 조정 — 가드로 전환 시 1회만).
+  const stateKey = `${currentCardGameState}:${currentRound}`;
+  const [prevStateKey, setPrevStateKey] = useState(stateKey);
+  if (stateKey !== prevStateKey) {
+    setPrevStateKey(stateKey);
+    if (currentCardGameState === 'PREPARE') {
       setCurrentTime(ROUND_TOTAL_TIME);
       setIsTimerActive(false);
-      return;
-    }
-
-    if (isPlayingState) {
+    } else if (currentCardGameState === 'PLAYING') {
       setCurrentTime(ROUND_TOTAL_TIME);
       setIsTimerActive(true);
     }
-  }, [currentCardGameState, currentRound]);
+  }
 
   return {
     currentTime,

--- a/frontend/src/features/miniGame/ladderGame/pages/LadderGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/ladderGame/pages/LadderGamePlayPage.tsx
@@ -18,18 +18,17 @@ const TimerBar = ({ endTimeEpochMs }: TimerBarProps) => {
 
   useEffect(() => {
     endTimeRef.current = endTimeEpochMs;
+    // 총 길이(분모)는 서버가 정하는 종료 시각이 바뀔 때마다 재계산해야 한다 — 렌더 순수성을 위해 effect 에서 파생.
+    if (endTimeEpochMs) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTotalTimeSec(Math.max(1, endTimeEpochMs - Date.now()) / 1000);
+    }
   }, [endTimeEpochMs]);
 
   useEffect(() => {
     let rafId: number;
-    let totalSec = 0;
     const tick = () => {
       if (endTimeRef.current !== null) {
-        // 총 길이(분모)는 첫 유효 프레임에 한 번만 확정한다 — rAF 콜백이므로 렌더 순수성에 영향 없음.
-        if (totalSec === 0) {
-          totalSec = Math.max(1, endTimeRef.current - Date.now()) / 1000;
-          setTotalTimeSec(totalSec);
-        }
         const remaining = Math.max(0, (endTimeRef.current - Date.now()) / 1000);
         setTimeLeft(remaining);
         if (remaining > 0) {

--- a/frontend/src/features/miniGame/ladderGame/pages/LadderGamePlayPage.tsx
+++ b/frontend/src/features/miniGame/ladderGame/pages/LadderGamePlayPage.tsx
@@ -13,22 +13,23 @@ type TimerBarProps = { endTimeEpochMs: number | null };
 
 const TimerBar = ({ endTimeEpochMs }: TimerBarProps) => {
   const [timeLeft, setTimeLeft] = useState(0);
-  const totalMsRef = useRef<number>(1);
+  const [totalTimeSec, setTotalTimeSec] = useState(0.001);
   const endTimeRef = useRef<number | null>(endTimeEpochMs);
 
   useEffect(() => {
     endTimeRef.current = endTimeEpochMs;
-    if (endTimeEpochMs) {
-      totalMsRef.current = Math.max(1, endTimeEpochMs - Date.now());
-    } else {
-      setTimeLeft(0);
-    }
   }, [endTimeEpochMs]);
 
   useEffect(() => {
     let rafId: number;
+    let totalSec = 0;
     const tick = () => {
-      if (endTimeRef.current !== null && totalMsRef.current > 0) {
+      if (endTimeRef.current !== null) {
+        // 총 길이(분모)는 첫 유효 프레임에 한 번만 확정한다 — rAF 콜백이므로 렌더 순수성에 영향 없음.
+        if (totalSec === 0) {
+          totalSec = Math.max(1, endTimeRef.current - Date.now()) / 1000;
+          setTotalTimeSec(totalSec);
+        }
         const remaining = Math.max(0, (endTimeRef.current - Date.now()) / 1000);
         setTimeLeft(remaining);
         if (remaining > 0) {
@@ -45,7 +46,7 @@ const TimerBar = ({ endTimeEpochMs }: TimerBarProps) => {
 
   return (
     <S.TimerBarWrapper>
-      <S.TimerBarFill $timeLeft={timeLeft} $totalTime={totalMsRef.current / 1000} />
+      <S.TimerBarFill $timeLeft={timeLeft} $totalTime={totalTimeSec} />
     </S.TimerBarWrapper>
   );
 };

--- a/frontend/src/features/miniGame/nunchiGame/components/NunchiEliminatedOverlay/NunchiEliminatedOverlay.tsx
+++ b/frontend/src/features/miniGame/nunchiGame/components/NunchiEliminatedOverlay/NunchiEliminatedOverlay.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 import { useNunchiGameContext } from '@/contexts/NunchiGame/NunchiGameContext';
 import * as S from './NunchiEliminatedOverlay.styled';
 
@@ -13,20 +13,21 @@ const NunchiEliminatedOverlay = () => {
   const { myInputState, currentNumber } = useNunchiGameContext();
 
   // 충돌 시점의 숫자를 고정한다 — 생존자가 이어가면 currentNumber 가 뒤에서 바뀌므로.
-  const collisionNumberRef = useRef<number | null>(null);
-  if (myInputState === 'COLLIDED' && collisionNumberRef.current === null) {
-    collisionNumberRef.current = currentNumber;
+  // 렌더 중 state 조정(React 공식 패턴): 가드로 첫 충돌 시 1회만 캡처한다.
+  const [collisionNumber, setCollisionNumber] = useState<number | null>(null);
+  if (myInputState === 'COLLIDED' && collisionNumber === null) {
+    setCollisionNumber(currentNumber);
   }
 
   if (myInputState !== 'COLLIDED') return null;
 
-  const collisionNumber = collisionNumberRef.current ?? currentNumber;
+  const displayNumber = collisionNumber ?? currentNumber;
 
   return (
     <S.Backdrop role="alert">
       <S.Stamp>탈락</S.Stamp>
       <S.Message>
-        <S.Headline>{collisionNumber}에서 같이 일어섰어요</S.Headline>
+        <S.Headline>{displayNumber}에서 같이 일어섰어요</S.Headline>
         <S.Sub>결과 화면에서 다시 만나요</S.Sub>
       </S.Message>
     </S.Backdrop>

--- a/frontend/src/features/miniGame/nunchiGame/hooks/useNunchiCountdown.ts
+++ b/frontend/src/features/miniGame/nunchiGame/hooks/useNunchiCountdown.ts
@@ -47,5 +47,7 @@ export const useNunchiCountdown = (
   }, [deadlineEpochMs, serverOffsetMs, enabled]);
 
   if (!enabled || deadlineEpochMs == null) return 0;
+  // 렌더 시점 Date.now() 계산은 상단 주석대로 게이지 깜빡임을 없애기 위한 의도된 설계다.
+  // eslint-disable-next-line react-hooks/purity
   return Math.max(0, deadlineEpochMs - (Date.now() + serverOffsetMs));
 };

--- a/frontend/src/features/miniGame/racingGame/components/RacingRanks/RacingRanks.tsx
+++ b/frontend/src/features/miniGame/racingGame/components/RacingRanks/RacingRanks.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useState } from 'react';
 import RankItem from '../RankItem/RankItem';
 import * as S from './RacingRanks.styled';
 
@@ -14,26 +14,28 @@ type Props = {
 };
 
 const RacingRanks = ({ players, myName, endDistance }: Props) => {
-  const finishOrderRef = useRef<Player[]>([]);
+  const [finishOrder, setFinishOrder] = useState<Player[]>([]);
+
+  // 결승선 통과 순서를 렌더 중 누적한다(React 공식 "렌더 중 state 조정" 패턴).
+  // 새 통과자가 있을 때만 setState → 즉시 재렌더 후 통과자 목록이 비어 무한 루프가 없다.
+  const newFinishers = players.filter(
+    ({ playerName, position }) =>
+      position >= endDistance && !finishOrder.some((player) => player.playerName === playerName)
+  );
+  if (newFinishers.length > 0) {
+    setFinishOrder((prev) => [
+      ...prev,
+      ...newFinishers.map(({ playerName, position }) => ({ playerName, position })),
+    ]);
+  }
 
   const rankedPlayers = useMemo(() => {
-    const finishOrder = finishOrderRef.current;
-
-    players.forEach(({ playerName, position }) => {
-      if (
-        position >= endDistance &&
-        !finishOrder.some((player) => player.playerName === playerName)
-      ) {
-        finishOrder.push({ playerName, position });
-      }
-    });
-
     const unFinishedSortedPlayers = players
       .filter((player) => !finishOrder.some((p) => p.playerName === player.playerName))
       .sort((a, b) => b.position - a.position);
 
     return [...finishOrder, ...unFinishedSortedPlayers];
-  }, [players, endDistance]);
+  }, [players, finishOrder]);
 
   return (
     <S.Container>

--- a/frontend/src/features/room/lobby/components/InvitationModal/useInvitationModalScreenReader.ts
+++ b/frontend/src/features/room/lobby/components/InvitationModal/useInvitationModalScreenReader.ts
@@ -5,6 +5,8 @@ export const useInvitationModalScreenReader = (timeout = 3000) => {
   const [message, setMessage] = useState<string>('');
 
   useEffect(() => {
+    // aria-live 영역: 빈 문자열→안내문 전환이 스크린리더 낭독을 트리거하므로 effect 에서 설정한다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMessage('친구 초대하기 모달입니다. QR 코드 또는 초대코드를 복사하여 친구들을 초대해보아요.');
     if (screenReaderRef.current) {
       screenReaderRef.current.focus();

--- a/frontend/src/features/room/lobby/components/MiniGameSection/useMiniGameScreenReader.ts
+++ b/frontend/src/features/room/lobby/components/MiniGameSection/useMiniGameScreenReader.ts
@@ -6,6 +6,8 @@ export const useMiniGameScreenReader = (loading: boolean, hasMiniGames: boolean)
 
   useEffect(() => {
     if (!loading && hasMiniGames) {
+      // aria-live 영역 낭독 트리거를 위해 effect 에서 안내문을 설정한다.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setMessage('미니게임 선택 영역입니다. 원하는 미니게임을 여러 개 선택할 수 있습니다.');
     }
   }, [loading, hasMiniGames]);

--- a/frontend/src/features/room/lobby/components/RouletteSection/useRouletteScreenReader.ts
+++ b/frontend/src/features/room/lobby/components/RouletteSection/useRouletteScreenReader.ts
@@ -8,6 +8,8 @@ export const useRouletteScreenReader = (playerProbabilities: PlayerProbability[]
     const initialMessage = `룰렛 화면입니다. 미니게임을 통해 당첨 확률이 조정됩니다. ${formatProbabilitiesForScreenReader(
       playerProbabilities
     )}`;
+    // aria-live 영역: 확률 변경 시 낭독 트리거를 위해 effect 에서 메시지를 갱신한다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMessage(initialMessage);
   }, [playerProbabilities]);
 

--- a/frontend/src/features/room/lobby/components/RouletteSettingsModal/RouletteSettingsModal.tsx
+++ b/frontend/src/features/room/lobby/components/RouletteSettingsModal/RouletteSettingsModal.tsx
@@ -1,5 +1,5 @@
 import Modal from '@/components/@common/Modal/Modal';
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 import useUpdateAdjustmentWeight from '../../hooks/useUpdateAdjustmentWeight';
 import * as S from './RouletteSettingsModal.styled';
 
@@ -23,11 +23,12 @@ const RouletteSettingsModal = ({
 }: Props) => {
   const [weight, setWeight] = useState(currentWeight);
 
-  useEffect(() => {
-    if (isOpen) {
-      setWeight(currentWeight);
-    }
-  }, [isOpen, currentWeight]);
+  // 모달이 열려 있는 동안 isOpen/currentWeight 변화 시 weight 를 재설정한다(렌더 중 state 조정).
+  const [syncKey, setSyncKey] = useState({ isOpen, currentWeight });
+  if (isOpen !== syncKey.isOpen || currentWeight !== syncKey.currentWeight) {
+    setSyncKey({ isOpen, currentWeight });
+    if (isOpen) setWeight(currentWeight);
+  }
 
   const handleSuccess = useCallback(() => {
     onSave?.(weight);

--- a/frontend/src/features/room/lobby/hooks/useGameAnnouncement.ts
+++ b/frontend/src/features/room/lobby/hooks/useGameAnnouncement.ts
@@ -39,6 +39,8 @@ export const useGameAnnouncement = ({
       return;
     }
 
+    // aria-live 영역 낭독: 준비 상태 전환에 반응하는 a11y 안내(디바운스 타이머 포함)라 effect 에서 호출한다.
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (!previousReadyStateRef.current && isAllReady) {
       if (playerType === 'HOST') {
         announce('모든 참가자가 준비되었습니다. 게임 시작 버튼을 눌러주세요.');
@@ -48,6 +50,7 @@ export const useGameAnnouncement = ({
     } else if (previousReadyStateRef.current && !isAllReady) {
       announce('참가자 중 누군가 준비를 취소했습니다.');
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
 
     previousReadyStateRef.current = isAllReady;
   }, [isAllReady, playerType, announce]);

--- a/frontend/src/features/roulette/hooks/useRouletteTransition.ts
+++ b/frontend/src/features/roulette/hooks/useRouletteTransition.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { RouletteSector, PlayerProbability } from '@/types/roulette';
 import { convertProbabilitiesToAngles, interpolateAngles } from '../utils';
 
@@ -19,8 +19,10 @@ export const useRouletteTransition = (
 
   const prevRef = useRef<PlayerProbability[]>([]);
   const currentRef = useRef<PlayerProbability[]>([]);
-  prevRef.current = prev || [];
-  currentRef.current = current || [];
+  useEffect(() => {
+    prevRef.current = prev || [];
+    currentRef.current = current || [];
+  });
 
   const startAnimationTransition = useCallback(() => {
     if (!prev || !current || prev.length === 0 || current.length === 0) {


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (base: `dev`)

# 🔥 연관 이슈

- 없음
- 참고: dependabot PR #1530 의 CI 실패를 해결하는 PR입니다. 의존성 업그레이드(`eslint-plugin-react-hooks` 7.1.1)와 그로 인한 린트 수정을 함께 담고 있어, #1530 을 대체할 수 있습니다.

# 🚀 작업 내용

`eslint-plugin-react-hooks` 를 5.2.0 → **7.1.1** 로 올리면서 v7 의 `recommended` 규칙(React Compiler 계열)이 새로 켜졌고, 기존 코드가 이를 위반해 Frontend CI 의 `lint` 단계가 **47건 에러**로 실패했습니다. 설정이 깨진 게 아니라 린트 규칙이 강화된 것입니다.

**규칙별 위반**: `refs` 24 · `set-state-in-effect` 21 · `immutability` 1 · `purity` 1

수정 방향은 크게 세 가지입니다.

1. **동작을 그대로 두는 리팩터링**
   - 렌더 중 `ref.current = ...` (최신값 보관용) → `useEffect` 로 이동: `useMutation`, `useRouletteTransition`, `useBlockStackingGame`, `useBlockStackingSounds`
   - 렌더 중 `ref.current` 읽기 → `state` 로 전환: `BlindTimerGamePlayPage`(정지 시각), `LadderGamePlayPage`(타이머 총 길이), `useNetworkCollector`(collectors)
   - `useMemo`/렌더 중 값 누적·캡처 → "렌더 중 state 조정"(React 공식 패턴): `RacingRanks`(결승 순서), `NunchiEliminatedOverlay`(충돌 숫자)
   - prop→state 동기화·파생·리셋 정리: `CircularProgress`(순수 계산), `SearchPanel`·`RankingAccordionItem`·`useCardGameTimer`·`RouletteSettingsModal`·`IframePreviewToggle`(렌더 중 state 조정), `HomePage`(스플래시 lazy 초기화 + 탭 변경 핸들러), `useFriendSearch`(빈 검색어 초기화를 입력 핸들러로)
   - 재귀 self-reference 해소: `useWebSocketSubscription`

2. **정당한 부수효과는 사유 주석 + 범위 지정 `eslint-disable`** (억지로 바꾸면 오히려 동작이 깨지는 곳)
   - 데이터 페칭 `useFetch` / STOMP 연결 `UserSocketProvider` / Portal DOM `Portal` / 구독 설정 `useNetworkCollector` / 로그아웃 리셋(ref 포함) `FriendsProvider` / rAF 애니메이션 `LowestProbabilitySlide`
   - 스크린리더 `aria-live` 낭독(빈 문자열→텍스트 전환이 낭독을 트리거하므로 보존 필수): `useInvitationModalScreenReader`, `useMiniGameScreenReader`, `useRouletteScreenReader`, `useGameAnnouncement`
   - 렌더 시점 `Date.now()`(게이지 깜빡임 방지를 위한 의도된 설계, 상단 주석에 명시): `useNunchiCountdown`

3. **자체 코드리뷰에서 발견한 회귀 2건 수정** (커밋 `1a90dbd`)
   - `useCardGameTimer`: 이미 `PLAYING` 상태로 마운트(새로고침·재접속)될 때 타이머가 시작되지 않던 문제 — sentinel 로 초기화해 마운트 시에도 1회 실행되도록 복원
   - `LadderGamePlayPage` 타이머 바: 서버가 종료 시각을 다시 보낼 때 총 길이(게이지 분모)가 갱신되지 않던 문제 — `endTimeEpochMs` 변경 시 재계산

**검증**: `lint`(에러 0/경고 0) · `type-check` · `jest`(10/10) · `build` 모두 로컬 통과.

# 💬 리뷰 중점사항

- **"렌더 중 state 조정" 패턴 도입**: `if (x !== prev) { setPrev(x); ... }` 형태로 여러 곳에 들어갔습니다. 모두 원시값/필드 단위 비교라 setState 후 조건이 거짓이 되어 무한 렌더가 없음을 확인했습니다(특히 `RouletteSettingsModal` 은 객체가 아니라 `isOpen`/`currentWeight` 필드로 비교).
- **`eslint-disable` 선택 기준**: 데이터 페칭·소켓 연결·Portal·구독·스크린리더 낭독처럼 "부수효과 자체가 목적"인 곳만 사유를 달아 억제했습니다. 억지 리팩터링이 접근성(aria-live 낭독)·초기 연결 동작을 깨뜨릴 수 있어 동작 보존을 우선했습니다. 이 부분을 규칙 하향(warn)으로 바꾸는 게 팀 정책에 더 맞다면 알려주세요.
- **미세한 동작 변화 1건**: `CircularProgress`(카드게임 카운트다운 링)는 값은 동일하나, 마운트 시 0에서 차오르던 초기 스윕 애니메이션이 사라집니다(라운드 진행 중 전환 애니메이션은 그대로).
- 게임·소켓·친구 기능은 실제 UI 로 한 번 더 확인해주시면 좋겠습니다(로컬에서 백엔드 연동 UI 검증은 미실시).

---
_Generated by [Claude Code](https://claude.ai/code/session_014r6D66A17PZdahDQKyNXkU)_