### PR TITLE
[fix] DSN_KEY 미설정 시 FE 빈 페이지 수정 — DefinePlugin 무조건 치환 + CI 주입

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,6 +48,7 @@ jobs:
         # 파일명을 .env로 쓰면 API_URL이 번들에 들어가지 않는다(undefined로 구워짐).
         run: |
           echo "API_URL=${{ github.ref_name == 'prod' && secrets.API_URL_PROD || secrets.API_URL }}" >> .env.production
+          echo "DSN_KEY=${{ secrets.DSN_KEY }}" >> .env.production
 
       - name: Run ESLint
         run: npm run lint

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           echo "API_URL=${{ github.ref_name == 'prod' && secrets.API_URL_PROD || secrets.API_URL }}" >> .env.production
           echo "DSN_KEY=${{ secrets.DSN_KEY }}" >> .env.production
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.production
 
       - name: Run ESLint
         run: npm run lint

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -24,10 +24,10 @@ export default (_, argv) => {
     'process.env.VERSION': JSON.stringify(appVersion),
     'process.env.API_URL': JSON.stringify(process.env.API_URL),
     'process.env.ENABLE_DEVTOOLS': JSON.stringify(process.env.ENABLE_DEVTOOLS === 'true'),
+    // 값이 없어도 반드시 치환한다 — 조건부로 두면 번들에 process.env.DSN_KEY가
+    // 리터럴로 남아 브라우저에서 ReferenceError(process is not defined)로 앱이 죽는다.
+    'process.env.DSN_KEY': JSON.stringify(process.env.DSN_KEY || ''),
   };
-  if (process.env.DSN_KEY) {
-    envKeys['process.env.DSN_KEY'] = JSON.stringify(process.env.DSN_KEY);
-  }
   if (process.env.SENTRY_AUTH_TOKEN) {
     envKeys['process.env.SENTRY_AUTH_TOKEN'] = JSON.stringify(process.env.SENTRY_AUTH_TOKEN);
   }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- related #1574 (prod 브랜치 이관 중 발견)

# 🚀 작업 내용

dev.zzol.site 빈 페이지의 잔여 원인 수정.

1. **webpack.common.js**: `DSN_KEY`가 없으면 DefinePlugin이 `process.env.DSN_KEY`를 치환하지 않아 번들에 리터럴로 남고, 프로덕션 모드에서 `main.tsx`의 `Sentry.init`(dsn: process.env.DSN_KEY)이 실행되는 순간 브라우저에서 **ReferenceError: process is not defined**로 렌더 전에 앱이 죽는다. 빈 값이어도 항상 `''`로 치환하도록 변경 — DSN이 비면 Sentry만 비활성화되고 앱은 뜬다.
2. **frontend-ci.yml**: `DSN_KEY` 시크릿을 `.env.production`에 주입 (기존엔 API_URL만 주입).

## 머지 전 필요

```bash
gh secret set DSN_KEY --repo woowacourse-teams/2025-zzol --body "<Sentry DSN>"
```

(미등록 상태로 머지해도 이제 크래시는 없음 — Sentry 리포팅만 꺼진 채 사이트는 정상 동작)

# 💬 리뷰 중점사항

- SENTRY_AUTH_TOKEN 조건부 정의는 유지 — 빌드 시 sourcemap 업로드에만 쓰이고 런타임 src에서 참조하지 않음.