### PR TITLE
[refactor] SB4 잔여 deprecation 경고 3건 제거 — Jackson 2 시리얼라이저·XAddOptions 신 API 교체

### DIFF
--- a/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisConfig.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisConfig.java
@@ -1,9 +1,7 @@
 package coffeeshout.global.redis.config;
 
 import coffeeshout.global.redis.config.RedisProperties;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -12,7 +10,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceClientConfigurat
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -37,20 +35,16 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(
-            RedisConnectionFactory redisConnectionFactory,
-            @Qualifier("redisObjectMapper") ObjectMapper objectMapper
-    ) {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         final RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
-        final GenericJackson2JsonRedisSerializer jackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(
-                objectMapper);
-        redisTemplate.setValueSerializer(jackson2JsonRedisSerializer);
-        redisTemplate.setHashValueSerializer(jackson2JsonRedisSerializer);
+        final RedisSerializer<Object> jsonRedisSerializer = RedisSerializer.json();
+        redisTemplate.setValueSerializer(jsonRedisSerializer);
+        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
 
         redisTemplate.afterPropertiesSet();
         return redisTemplate;

--- a/backend/infra/src/main/java/coffeeshout/global/redis/stream/StreamPublisher.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/stream/StreamPublisher.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.RedisStreamCommands.TrimOptions;
 import org.springframework.data.redis.connection.RedisStreamCommands.XAddOptions;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -89,7 +90,7 @@ public class StreamPublisher {
 
         stringRedisTemplate.opsForStream().add(
                 StreamRecords.newRecord().in(redisKey).ofMap(fields),
-                XAddOptions.maxlen(maxLength).approximateTrimming(true)
+                XAddOptions.trim(TrimOptions.maxLen(maxLength).approximate())
         );
     }
 }

--- a/backend/test-support/src/main/java/coffeeshout/support/TestStompSessionFactory.java
+++ b/backend/test-support/src/main/java/coffeeshout/support/TestStompSessionFactory.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.JacksonJsonMessageConverter;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -35,7 +35,7 @@ public class TestStompSessionFactory {
         final SockJsClient sockJsClient = new SockJsClient(
                 List.of(new WebSocketTransport(new StandardWebSocketClient())));
         final WebSocketStompClient stompClient = new WebSocketStompClient(sockJsClient);
-        final MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter(objectMapper);
+        final JacksonJsonMessageConverter converter = new JacksonJsonMessageConverter();
         converter.setStrictContentTypeMatch(false);
         stompClient.setMessageConverter(converter);
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1579

# 🚀 작업 내용

1. `RedisConfig` — 제거 예정(deprecated for removal)인 `GenericJackson2JsonRedisSerializer` 대신 `RedisSerializer.json()`(Jackson 3 기반 `GenericJacksonJsonRedisSerializer`)을 사용하도록 교체했습니다. 이 템플릿의 값 직렬화기로 값을 다시 읽는 곳이 없어서(조인코드 `setIfAbsent("1")`, pub/sub `"refresh"`, 스트림 `size()` 조회뿐) 안전하게 바꿀 수 있고, 템플릿에서만 쓰이던 `redisObjectMapper` 주입도 함께 제거했습니다.
2. `StreamPublisher` — deprecated된 `XAddOptions.maxlen(n).approximateTrimming(true)`을 새 API `XAddOptions.trim(TrimOptions.maxLen(n).approximate())`로 교체했습니다. Redis에 나가는 명령(`XADD ... MAXLEN ~ n`)은 동일합니다.
3. `TestStompSessionFactory` — 제거 예정인 `MappingJackson2MessageConverter` 대신 `JacksonJsonMessageConverter`(Jackson 3)를 사용합니다. 이 컨버터는 테스트 클라이언트의 **송신(직렬화)** 에만 쓰이고, 수신 파싱은 기존 Jackson 2 mapper 수동 파싱 그대로입니다. 서버 쪽 STOMP는 Phase 2에서 이미 Jackson 3 컨버터를 쓰고 있어 클라이언트가 서버와 같은 계열로 맞춰집니다.

# 💬 리뷰 중점사항

- **ADR-0020과의 관계**: Jackson 3 전면 전환은 Phase 3 범위지만, 이 PR은 REST 응답 와이어 포맷에 영향이 없는 세 지점만 국소 교체합니다. `spring-boot-jackson2` 호환 모듈과 REST 직렬화 경로는 건드리지 않았습니다.
- **직렬화 포맷 변화 여부**: `RedisSerializer.json()`은 타입 정보(`@class`)를 기본 활성화하지만, 이 템플릿으로 저장하는 값은 문자열(`"1"`, `"refresh"`)뿐이라 문자열은 타입 정보 없이 동일한 JSON으로 저장됩니다. 역직렬화 소비자도 없습니다.
- **검증**: 로컬에서 전체 테스트(`./gradlew test`, TestContainers 통합 포함) 통과(BUILD SUCCESSFUL), `:infra`·`:test-support` 컴파일 시 deprecation 경고 0건 확인.
