### PR TITLE
[chore] FE 빌드에 ENABLE_DEVTOOLS 주입 — dev=true, prod=false

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -50,6 +50,7 @@ jobs:
           echo "API_URL=${{ github.ref_name == 'prod' && secrets.API_URL_PROD || secrets.API_URL }}" >> .env.production
           echo "DSN_KEY=${{ secrets.DSN_KEY }}" >> .env.production
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env.production
+          echo "ENABLE_DEVTOOLS=${{ github.ref_name == 'prod' && 'false' || 'true' }}" >> .env.production
 
       - name: Run ESLint
         run: npm run lint


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- related #1574

# 🚀 작업 내용

1. `frontend-ci.yml`의 .env.production 생성 스텝에 `ENABLE_DEVTOOLS` 추가 — **dev(및 PR CI) 빌드는 `true`, prod 브랜치 빌드는 `false`**. 기존엔 CI가 값을 주입하지 않아 모든 배포 빌드에서 DevTools가 꺼져 있었다(webpack이 `=== 'true'\' 비교로 boolean을 굽는 구조).

# 💬 리뷰 중점사항

- 시크릿 아닌 고정 정책값이라 GH vars 대신 워크플로우에 브랜치 조건으로 하드코딩했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 환경에 따라 개발자 도구 사용 설정이 자동으로 적용됩니다.
  * 운영 배포에서는 개발자 도구가 비활성화되고, 개발 및 검증 환경에서는 활성화되어 환경별 점검과 문제 확인이 더욱 편리해졌습니다.
  * 기존 API 및 오류 모니터링 관련 설정은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->