### PR TITLE
fix(ci): Publish Test Results dorny → EnricoMi 롤백 (OOM)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -115,16 +115,16 @@ jobs:
       - name: Run Tests
         run: ./gradlew test jacocoTestReport --build-cache --no-daemon
 
-      # 테스트 결과는 dorny/test-reporter로 Checks 탭에 표시(스위트/테스트 드릴다운,
-      # 실패 스택트레이스 인라인). 표기 시간은 JUnit XML 합계라 wall-clock이 아니다 —
+      # 테스트 결과는 EnricoMi로 Checks 탭에 표시. dorny/test-reporter(내장 Node)는
+      # 멀티모듈 XML 전체 + git 추적 파일 2121개를 한 번에 메모리 적재하다 V8 힙
+      # OOM으로 죽어(#1564) 롤백. 표기 시간은 JUnit XML 합계라 wall-clock이 아니다 —
       # 실제 경과는 Build Scan 참조.
       - name: Publish Test Results
-        uses: dorny/test-reporter@v3
+        uses: EnricoMi/publish-unit-test-result-action@v2.24.0
         if: always()
         with:
-          name: Backend Test Results
-          path: backend/*/build/test-results/test/*.xml
-          reporter: java-junit
+          files: backend/*/build/test-results/test/*.xml
+          check_name: "Backend Test Results"
 
       - name: Report Coverage
         if: github.event_name == 'pull_request'

--- a/backend/.claude/skills/ci-fix/SKILL.md
+++ b/backend/.claude/skills/ci-fix/SKILL.md
@@ -11,7 +11,7 @@ PR 번호를 받아 GitHub Actions `backend-ci.yml` 런 로그에서 실패한 �
 
 ## Step 1–2: 실패 테스트 추출
 
-`fetch-failures.sh`로 PR 상태 확인 및 실패 목록을 가져온다. 이 스크립트는 PR head 브랜치의 최근 `backend-ci.yml` 런 로그(gradle JUnit 출력)를 직접 파싱한다 — dorny "Backend Test Results" 체크런은 생성되지 않으므로 의존하지 않는다(#1521):
+`fetch-failures.sh`로 PR 상태 확인 및 실패 목록을 가져온다. 이 스크립트는 "Backend Test Results" 체크런의 실패 annotation을 먼저 시도하고, 체크런이 없거나 annotation이 비어 있으면 PR head 브랜치의 최근 `backend-ci.yml` 런 로그(gradle JUnit 출력)를 직접 파싱하는 것으로 폴백한다(#1521, #1564):
 
 ```bash
 bash .claude/skills/ci-fix/fetch-failures.sh <PR번호>

--- a/backend/.claude/skills/ci-fix/fetch-failures.sh
+++ b/backend/.claude/skills/ci-fix/fetch-failures.sh
@@ -3,10 +3,11 @@
 #
 # PR head 브랜치의 최근 backend-ci.yml 런에서 실패한 테스트를 추출한다.
 #
-# 배경(#1521): dorny/test-reporter는 결과를 job summary에만 쓰고 "Backend Test Results"
-# 체크런을 생성하지 않는다(성공·실패 런 모두 없음). 또 job summary(step summary) 텍스트는
-# 공개 REST API로 가져올 수 없다. 따라서 체크런 annotation이 아니라 GitHub Actions
-# 런 로그의 gradle JUnit 출력을 직접 파싱한다.
+# 배경(#1521 → #1564): dorny/test-reporter는 "Backend Test Results" 체크런을 만들지
+# 않아 annotation을 쓸 수 없었고(#1521), 로그 파싱으로 우회했다. #1564에서 OOM 때문에
+# EnricoMi로 롤백하며 체크런이 다시 생성될 수 있으므로, 체크런 annotation을 먼저
+# 시도하고 없으면(체크런 미생성·annotation 없음) Actions 런 로그의 gradle JUnit 출력
+# 직접 파싱으로 폴백한다. 어느 리포터를 쓰든 동작한다.
 set -euo pipefail
 
 PR=${1:-$(gh pr view --json number -q .number 2>/dev/null || true)}
@@ -15,35 +16,52 @@ if [ -z "$PR" ]; then
   exit 1
 fi
 
-BRANCH=$(gh pr view "$PR" --json headRefName -q .headRefName)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PR_INFO=$(gh pr view "$PR" --json headRefName,headRefOid -q '"\(.headRefName)\t\(.headRefOid)"')
+IFS=$'\t' read -r BRANCH HEAD_SHA <<< "$PR_INFO"
 
-# PR head 브랜치의 가장 최근 backend-ci.yml 런 (id/상태/결론)
+# PR head 브랜치의 가장 최근 backend-ci.yml 런 (id/상태/결론). 체크런이 없거나
+# annotation이 비었을 때 로그 폴백에도 이 RUN_ID를 그대로 쓴다.
 RUN_INFO=$(gh run list --branch "$BRANCH" --workflow backend-ci.yml --limit 1 \
   --json databaseId,status,conclusion \
   --jq '.[0] | "\(.databaseId)\t\(.status)\t\(.conclusion)"' 2>/dev/null || true)
-IFS=$'\t' read -r RUN_ID STATUS CONCLUSION <<< "${RUN_INFO:-}"
+IFS=$'\t' read -r RUN_ID RUN_STATUS RUN_CONCLUSION <<< "${RUN_INFO:-}"
 
 if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
   echo "backend-ci.yml 런을 찾을 수 없습니다. PR에 백엔드 CI가 실행됐는지 확인해주세요." >&2
   exit 1
 fi
 
-if [ "$STATUS" != "completed" ]; then
-  echo "CI가 아직 실행 중입니다 (status: ${STATUS}). 완료 후 다시 시도하세요." >&2
+if [ "$RUN_STATUS" != "completed" ]; then
+  echo "CI가 아직 실행 중입니다 (status: ${RUN_STATUS}). 완료 후 다시 시도하세요." >&2
   exit 1
 fi
 
-if [ "$CONCLUSION" = "success" ]; then
+if [ "$RUN_CONCLUSION" = "success" ]; then
   echo "CI가 통과 상태입니다 (conclusion: success)"
   exit 0
 fi
 
-if [ "$CONCLUSION" != "failure" ]; then
-  echo "CI 결론: ${CONCLUSION} — 실패가 아닙니다 (취소·스킵 등). 재실행이 필요할 수 있습니다." >&2
+if [ "$RUN_CONCLUSION" != "failure" ]; then
+  echo "CI 결론: ${RUN_CONCLUSION} — 실패가 아닙니다 (취소·스킵 등). 재실행이 필요할 수 있습니다." >&2
   exit 1
 fi
 
-# 실패한 스텝 로그에서 gradle JUnit 실패를 파싱한다.
+# 1) 체크런 우선: "Backend Test Results" 체크런의 실패 annotation을 시도한다.
+CHECK_RUN_ID=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+  --jq '[.check_runs[] | select(.name == "Backend Test Results")] | first | .id' 2>/dev/null || true)
+
+if [ -n "$CHECK_RUN_ID" ] && [ "$CHECK_RUN_ID" != "null" ]; then
+  ANNOTATIONS=$(gh api --paginate "repos/${REPO}/check-runs/${CHECK_RUN_ID}/annotations" \
+    --jq '.[] | select(.annotation_level == "failure") | "\(.title)\n  경로: \(.path):\(.start_line)\n  메시지: \(.message)\n"' 2>/dev/null || true)
+  if [ -n "$ANNOTATIONS" ]; then
+    echo "$ANNOTATIONS"
+    exit 0
+  fi
+fi
+
+# 2) 로그 폴백: 체크런이 없거나 annotation이 비어 있을 때, 실패한 스텝 로그에서
+# gradle JUnit 실패를 직접 파싱한다.
 # 로그 각 줄은 "<job>\t<step>\t<ISO timestamp> <message>" 형식이라 timestamp까지 벗겨낸다.
 # gradle 출력 형식:
 #   <Suite> > <testMethod>() FAILED


### PR DESCRIPTION
## Summary
- `backend-ci.yml`의 `Publish Test Results` 스텝을 `dorny/test-reporter@v3` → `EnricoMi/publish-unit-test-result-action@v2.24.0`으로 롤백
- dorny(내장 Node)가 멀티모듈 JUnit XML 전체 + git 추적 파일 2121개를 annotation 경로 매핑용으로 한 번에 메모리 적재하다 V8 힙 OOM으로 반복 실패(#1564). `if: always()`라 테스트가 전부 통과해도 이 스텝이 죽으면 `ci-build` 잡 전체가 `failure`로 뜬다
- #1506에서 dorny로 바꾼 이유(EnricoMi가 13개 모듈 JUnit 시간을 합산 표기해 wall-clock과 다르게 보이는 혼란)는 같은 커밋에서 추가한 Gradle Build Scan이 이미 해결했으므로 롤백해도 재발하지 않음
- 버전은 dorny 도입 전 floating `@v2` 대신 최신 안정 릴리스로 명시 핀(`@v2.24.0`)
- `/ci-fix`의 `fetch-failures.sh`를 **체크런 우선 · 로그 폴백**으로 재설계(#1521, #1564): "Backend Test Results" 체크런의 실패 annotation을 먼저 시도하고, 체크런이 없거나 annotation이 비어 있으면 기존 Actions 런 로그 gradle JUnit 파싱으로 폴백. 이 PR의 실제 CI로 체크런 복원 여부가 검증되기 전이므로, 되든 안 되든 동작하도록 설계했다

## Base 브랜치 안내
이슈 #1564 TODO에 따라 base를 `dev`가 아니라 `chore/1553-spring-boot-4-phase2`로 잡았습니다(Boot 4 마이그레이션 Phase 2 브랜치 위에서 발견·진행되는 후속 작업, PR #1563 CI를 막고 있던 이슈).

## 남은 검증 (이 PR 범위 밖)
이슈 #1564의 나머지 성공 기준은 실제 CI 실행 결과로만 확인 가능합니다:
- [ ] 이 PR의 backend-ci.yml 런에서 `Publish Test Results` 스텝이 OOM 없이 통과하는지
- [ ] `gh api repos/.../commits/<sha>/check-runs`로 "Backend Test Results" 체크런이 실제로 생성되는지
- [ ] 체크런이 생성되면 `fetch-failures.sh`의 체크런 경로가 정상 동작하는지(annotation 파싱), 생성되지 않으면 로그 폴백이 여전히 정상 동작하는지

## Test plan
- [ ] 이 PR의 backend-ci.yml 실행에서 `Publish Test Results` 스텝이 OOM 없이 통과하는지 확인
- [ ] `gh api repos/woowacourse-teams/2025-zzol/commits/<sha>/check-runs`로 "Backend Test Results" 체크런 생성 여부 확인
- [ ] `bash backend/.claude/skills/ci-fix/fetch-failures.sh <이 PR 번호>`로 정상/실패 양쪽 케이스 동작 확인