### PR TITLE
[refactor] CVE 전이 버전 오버라이드를 버전 카탈로그로 이관

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -9,6 +9,9 @@ group = "coffeeshout"
 version = "0.0.1-SNAPSHOT"
 
 val testcontainersVersion: String = libs.versions.testcontainers.get()
+val tomcatVersion: String = libs.versions.tomcat.get()
+val springSecurityVersion: String = libs.versions.spring.security.get()
+val thymeleafVersion: String = libs.versions.thymeleaf.get()
 
 tasks.register<Exec>("pruneStaleTestContainers") {
     group = "verification"
@@ -28,11 +31,11 @@ subprojects {
     extra["testcontainers.version"] = testcontainersVersion
 
     // CVE-2026-41293 / CVE-2026-43512 / CVE-2026-43515
-    extra["tomcat.version"] = "10.1.55"
+    extra["tomcat.version"] = tomcatVersion
     // CVE-2026-***732
-    extra["spring-security.version"] = "6.5.9"
+    extra["spring-security.version"] = springSecurityVersion
     // CVE-2026-40477 / CVE-2026-40478 / CVE-2026-41901
-    extra["thymeleaf.version"] = "3.1.5.RELEASE"
+    extra["thymeleaf.version"] = thymeleafVersion
 
     // Spring Boot bootJar 기본 비활성화 (라이브러리 모듈은 jar만, :app이 override)
     tasks.named("bootJar") { enabled = false }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -17,6 +17,12 @@ jsqlparser                   = "5.3"
 spring-dotenv                = "5.1.0"
 archunit                     = "1.4.2"
 
+# BOM 관리 전이 의존성의 CVE 패치 오버라이드 — 라이브러리 선언 없이 루트
+# build.gradle.kts subprojects{}의 extra["*.version"]에서 버전만 참조한다.
+tomcat                       = "10.1.55"
+spring-security              = "6.5.9"
+thymeleaf                    = "3.1.5.RELEASE"
+
 [libraries]
 springdoc-openapi            = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui",       version.ref = "spring-doc" }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (base: `dev`)

# 🔥 연관 이슈

- close #1545

# 🚀 작업 내용

루트 `build.gradle.kts`에 문자열로 박혀 있던 CVE 전이 버전 오버라이드 3건을 버전 카탈로그(`gradle/libs.versions.toml`)로 옮겼습니다. 서드파티 버전을 한 파일에서만 관리하려는 것이 목적입니다.

1. `gradle/libs.versions.toml [versions]`에 `tomcat = 10.1.55`, `spring-security = 6.5.9`, `thymeleaf = 3.1.5.RELEASE` 추가 (라이브러리 선언 없이 버전만 두는 항목 — 주석으로 용도 명시)
2. 루트 `build.gradle.kts`에서 상단 val 3개(`tomcatVersion` 등)로 카탈로그 값을 읽고, `subprojects{}`의 `extra["*.version"]`은 문자열 리터럴 대신 이 val을 참조하도록 교체 — 바로 위 `testcontainers`가 쓰던 방식과 동일하게 맞췄습니다.

# 💬 리뷰 중점사항

- **동작 변화 없음**: BOM이 관리하는 전이 의존성 버전을 강제로 올리는 오버라이드라 카탈로그의 `[libraries]`가 아니라 `[versions]`에 버전만 넣고 `libs.versions.*.get()`으로 참조합니다. `./gradlew :app:dependencies --configuration runtimeClasspath`로 확인한 해석 버전이 이관 전과 동일합니다 — tomcat `→ 10.1.55`, spring-security `→ 6.5.9`, thymeleaf `→ 3.1.5.RELEASE`.
- **CVE 참조 주석 유지**: 어떤 CVE 때문에 올렸는지 알 수 있도록 각 오버라이드 위 주석을 그대로 뒀습니다.
- **왜 상단 val로 뺐나**: `subprojects{}` 블록 안에서 바로 `libs.versions...` 접근자를 쓰는 대신, 기존 `testcontainersVersion`처럼 스크립트 상단에서 한 번 읽어 재사용하는 패턴을 그대로 따랐습니다(일관성).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 주요 서버 구성 요소의 버전 관리 방식을 중앙화해 업데이트와 보안 패치 적용의 일관성을 높였습니다.
  * 기존 동작과 사용자 인터페이스에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->