### PR TITLE
[chore] 스킬 disable-model-invocation 플래그 제거

### DIFF
--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -2,7 +2,6 @@
 name: adr
 description: Architecture Decision Record를 작성한다. 기술 선택, 설계 결정, 패턴 도입 등 팀이 내린 중요한 기술적 의사결정을 기록할 때 사용한다.
 argument-hint: "[결정 주제] (예: Redis Stream 도입, Notifier 패턴 적용)"
-disable-model-invocation: true
 allowed-tools: Read, Glob, Write, Bash
 ---
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -3,7 +3,6 @@ name: create-issue
 description: GitHub 이슈를 템플릿 기반으로 생성하고, 이슈 번호로 dev에서 작업 브랜치를 체크아웃한다. 백엔드·프론트엔드 공통.
 argument-hint: "[type] 이슈 제목 — type: feat | fix | refactor | chore | docs | test"
 allowed-tools: Bash
-disable-model-invocation: true
 ---
 
 # create-issue

--- a/backend/.claude/skills/postmortem/SKILL.md
+++ b/backend/.claude/skills/postmortem/SKILL.md
@@ -2,7 +2,6 @@
 name: postmortem
 description: 장애·인시던트·반복된 오진의 사후 회고(Postmortem)를 작성한다. 프로덕션 장애, CI 플레이키, 배포 사고, 진단이 여러 번 빗나간 사건 등 "무엇이 어떻게 터졌고 왜 그렇게 진단했는가"를 복기할 때 사용한다.
 argument-hint: "[사건 주제] (예: 게임 통합테스트 플레이키, Redis 구독 영구 중단)"
-disable-model-invocation: true
 allowed-tools: Read, Glob, Write, Bash
 ---
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1551

# 🚀 작업 내용

1. `create-issue`, `adr`, `postmortem` 세 스킬(SKILL.md)의 frontmatter에서 `disable-model-invocation: true` 라인을 제거했다. 다른 본문 내용은 수정하지 않았다.

# 💬 리뷰 중점사항

이 플래그가 있으면 Claude가 대화 중 Skill 툴로 이 스킬들을 직접 호출할 수 없고, 사용자가 슬래시 커맨드(`/create-issue` 등)를 직접 입력해야만 실행됐다. 세 스킬 모두 실행 전에 사용자 확인 절차(예: create-issue 3단계 질문)가 내장돼 있어, 플래그를 지워도 GitHub 이슈·ADR·포스트모템이 확인 없이 즉시 생성되지는 않는다. 제거 여부와 범위(3개 전부)는 사용자가 명시적으로 요청한 내용이다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * ADR, 이슈 생성, 포스트모템 관련 가이드의 설정을 업데이트했습니다.
  * 해당 가이드가 필요할 때 자동으로 활용될 수 있도록 개선되었습니다.
  * 기존 작성 절차와 원칙, 템플릿 및 실행 단계는 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->