### PR TITLE
[chore] 브랜치 전략 잔재 정리 — be/dev·fe/dev·be/prod·fe/prod 제거, dev·prod 2브랜치 체계로 간략화

### DIFF
--- a/.claude/rules/git-push-safety.md
+++ b/.claude/rules/git-push-safety.md
@@ -4,13 +4,11 @@
 
 ### 보호 브랜치 (직접 push·commit 금지)
 
-`dev`, `prod`, `be/dev`, `be/prod`, `fe/dev`, `fe/prod`, `main`, `master`
+`dev`, `prod`, `main`, `master`
 
 > `dev`는 BE+FE 통합 브랜치다. **모든 작업(백엔드·프론트·풀스택)은 `dev`에서 분기해 `dev`로 PR한다.** 브랜치명은 prefix 없이 `{type}/{N}-{slug}`.
 >
 > `prod`는 BE+FE 통합 **프로덕션** 브랜치다(#1574). 승격은 `dev`→`prod` PR로만 하며, `prod` push가 곧 운영 배포 트리거다(backend-cd·frontend-cd).
->
-> `be/dev`·`fe/dev`·`be/prod`·`fe/prod`는 전환기 호환으로 보호 목록에 남기지만 **신규 분기·PR 대상이 아니다**. 원격에서 이 브랜치들을 삭제하면 이 목록과 `backend/.claude/skills/commit/preflight.sh`의 `PROTECTED`에서도 제거한다(TODO).
 
 이 브랜치들의 변경은 **PR로만** 반영한다. Claude는 어떤 경우에도 이 브랜치로 직접 push하거나, 이 브랜치를 체크아웃해 직접 커밋하지 않는다.
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Read, Bash, Glob
 4. **브랜치를 원격에 올린다 (`gh pr create`의 전제).** 먼저 아래 보호 브랜치·detached HEAD 가드를 실행한다(`ABORT` 출력 시 중단·보고). 보호 목록 SSOT는 `.claude/rules/git-push-safety.md`. 통과하면 **자기 이름 명시 refspec**으로 push한다 (bare `git push` 금지). 이미 올라가 있으면 push는 생략한다.
 
    ```bash
-   PROTECTED="dev be/dev be/prod fe/dev fe/prod main master"
+   PROTECTED="dev prod main master"
    branch="$(git symbolic-ref --short -q HEAD || true)"
    [ -z "$branch" ] && { echo "ABORT: detached HEAD — 작업 브랜치로 전환하세요."; exit 1; }
    case " $PROTECTED " in *" $branch "*) echo "ABORT: 보호 브랜치 '$branch' 직접 push 금지 (git-push-safety). PR로 반영하세요."; exit 1;; esac

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,7 +12,7 @@ reviews:
   auto_review:
     enabled: true               # PR 자동 리뷰 활성화
     auto_incremental_review: true
-    base_branches: ["dev", "be/dev", "fe/dev"]
+    base_branches: ["dev"]
 
 chat:
   auto_reply: true              # PR 코멘트에 자동 답변

--- a/.github/workflows/api-mcp-ci.yml
+++ b/.github/workflows/api-mcp-ci.yml
@@ -2,14 +2,13 @@ name: api-mcp CI
 
 on:
   pull_request:
-    branches: [be/dev, be/prod, dev]
+    branches: [dev]
     paths:
       - 'tools/api-mcp/**'
       - 'backend/app/src/test/resources/__fixtures__/ws-catalog.json'
       - '.github/workflows/api-mcp-ci.yml'
   push:
     branches:
-      - be/dev
       - dev
     paths:
       - 'tools/api-mcp/**'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,8 +4,6 @@ on:
   # 1. PR 발생 시 자동 실행 (테스트 용도)
   pull_request:
     branches:
-      - be/dev
-      - be/prod
       - dev
       - prod
     paths:
@@ -93,7 +91,7 @@ jobs:
           # PR 런도 캐시를 저장한다 — 같은 PR에 커밋을 거듭 푸시할 때
           # 직전 푸시에서 실행한 모듈 테스트 결과(FROM-CACHE)를 재사용하기 위함.
           # 캐시는 head 브랜치 스코프에 저장되고, 다른 브랜치는 base/default 브랜치
-          # 캐시를 단방향으로 읽기만 하므로 sibling PR이나 배포 빌드(be/dev·be/prod)로
+          # 캐시를 단방향으로 읽기만 하므로 sibling PR이나 배포 빌드(dev·prod)로
           # 역전파되지 않는다. 10GB LRU 압박은 v6 기본 cache-cleanup(on-success)이 완화.
           cache-read-only: false
           # Build Scan 발행 — 실제 wall-clock·병렬 타임라인·모듈/테스트별 시간을

--- a/.github/workflows/be-delete-merged-branch.yml
+++ b/.github/workflows/be-delete-merged-branch.yml
@@ -3,7 +3,6 @@ name: be-delete-merged-branch.yml
 on:
   pull_request:
     branches:
-      - be/dev
       - dev
       - prod
     types:
@@ -40,7 +39,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.branch-name.outputs.branch }}"
 
-          PROTECTED_BRANCHES=("main" "dev" "prod" "fe/dev" "fe/prod" "be/dev" "be/prod")
+          PROTECTED_BRANCHES=("main" "dev" "prod")
 
           for protected in "${PROTECTED_BRANCHES[@]}"; do
             if [[ "$BRANCH_NAME" == "$protected" ]]; then
@@ -69,7 +68,7 @@ jobs:
         with:
           script: |
             const branchName = '${{ steps.branch-name.outputs.branch }}';
-            const protectedBranches = ['main', 'dev', 'prod', 'fe/dev', 'fe/prod', 'be/dev', 'be/prod'];
+            const protectedBranches = ['main', 'dev', 'prod'];
 
             if (protectedBranches.includes(branchName)) {
               await github.rest.issues.createComment({

--- a/.github/workflows/chromatic-base.yml
+++ b/.github/workflows/chromatic-base.yml
@@ -1,9 +1,8 @@
-name: Deploy Base Storybook (fe/dev)
+name: Deploy Base Storybook (dev)
 
 on:
   push:
     branches:
-      - fe/dev
       - dev
 
 jobs:

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -3,7 +3,6 @@ name: Deploy PR Storybook Preview
 on:
   pull_request:
     branches:
-      - fe/dev
       - dev
     types: [opened, synchronize]
     paths:

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -2,7 +2,7 @@ name: Close issues when PR is merged
 on:
   pull_request:
     types: [closed] # PR이 닫힐 때
-    branches: [dev, prod, fe/dev, fe/prod, be/dev, be/prod]
+    branches: [dev, prod]
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: CodeQL Security Analysis
 
 on:
   push:
-    branches: [be/dev, be/prod, dev]
+    branches: [dev, prod]
     paths: ['backend/**']
   pull_request:
-    branches: [be/dev, be/prod, dev]
+    branches: [dev, prod]
     paths: ['backend/**']
   schedule:
     - cron: '0 2 * * 1'

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -3,7 +3,7 @@ name: Docs CI
 on:
   # PR이 열릴 때, 업데이트될 때, 다시 열릴 때
   pull_request:
-    branches: [be/dev, dev]
+    branches: [dev]
     paths:
       - "**/*.md"
       - ".markdownlint.jsonc"
@@ -12,7 +12,7 @@ on:
 
   # 커밋이 푸시될 때
   push:
-    branches: [be/dev, dev]
+    branches: [dev]
     paths:
       - "**/*.md"
       - ".markdownlint.jsonc"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -3,7 +3,7 @@ name: Frontend CI
 on:
   # PR이 열릴 때, 업데이트될 때, 다시 열릴 때
   pull_request:
-    branches: [fe/dev, fe/prod, dev, prod]
+    branches: [dev, prod]
     paths:
       - "frontend/**"
 

--- a/.github/workflows/monitoring-rules-ci.yml
+++ b/.github/workflows/monitoring-rules-ci.yml
@@ -6,12 +6,12 @@ name: Monitoring Rules CI
 
 on:
   pull_request:
-    branches: [be/dev, dev]
+    branches: [dev]
     paths:
       - "backend/docker/monitoring/conf/rules/**"
       - ".github/workflows/monitoring-rules-ci.yml"
   push:
-    branches: [be/dev, dev]
+    branches: [dev]
     paths:
       - "backend/docker/monitoring/conf/rules/**"
       - ".github/workflows/monitoring-rules-ci.yml"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,7 @@
 - **모든 작업(백엔드·프론트·풀스택)은 통합 브랜치 `dev`에서 분기해 `dev`로 PR한다.**
 - 브랜치명은 prefix 없이 `{type}/{N}-{slug}` (예: `feat/1502-nunchi-game`). type: `feat`·`fix`·`refactor`·`chore`·`docs`·`test`.
 - 영역(BE/FE)은 브랜치가 아니라 **라벨**로 구분한다 — `create-issue`/`create-pr`가 변경 영역을 판별해 `BE`/`FE`(풀스택이면 둘 다) 라벨을 단다.
-- 프로덕션 승격은 통합 `prod` 브랜치로의 `dev`→`prod` PR로만 한다. `prod` push가 곧 운영 배포다.
-- `be/dev`·`fe/dev`·`be/prod`·`fe/prod`는 전환기 호환으로만 남아 있다. 신규 분기·PR 대상이 아니다. 상세는 [git-push-safety](.claude/rules/git-push-safety.md).
+- 프로덕션 승격은 통합 `prod` 브랜치로의 `dev`→`prod` PR로만 한다. `prod` push가 곧 운영 배포다. 상세는 [git-push-safety](.claude/rules/git-push-safety.md).
 
 ## 공통 스킬 (전역)
 

--- a/backend/.claude/skills/commit/SKILL.md
+++ b/backend/.claude/skills/commit/SKILL.md
@@ -38,7 +38,7 @@ bash .claude/skills/commit/preflight.sh
 그룹 유형별 검증 대상:
 
 - **자바 프로덕션 포함** → `/run-tests`로 위임. 한 모듈 안이면 `:module` 타겟, 여러 모듈/패키지에 걸치면 해당 패키지 필터를 모두 포함한다 (`./gradlew` 직접 실행 금지 — CLAUDE.md).
-- **문서(`.md`)만** → 저장소 루트에서 `npx markdownlint-cli2` (Docs CI가 be/dev PR에서 강제하는 것과 동일).
+- **문서(`.md`)만** → 저장소 루트에서 `npx markdownlint-cli2` (Docs CI가 dev PR에서 강제하는 것과 동일).
 - **설정/빌드만** → 자동 검증 없음.
 - **테스트 파일만** → 해당 테스트만 실행한다.
 

--- a/backend/.claude/skills/commit/preflight.sh
+++ b/backend/.claude/skills/commit/preflight.sh
@@ -9,7 +9,7 @@
 # 테스트용: PREFLIGHT_BRANCH 를 set 하면(빈 값 포함) 브랜치 감지를 오버라이드한다.
 set -u
 
-PROTECTED="dev prod be/dev be/prod fe/dev fe/prod main master"
+PROTECTED="dev prod main master"
 
 # 현재 브랜치 (detached 면 빈 문자열). PREFLIGHT_BRANCH 가 set 돼 있으면 그 값을 쓴다.
 if [ -n "${PREFLIGHT_BRANCH+set}" ]; then

--- a/backend/.claude/skills/postmortem/SKILL.md
+++ b/backend/.claude/skills/postmortem/SKILL.md
@@ -16,7 +16,7 @@ ADR과 포스트모템은 장르가 다르다. **ADR은 "앞으로 무엇을 할
 3. 사실관계는 메모리·추측이 아니라 git 로그·PR·실제 코드로 검증한 뒤 서술한다. 확인 못 한 부분은 "미해결/미확인"으로 명시한다.
 4. 회고에서 결정이 도출됐으면 `/adr`로 ADR을 작성하고, 포스트모템 상단 메타의 `관련 ADR`에 링크한다.
 5. `index.md` 테이블 맨 끝에 한 줄을 추가한다 ([format.md](format.md)의 행 형식, 번호 오름차순 유지).
-6. **markdownlint 검증** — 저장소 루트에서 `npx markdownlint-cli2`을 실행해 통과시킨다 (Docs CI가 be/dev PR에서 강제). 규칙·예시는 `docs/conventions-docs.md`.
+6. **markdownlint 검증** — 저장소 루트에서 `npx markdownlint-cli2`을 실행해 통과시킨다 (Docs CI가 dev PR에서 강제). 규칙·예시는 `docs/conventions-docs.md`.
 
 ## 작성 원칙
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -8,7 +8,7 @@
 
 브랜치 전략은 모노레포 공통이다 — 루트 [CLAUDE.md](../CLAUDE.md)·[git-push-safety](../.claude/rules/git-push-safety.md)를 따른다. 요약:
 
-- 작업 브랜치는 통합 브랜치 **`dev`에서 분기**하고 PR 타깃도 `dev`다 (백엔드도 `be/dev`가 아니라 `dev`). 분기 시 `git switch -c {type}/{N}-{slug} origin/dev` 후 `git branch --unset-upstream`.
+- 작업 브랜치는 통합 브랜치 **`dev`에서 분기**하고 PR 타깃도 `dev`다. 분기 시 `git switch -c {type}/{N}-{slug} origin/dev` 후 `git branch --unset-upstream`.
 - 브랜치 네이밍은 prefix 없이 `{type}/{N}-{slug}`. 영역(BE)은 `create-issue`/`create-pr`가 라벨로 붙인다.
 - `dev`가 저장소 **기본 브랜치**다. README·dependabot·CodeRabbit·워크플로우 등 GitHub 관련 파일도 `dev`에서 관리한다(dependabot·보안 스캔·스케줄은 기본 브랜치 기준으로 동작). `main`은 배포 브랜치가 아니며(배포는 `dev`·`prod` push 트리거) 전환기 잔재로만 남아 있다 — 신규 작업에 사용하지 않는다.
 - 이슈·PR 생성은 루트 공통 스킬 `create-issue`·`create-pr`를 쓴다.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -37,7 +37,7 @@ BE 컨트랙트(WebSocket + HTTP)를 직접 `curl` 로 받아도 되지만, 본 
 
 **MCP 빌드**: 별도 빌드 불필요. `frontend/.mcp.json` 이 self-healing 런처(`../tools/api-mcp/scripts/launch.mjs`)를 가리키므로 실행 시점에 의존성 설치·빌드를 자동 보장한다.
 
-**컨트랙트 검증 위치**: api-mcp 의 zod 스키마와 BE 카탈로그의 일치(contract drift) 검증은 **be/dev 가 단독으로 소유**한다 — fixture 생성기(`WsCatalogFixtureGeneratorTest`, `-DupdateFixture=true`)·커밋된 fixture·BE 소스가 모두 be/dev 에 있기 때문이다. `tools/api-mcp` 는 be/dev 미러이므로 fe/dev CI 는 컨트랙트 검증을 수행하지 않고 빌드·린트·단위 테스트만 돌린다.
+**컨트랙트 검증 위치**: api-mcp 의 zod 스키마와 BE 카탈로그의 일치(contract drift) 검증은 **BE CI(api-mcp CI)가 단독으로 소유**한다 — fixture 생성기(`WsCatalogFixtureGeneratorTest`, `-DupdateFixture=true`)·커밋된 fixture·BE 소스가 모두 `backend/` 에 있기 때문이다. `tools/api-mcp` 는 BE 소스의 미러이므로 FE CI 는 컨트랙트 검증을 수행하지 않고 빌드·린트·단위 테스트만 돌린다.
 
 **prefix 주의사항**: MCP 카탈로그의 path 는 prefix 를 포함(`/topic/room/...`, `/user/queue/...`, `/app/...`)하지만, FE 의 `useWebSocketSubscription`/`send` 는 wrapper 가 prefix 를 자동 추가하므로 path 에서 `/topic`·`/app` 부분을 제거해 전달한다 (자세한 규칙은 `.claude/rules/websocket.md`).
 

--- a/frontend/docs/architecture.md
+++ b/frontend/docs/architecture.md
@@ -79,7 +79,7 @@ fetch를 래핑한 커스텀 훅:
 
 ## DevTools (`src/devtools/`, `ENABLE_DEVTOOLS`)
 
-`process.env.ENABLE_DEVTOOLS`가 truthy일 때만 `DevToolsWrapper`(iframe 자동 테스트 패널, 네트워크 디버거)가 렌더링된다. `.env.development`에 `ENABLE_DEVTOOLS=true`가 설정되어 있어 로컬 dev 서버와 `build:dev`(be/dev 환경) 양쪽에서 활성화된다.
+`process.env.ENABLE_DEVTOOLS`가 truthy일 때만 `DevToolsWrapper`(iframe 자동 테스트 패널, 네트워크 디버거)가 렌더링된다. `.env.development`에 `ENABLE_DEVTOOLS=true`가 설정되어 있어 로컬 dev 서버와 `build:dev`(dev 환경) 양쪽에서 활성화된다.
 
 **기능별 가드도 `ENABLE_DEVTOOLS` 기준을 따른다.** `useMockMode`와 `useServiceWorkerUpdate`의 기능 활성화 조건은 `NODE_ENV === 'development'`가 아니라 `Boolean(process.env.ENABLE_DEVTOOLS)`로 통일되어 있다. `NODE_ENV`를 사용하면 `build:dev`처럼 `NODE_ENV=development`이지만 별도 배포 환경인 경우에도 동작하지만, `ENABLE_DEVTOOLS` 없이 `NODE_ENV=production` 빌드에 devtools를 붙이는 경우엔 기능이 비활성화된다. 두 조건을 일치시킴으로써 패널 노출 여부와 기능 동작 여부가 항상 같은 변수로 제어된다.
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1582

# 🚀 작업 내용

1. **문서·규칙·스킬 (9개 파일)** — 루트·backend·frontend CLAUDE.md, git-push-safety 규칙, create-pr·commit·postmortem 스킬에서 `be/dev`·`fe/dev`·`be/prod`·`fe/prod` 전환기 문구와 TODO를 제거했습니다. 보호 브랜치 목록(PROTECTED)은 `dev prod main master` 4개로 통일했습니다.
2. **CI 설정 (11개 파일)** — 워크플로우 10개와 `.coderabbit.yaml`의 레거시 브랜치 트리거를 제거했습니다. 모든 워크플로우 트리거에 이미 `dev`(필요한 곳은 `prod`)가 포함돼 있어 순수 삭제입니다. 예외 하나: CodeQL은 기존에 `be/prod` push를 분석하고 있었으므로 대응 관계에 맞춰 `prod`를 추가했습니다.

# 💬 리뷰 중점사항

- **의도적으로 남긴 것 2곳**: ① `git-push-safety.md` 첫 문단의 `be/dev` 언급은 #1404 사고 기록(역사 서술)이라 유지했습니다. ② `test-validate-deployment.sh`의 be/dev·be/prod 테스트는 "레거시 브랜치 push가 배포 검증에서 거부되는지"를 확인하는 회귀 테스트라 유지했습니다.
- **브랜치 자동 삭제 보호 목록 축소**: `be-delete-merged-branch.yml`의 삭제 보호 목록을 `main·dev·prod`로 줄였습니다. 원격에 아직 남아 있는 `be/dev` 등 레거시 브랜치가 PR의 head가 되는 경우(예: 마지막 동기화 PR)에는 머지 후 자동 삭제될 수 있습니다 — 레거시 브랜치는 어차피 삭제 예정(기존 TODO)이라 수용 가능하다고 판단했는데, 보수적으로 가려면 이 목록만 되돌리면 됩니다.
- **ADR·포스트모템은 미수정**: 과거 결정·사고 기록이므로 손대지 않았습니다.
- **검증**: 워크플로우·coderabbit YAML 파싱 통과, `npx markdownlint-cli2` 0건.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 개발·배포 자동화가 통합 브랜치인 `dev`와 `prod`를 기준으로 실행되도록 조정되었습니다.
  * 백엔드·프론트엔드·문서·보안·모니터링 검증 및 Storybook 미리보기의 대상 브랜치가 정리되었습니다.
  * 병합된 브랜치 자동 삭제와 보호 브랜치 정책이 통합 브랜치 기준으로 일관되게 적용됩니다.
  * 브랜치 전략 및 CI 검증 안내 문서가 현재 운영 방식에 맞게 업데이트되었습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->