### PR TITLE
[fix] Stream 컨테이너를 SmartLifecycle로 편입해 컨텍스트 pause 시 폴러 정지 (#1572)

### DIFF
--- a/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
@@ -18,8 +18,7 @@ import org.springframework.stereotype.Component;
  * 컨테이너는 Starter가 수동 생성한 비(非)빈이라 Spring 라이프사이클(컨텍스트 close의 lifecycle
  * stop, Spring Framework 7 테스트 컨텍스트 pause)이 인지하지 못한다 — 커넥션 팩토리만 정지되고
  * 폴러는 살아남아 정지된 팩토리에 무한 재시도한다. 레지스트리가 {@link SmartLifecycle}로 stop/start를
- * 대신 위임받아 컨테이너를 라이프사이클에 편입시킨다. phase는 기본값(Integer.MAX_VALUE)을 그대로 써서
- * {@code LettuceConnectionFactory}(phase 0)보다 먼저 멈추고 늦게 시작된다.
+ * 대신 위임받아 컨테이너를 라이프사이클에 편입시킨다.
  */
 @Slf4j
 @Component
@@ -53,6 +52,15 @@ public class RedisStreamContainerRegistry implements SmartLifecycle {
     @Override
     public boolean isRunning() {
         return containers.values().stream().anyMatch(StreamMessageListenerContainer::isRunning);
+    }
+
+    // 종료(stop)는 phase 내림차순이다. 폴러는 웹 트래픽 드레인이 모두 끝난 뒤 멈춰야
+    // 드레인 중 수신된 커맨드의 소비·브로드캐스트가 유지되고(WS 세션 드레인 MAX-1,
+    // Tomcat 드레인 MAX-1024, 웹서버 stop MAX-2048), LettuceConnectionFactory(phase 0)보다는
+    // 먼저 멈춰야 정지된 팩토리에 폴링하지 않는다. 그 사이 값이면 되고, 1024는 그 표식이다
+    @Override
+    public int getPhase() {
+        return 1024;
     }
 
     // refresh 실패 시에는 ContextClosedEvent도 lifecycle stop도 없이 빈 파괴만 진행되어 이미

--- a/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
@@ -5,18 +5,25 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.stereotype.Component;
 
 /**
- * 스트림 키별 ListenerContainer의 단일 장부.
+ * 스트림 키별 ListenerContainer의 단일 장부이자 라이프사이클 대리인.
  * <p>
  * Spring 컨테이너에 동적 빈으로 등록하던 기존 방식(문자열 빈 이름 + getBean 조회)을 대체한다.
  * 등록은 {@link RedisStreamListenerStarter}, 조회는 Recovery/HealthIndicator가 담당한다.
+ * <p>
+ * 컨테이너는 Starter가 수동 생성한 비(非)빈이라 Spring 라이프사이클(컨텍스트 close의 lifecycle
+ * stop, Spring Framework 7 테스트 컨텍스트 pause)이 인지하지 못한다 — 커넥션 팩토리만 정지되고
+ * 폴러는 살아남아 정지된 팩토리에 무한 재시도한다. 레지스트리가 {@link SmartLifecycle}로 stop/start를
+ * 대신 위임받아 컨테이너를 라이프사이클에 편입시킨다. phase는 기본값(Integer.MAX_VALUE)을 그대로 써서
+ * {@code LettuceConnectionFactory}(phase 0)보다 먼저 멈추고 늦게 시작된다.
  */
 @Slf4j
 @Component
-public class RedisStreamContainerRegistry {
+public class RedisStreamContainerRegistry implements SmartLifecycle {
 
     private final Map<String, StreamMessageListenerContainer<?, ?>> containers = new ConcurrentHashMap<>();
 
@@ -28,17 +35,45 @@ public class RedisStreamContainerRegistry {
         return Optional.ofNullable(containers.get(streamKey));
     }
 
-    // refresh 실패 시에는 ContextClosedEvent가 발행되지 않아 이미 시작된 컨테이너가
-    // 파괴된 커넥션 팩토리에 무한 폴링한다. @PreDestroy는 정상 종료와 refresh 실패
-    // 양쪽에서 호출되므로 여기서 확정적으로 멈춘다 (stop()은 멱등).
+    // 최초 기동은 Starter의 @PostConstruct가 register→start→await로 직접 수행하므로(ADR-0022)
+    // onRefresh 시점의 이 호출은 no-op이다. 실질 호출처는 테스트 컨텍스트 pause 해제(재사용) 시점의
+    // lifecycle 재시작이다 — 컨테이너는 등록된 구독을 유지하므로 start()만으로 폴링이 재개된다
+    @Override
+    public void start() {
+        containers.forEach(this::startSafely);
+    }
+
+    @Override
+    public void stop() {
+        containers.forEach(this::stopSafely);
+    }
+
+    // 상태 플래그를 따로 두지 않고 컨테이너에서 유도한다 — lifecycle processor는 running일 때만
+    // stop을, not running일 때만 start를 호출하므로 이 값이 위임의 유일한 진실 공급원이다
+    @Override
+    public boolean isRunning() {
+        return containers.values().stream().anyMatch(StreamMessageListenerContainer::isRunning);
+    }
+
+    // refresh 실패 시에는 ContextClosedEvent도 lifecycle stop도 없이 빈 파괴만 진행되어 이미
+    // 시작된 컨테이너가 파괴된 커넥션 팩토리에 무한 폴링한다. @PreDestroy는 정상 종료와 refresh
+    // 실패 양쪽에서 호출되므로 여기서 확정적으로 멈춘다 (stop()은 멱등).
     // 빈 파괴는 역의존 순서이므로 Starter의 stopping 플래그 설정이 항상 이보다 먼저 실행된다 (ADR-0022)
     // package-private: 라이프사이클 콜백이라 외부 호출은 불필요하며, 동일 패키지 테스트 접근용으로만 연다
     @PreDestroy
     void stopAll() {
-        containers.forEach(this::stopSafely);
+        stop();
     }
 
-    // 한 컨테이너의 stop() 실패가 나머지 컨테이너 정지를 막지 않도록 예외를 격리한다
+    // 한 컨테이너의 start/stop 실패가 나머지 컨테이너의 처리를 막지 않도록 예외를 격리한다
+    private void startSafely(String streamKey, StreamMessageListenerContainer<?, ?> container) {
+        try {
+            container.start();
+        } catch (Exception e) {
+            log.warn("Redis Stream 컨테이너 시작 실패: streamKey={}", streamKey, e);
+        }
+    }
+
     private void stopSafely(String streamKey, StreamMessageListenerContainer<?, ?> container) {
         try {
             container.stop();

--- a/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamContainerRegistryTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamContainerRegistryTest.java
@@ -127,4 +127,12 @@ class RedisStreamContainerRegistryTest {
 
         assertThat(registry.getPhase()).isGreaterThan(factory.getPhase());
     }
+
+    @Test
+    void 웹_트래픽_드레인보다_늦게_정지하도록_phase가_드레인_단계들보다_낮다() {
+        // 드레인 중 수신된 커맨드의 소비·브로드캐스트를 유지한다. 상수는 package-private이라 값으로 고정:
+        // WebSocketGracefulShutdownHandler(MAX-1) > WebServerGracefulShutdownLifecycle(MAX-1024)
+        // > WebServerStartStopLifecycle(MAX-2048) > 레지스트리
+        assertThat(registry.getPhase()).isLessThan(Integer.MAX_VALUE - 2048);
+    }
 }

--- a/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamContainerRegistryTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/redis/config/RedisStreamContainerRegistryTest.java
@@ -2,6 +2,7 @@ package coffeeshout.global.redis.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 
 @ExtendWith(MockitoExtension.class)
@@ -62,5 +64,67 @@ class RedisStreamContainerRegistryTest {
 
         verify(container).stop();
         verify(anotherContainer).stop();
+    }
+
+    @Test
+    void lifecycle_stop_시_등록된_모든_컨테이너를_정지한다() {
+        // 컨텍스트 pause(SF7)와 정상 종료의 lifecycle stop 양쪽이 이 경로를 탄다
+        registry.register("room", container);
+        registry.register("minigame", anotherContainer);
+
+        registry.stop();
+
+        verify(container).stop();
+        verify(anotherContainer).stop();
+    }
+
+    @Test
+    void lifecycle_start_시_등록된_모든_컨테이너를_재시작한다() {
+        // 컨텍스트 pause 해제 시 lifecycle processor가 auto-startup 빈으로 재시작한다
+        registry.register("room", container);
+        registry.register("minigame", anotherContainer);
+
+        registry.start();
+
+        verify(container).start();
+        verify(anotherContainer).start();
+    }
+
+    @Test
+    void 한_컨테이너의_시작_실패가_나머지_컨테이너_시작을_막지_않는다() {
+        registry.register("room", container);
+        registry.register("minigame", anotherContainer);
+        doThrow(new IllegalStateException("start 실패")).when(container).start();
+
+        assertThatCode(() -> registry.start()).doesNotThrowAnyException();
+
+        verify(container).start();
+        verify(anotherContainer).start();
+    }
+
+    @Test
+    void 실행_중인_컨테이너가_하나라도_있으면_running이다() {
+        // mock 기본값이 false이므로 room 컨테이너는 스텁 없이 정지 상태다 (anyMatch 단락 평가로 미호출 가능)
+        registry.register("room", container);
+        registry.register("minigame", anotherContainer);
+        given(anotherContainer.isRunning()).willReturn(true);
+
+        assertThat(registry.isRunning()).isTrue();
+    }
+
+    @Test
+    void 모든_컨테이너가_정지_상태면_running이_아니다() {
+        registry.register("room", container);
+        given(container.isRunning()).willReturn(false);
+
+        assertThat(registry.isRunning()).isFalse();
+    }
+
+    @Test
+    void 커넥션_팩토리보다_늦게_시작하고_먼저_정지하도록_phase가_더_높다() {
+        // pause/종료 시 폴러가 팩토리보다 먼저 멈춰야 정지된 팩토리에 폴링하지 않는다
+        final LettuceConnectionFactory factory = new LettuceConnectionFactory();
+
+        assertThat(registry.getPhase()).isGreaterThan(factory.getPhase());
     }
 }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1572

# 🚀 작업 내용

1. `RedisStreamContainerRegistry`가 `SmartLifecycle`을 구현해 수동 생성 컨테이너들의 stop/start를 Spring 라이프사이클에 편입
   - **원인**: Spring Framework 7(Boot 4, #1563)의 [테스트 컨텍스트 pause](https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/ctx-management/context-pausing.html)는 Lifecycle **빈**만 정지시킨다. `RedisStreamListenerStarter`가 `@PostConstruct`에서 수동 생성하는 `StreamMessageListenerContainer`는 빈이 아니라 정지 대상에서 제외되어, pause된 캐시 컨텍스트의 폴러가 정지된 `LettuceConnectionFactory`에 무한 재시도했다
   - **증상**: #1563 CI에서 테스트 JVM 6개 전부 `IllegalStateException: LettuceConnectionFactory has been STOPPED` ERROR 1.5만+ 줄 폭주 → ① 테스트 XML CData 비대로 결과 퍼블리셔 47 parse errors ② 전역 로거를 검사하는 `RedisStreamListenerStarterTest.종료_중에는_어떤_오류도_ERROR로_기록하지_않는다` 플레이키 실패
2. phase는 `1024` — 종료(내림차순 stop) 시 웹 트래픽 드레인(`WebSocketGracefulShutdownHandler` MAX−1 → Tomcat 드레인 MAX−1024 → 웹서버 stop MAX−2048)이 **모두 끝난 뒤** 폴러가 멈추고, `LettuceConnectionFactory`(phase 0)보다는 **먼저** 멈춘다. 드레인 중 수신된 커맨드의 소비·브로드캐스트를 유지하면서 정지된 팩토리 폴링을 막는다 (상·하한 모두 테스트로 고정)
3. `isRunning()`은 별도 플래그 없이 컨테이너 상태에서 유도 — lifecycle processor의 stop/start 판단 기준과 실제 컨테이너 상태가 항상 일치
4. 기존 `@PreDestroy stopAll()`은 refresh 실패 경로(lifecycle stop 미실행) 안전망으로 유지, 내부는 `stop()` 재사용
5. 단위 테스트 7건 추가 (stop/start 위임, 실패 격리, isRunning 유도, phase 상·하한)

# 💬 리뷰 중점사항

- dev(SF 6.2)에는 pause가 없어 이 버그가 발현되지 않지만, **정상 종료 시** 팩토리 stop(lifecycle 단계)과 컨테이너 stop(`@PreDestroy`, 빈 파괴 단계) 사이 창에서 폴러가 정지된 팩토리를 두드리는 동일 구조 문제를 이 변경이 함께 해소합니다 (현재는 `stopping` 플래그 DEBUG 강등으로 로그만 억제 — 플래그는 안전망으로 유지)
- pause 해제 시 재시작은 라이브러리가 보장합니다: `DefaultStreamMessageListenerContainer.start()`가 비활성 구독을 재실행하고, `StreamPollTask.run()`이 CANCELLED 상태를 STARTING→RUNNING으로 재설정하는 것을 spring-data-redis 4.1.0에서 확인했습니다
- `RedisStreamContainerRecovery`(`@Scheduled`)와의 경합: pause는 scheduled task도 함께 정지시키므로(`ScheduledAnnotationBeanPostProcessor`도 SmartLifecycle) pause 중 복구 로직이 컨테이너를 되살리는 충돌은 없습니다
- #1563은 이 변경이 dev에 머지된 뒤 rebase하면 CI 플레이키가 해소됩니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Redis stream listeners now start and stop in coordination with the application lifecycle.
  * A failure affecting one listener no longer prevents other listeners from starting or stopping.

* **Bug Fixes**
  * Improved shutdown ordering for Redis stream listeners.

* **Tests**
  * Added coverage for lifecycle operations, running-state detection, failure isolation, and shutdown ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->