### PR TITLE
chore(infra): IpBlockFilter의 deprecated NonNull을 JSpecify로 전환

### DIFF
--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
## Summary
- `IpBlockFilter`의 `org.springframework.lang.NonNull` import를 `org.jspecify.annotations.NonNull`로 교체
- Spring Framework 7(Boot 4)이 자체 null-safety 애노테이션을 JSpecify로 전환하며 기존 애노테이션이 deprecated됨
- `org.jspecify:jspecify`는 Spring Framework 7 전이 의존성으로 이미 `:infra` 컴파일 클래스패스에 존재 — 신규 Gradle 의존성 추가 없음
- **범위: 백엔드 전체 모듈(main+test)을 스캔** — `org.springframework.lang.{NonNull,Nullable,NonNullApi,NonNullFields}` 사용처를 `admin`/`app`/`common`/`game`/`game-api`/`infra`/`room`/`user`/`web`/`websocket`/`profanity`/`test-support`/`zzolbot` 전 모듈에서 검색했고, `IpBlockFilter.java` 1건 외 추가 사용처 없음을 확인

## Test plan
- [x] `./gradlew :infra:compileJava` — `[deprecation]` 경고 사라짐, 빌드 성공
- [x] `./gradlew compileJava compileTestJava`(전체 모듈, main+test) — 관련 경고 없이 통과
- [x] `./gradlew :infra:test --tests IpBlockFilterTest` — 통과
- [x] `rg -n "springframework\.lang" backend` — 코드상 잔존 사용처 없음(ADR 문서 언급 1건 제외, 코드 아님)

Closes #1565