### PR TITLE
docs: 레거시 be/·fe/ 브랜치 표기 정리 및 AI 워크트리 작업 규칙 추가

### DIFF
--- a/.claude/rules/git-push-safety.md
+++ b/.claude/rules/git-push-safety.md
@@ -10,7 +10,7 @@
 >
 > `prod`는 BE+FE 통합 **프로덕션** 브랜치다(#1574). 승격은 `dev`→`prod` PR로만 하며, `prod` push가 곧 운영 배포 트리거다(backend-cd·frontend-cd).
 >
-> `be/dev`·`fe/dev`·`be/prod`·`fe/prod`는 전환기 호환으로 보호 목록에 남기지만 **신규 분기·PR 대상이 아니다**. 원격에서 이 브랜치들을 삭제하면 이 목록과 `backend/.claude/skills/commit/preflight.sh`의 `PROTECTED`에서도 제거한다(TODO).
+> `be/dev`·`fe/dev`·`be/prod`·`fe/prod` 체계는 **폐기됐다** — 작업·PR·배포 트리거가 모두 `dev`·`prod`로 이관됐다. 원격에 브랜치가 남아 있는 동안만 보호 목록에 유지하며, 원격에서 삭제하면 이 목록과 `backend/.claude/skills/commit/preflight.sh`의 `PROTECTED`에서도 제거한다(TODO).
 
 이 브랜치들의 변경은 **PR로만** 반영한다. Claude는 어떤 경우에도 이 브랜치로 직접 push하거나, 이 브랜치를 체크아웃해 직접 커밋하지 않는다.
 
@@ -30,6 +30,13 @@ git push -u origin feat/x:dev
 ```bash
 git push -u origin HEAD:{type}/{N}-{slug}
 ```
+
+### AI는 별도 워크트리에서 작업한다
+
+Claude가 코드를 수정할 때는 사용자가 체크아웃한 브랜치(워킹 카피)에서 직접 작업하지 않는다. `dev` 기준 별도 git worktree를 만들어 그 안에서 작업한다.
+
+- 사용자의 워킹 카피·IDE 상태와 격리되고, 보호 브랜치를 체크아웃한 채 커밋할 소지가 원천 차단된다.
+- 워크트리의 작업 브랜치에도 위 규칙이 동일하게 적용된다: `{type}/{N}-{slug}` 네이밍, upstream 미설정(`git branch --unset-upstream`), 명시 refspec push.
 
 ### push 전 검증 절차
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@
 - 브랜치명은 prefix 없이 `{type}/{N}-{slug}` (예: `feat/1502-nunchi-game`). type: `feat`·`fix`·`refactor`·`chore`·`docs`·`test`.
 - 영역(BE/FE)은 브랜치가 아니라 **라벨**로 구분한다 — `create-issue`/`create-pr`가 변경 영역을 판별해 `BE`/`FE`(풀스택이면 둘 다) 라벨을 단다.
 - 프로덕션 승격은 통합 `prod` 브랜치로의 `dev`→`prod` PR로만 한다. `prod` push가 곧 운영 배포다.
-- `be/dev`·`fe/dev`·`be/prod`·`fe/prod`는 전환기 호환으로만 남아 있다. 신규 분기·PR 대상이 아니다. 상세는 [git-push-safety](.claude/rules/git-push-safety.md).
+- `be/dev`·`fe/dev`·`be/prod`·`fe/prod` 같은 영역 prefix 브랜치 체계는 **폐기됐다**. 모든 커밋은 `dev` 기준 작업 브랜치에서 하며, 어떤 작업도 이 브랜치들을 대상으로 하지 않는다. 상세는 [git-push-safety](.claude/rules/git-push-safety.md).
+- **AI(Claude)는 체크아웃된 브랜치에서 바로 작업하지 않는다** — 코드 수정 시 `dev` 기준 별도 git worktree를 만들어 그 안에서 작업하고, 작업 브랜치를 push해 PR한다.
 
 ## 공통 스킬 (전역)
 

--- a/backend/.claude/skills/commit/SKILL.md
+++ b/backend/.claude/skills/commit/SKILL.md
@@ -38,7 +38,7 @@ bash .claude/skills/commit/preflight.sh
 그룹 유형별 검증 대상:
 
 - **자바 프로덕션 포함** → `/run-tests`로 위임. 한 모듈 안이면 `:module` 타겟, 여러 모듈/패키지에 걸치면 해당 패키지 필터를 모두 포함한다 (`./gradlew` 직접 실행 금지 — CLAUDE.md).
-- **문서(`.md`)만** → 저장소 루트에서 `npx markdownlint-cli2` (Docs CI가 be/dev PR에서 강제하는 것과 동일).
+- **문서(`.md`)만** → 저장소 루트에서 `npx markdownlint-cli2` (Docs CI가 dev PR에서 강제하는 것과 동일).
 - **설정/빌드만** → 자동 검증 없음.
 - **테스트 파일만** → 해당 테스트만 실행한다.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -8,7 +8,8 @@
 
 브랜치 전략은 모노레포 공통이다 — 루트 [CLAUDE.md](../CLAUDE.md)·[git-push-safety](../.claude/rules/git-push-safety.md)를 따른다. 요약:
 
-- 작업 브랜치는 통합 브랜치 **`dev`에서 분기**하고 PR 타깃도 `dev`다 (백엔드도 `be/dev`가 아니라 `dev`). 분기 시 `git switch -c {type}/{N}-{slug} origin/dev` 후 `git branch --unset-upstream`.
+- 작업 브랜치는 통합 브랜치 **`dev`에서 분기**하고 PR 타깃도 `dev`다. 분기 시 `git switch -c {type}/{N}-{slug} origin/dev` 후 `git branch --unset-upstream`.
+- AI(Claude)는 체크아웃된 브랜치에서 직접 코드를 수정하지 않는다 — `dev` 기준 별도 git worktree에서 작업한다.
 - 브랜치 네이밍은 prefix 없이 `{type}/{N}-{slug}`. 영역(BE)은 `create-issue`/`create-pr`가 라벨로 붙인다.
 - `dev`가 저장소 **기본 브랜치**다. README·dependabot·CodeRabbit·워크플로우 등 GitHub 관련 파일도 `dev`에서 관리한다(dependabot·보안 스캔·스케줄은 기본 브랜치 기준으로 동작). `main`은 배포 브랜치가 아니며(배포는 `dev`·`prod` push 트리거) 전환기 잔재로만 남아 있다 — 신규 작업에 사용하지 않는다.
 - 이슈·PR 생성은 루트 공통 스킬 `create-issue`·`create-pr`를 쓴다.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -37,7 +37,7 @@ BE 컨트랙트(WebSocket + HTTP)를 직접 `curl` 로 받아도 되지만, 본 
 
 **MCP 빌드**: 별도 빌드 불필요. `frontend/.mcp.json` 이 self-healing 런처(`../tools/api-mcp/scripts/launch.mjs`)를 가리키므로 실행 시점에 의존성 설치·빌드를 자동 보장한다.
 
-**컨트랙트 검증 위치**: api-mcp 의 zod 스키마와 BE 카탈로그의 일치(contract drift) 검증은 **be/dev 가 단독으로 소유**한다 — fixture 생성기(`WsCatalogFixtureGeneratorTest`, `-DupdateFixture=true`)·커밋된 fixture·BE 소스가 모두 be/dev 에 있기 때문이다. `tools/api-mcp` 는 be/dev 미러이므로 fe/dev CI 는 컨트랙트 검증을 수행하지 않고 빌드·린트·단위 테스트만 돌린다.
+**컨트랙트 검증 위치**: api-mcp 의 zod 스키마와 BE 카탈로그의 일치(contract drift) 검증은 **백엔드 CI 가 단독으로 소유**한다 — fixture 생성기(`WsCatalogFixtureGeneratorTest`, `-DupdateFixture=true`)·커밋된 fixture·BE 소스가 모두 `dev` 의 `backend/` 에 있기 때문이다. `tools/api-mcp` 는 BE 카탈로그 미러이므로 프론트 CI 는 컨트랙트 검증을 수행하지 않고 빌드·린트·단위 테스트만 돌린다.
 
 **prefix 주의사항**: MCP 카탈로그의 path 는 prefix 를 포함(`/topic/room/...`, `/user/queue/...`, `/app/...`)하지만, FE 의 `useWebSocketSubscription`/`send` 는 wrapper 가 prefix 를 자동 추가하므로 path 에서 `/topic`·`/app` 부분을 제거해 전달한다 (자세한 규칙은 `.claude/rules/websocket.md`).
 


### PR DESCRIPTION
## 개요

문서·규칙 파일에 남아 있던 `be/dev`·`be/prod`·`fe/dev`·`fe/prod` 기반 표기를 정리하고, AI 작업 시 별도 워크트리 사용 규칙을 추가한다.

## 변경 사항

- **루트 CLAUDE.md / git-push-safety.md**: 영역 prefix 브랜치 체계를 '전환기 호환'이 아닌 **폐기**로 명시 — 작업·PR·배포 트리거가 모두 `dev`·`prod`로 이관 완료된 상태를 반영. 원격 브랜치가 남아 있는 동안만 보호 목록 유지(삭제 시 preflight PROTECTED 정리 TODO 유지).
- **AI 워크트리 규칙 추가**: Claude는 체크아웃된 브랜치에서 직접 코드를 수정하지 않고, `dev` 기준 별도 git worktree를 만들어 작업 후 작업 브랜치를 push해 PR한다 (루트 CLAUDE.md·git-push-safety.md·backend/CLAUDE.md).
- **잔여 표기 수정**: commit 스킬의 'Docs CI가 be/dev PR에서 강제' → dev PR, frontend/CLAUDE.md의 컨트랙트 검증 소유 주체를 be/dev → 백엔드 CI(dev) 기준으로 수정.

## 변경하지 않은 것

- `preflight.sh`·`create-pr` 스킬의 PROTECTED 목록: `be/dev` 등이 원격에 아직 존재하므로 보호 목록에는 유지 (기존 TODO대로 원격 삭제 시 함께 제거).
- ADR·포스트모템의 be/dev 언급: 당시 사실의 역사 기록이므로 미수정.
- CI 워크플로우 yml: 문서 범위 밖 (docs-ci.yml의 `branches: [be/dev, dev]` 잔재는 별도 정리 대상).