### PR TITLE
[fix] IP 차단 알림 룰을 prod로 한정하고 job 라벨 보존

### DIFF
--- a/backend/docker/monitoring/conf/rules/alerts-app.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-app.yml
@@ -31,30 +31,36 @@ groups:
           summary: "HTTP 5xx 비율 5% 초과 ({{ $labels.job }})"
           description: "최근 5분 5xx 비율이 {{ $value | humanizePercentage }}. 서버 측 광범위 실패 가능성."
 
-      # 대량 IP 차단 급증 — 본 프로젝트가 반응한 그 인시던트의 증상.
-      # X-Forwarded-For 소실 → 전 트래픽이 단일 내부 IP로 인식 → IpBlockFilter가 BAN →
-      # 차단 요청 수가 평소 베이스라인을 크게 벗어나 치솟는다(ADR-0026 §5).
-      # ⚠️ 임계 5 req/s는 순수 추정. 정상 차단(악성 트래픽)과 구분하려면 베이스라인 필수.
-      #    라벨 기반 정밀화(ip_type=private 즉발)는 후속 PR에서 오탐을 줄인다.
+      # 대량 IP 차단 급증 — 이미 차단된 IP의 요청이 거절되는 비율(ADR-0026 §5).
+      # prod로 한정하고 job 라벨을 보존한다(#1592). 이전에는 job 필터 없는 sum()이라
+      # dev·prod를 합산했고, dev가 스캐너 스윕을 받는 동안 그 수치가 전체 합계가 되어
+      # prod 무이상 상태에서 CRITICAL 13건이 오발화했다. 또한 sum()이 라벨을 제거해
+      # Alertmanager 라우팅과 zzol-bot의 환경 식별이 불가능했다(ADR-0032).
+      # 임계 2 req/s — prod 관측 최대 0.528 req/s 대비 약 4배 여유(2026-07 실측).
+      # ⚠️ 30일 베이스라인 확보 후 재조정 필요.
+      # description에 원인 가설을 적지 않는다 — 웹훅 payload로 zzol-bot 프롬프트에
+      # 들어가 LLM이 그 가설을 결론으로 되돌려준다(#1592).
       - alert: MassIpBlockingSpike
-        expr: sum(rate(ip_block_request_blocked_total[5m])) > 5
+        expr: sum by (job) (rate(ip_block_request_blocked_total{job="prod-app"}[5m])) > 2
         for: 3m
         labels:
           severity: critical
         annotations:
-          summary: "IP 차단 요청 급증 (전 트래픽 차단 인시던트 의심)"
-          description: "차단 요청이 {{ $value | printf \"%.2f\" }} req/s. X-Forwarded-For 소실로 내부 IP가 BAN되는 패턴인지 즉시 확인."
+          summary: "IP 차단 요청 급증 ({{ $labels.job }})"
+          description: "차단 요청이 {{ $value | printf \"%.2f\" }} req/s. 베이스라인(약 0.5 req/s) 대비 급증. 차단된 IP와 요청 경로를 확인."
 
-      # 신규 BAN 급증 — 위 증상의 선행 신호(차단보다 BAN 등록이 먼저 튄다).
-      # ⚠️ 임계 추정. 짧은 창에 신규 BAN이 몰리면 비정상.
+      # 신규 BAN 급증 — 위 증상의 선행 신호(차단 요청보다 BAN 등록이 먼저 튄다).
+      # MassIpBlockingSpike와 동일하게 prod 한정 + job 라벨 보존(#1592).
+      # 임계 0.5/s — prod 관측 최대 0.055/s 대비 약 9배 여유(2026-07 실측).
+      # ⚠️ 30일 베이스라인 확보 후 재조정 필요.
       - alert: IpBanRateSpike
-        expr: sum(rate(ip_block_new_total[5m])) > 1
+        expr: sum by (job) (rate(ip_block_new_total{job="prod-app"}[5m])) > 0.5
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "신규 IP BAN 급증"
-          description: "신규 BAN이 {{ $value | printf \"%.2f\" }} /s. 정상 베이스라인 대비 비정상이면 차단 정책/프록시 헤더를 점검."
+          summary: "신규 IP BAN 급증 ({{ $labels.job }})"
+          description: "신규 BAN이 {{ $value | printf \"%.2f\" }} /s. 차단된 IP 대역과 접근 경로를 확인."
 
       # WebSocket 핸드셰이크 실패 — /ws 엔드포인트의 HTTP 에러 응답 급증.
       # 기존 Grafana 룰(websocket_connections_failed_total, STOMP 연결 단계)과 중복을 피하려


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1592

# 🚀 작업 내용

## 문제 상황

알림 룰이 **dev와 prod 수치를 하나로 합쳐서** 보고 있었습니다.

```yaml
expr: sum(rate(ip_block_request_blocked_total[5m])) > 5   # job 필터 없음
```

dev가 스캐너 공격(`/.env`, `/.git/config`, `/.ssh/id_rsa` 탐색)을 받는 동안 그 값이 곧 전체 합계가 되어, prod는 정상인데도 CRITICAL이 울렸습니다. 07/11~15 사이 알림 13건이 전부 이 경로로 잘못 발화했습니다.

| 지표 | dev 최대 | prod 최대 | 당시 임계 |
|---|---|---|---|
| 차단 요청 | **10.541** req/s | 0.528 req/s | 5 |
| 신규 BAN | **2.166** /s | 0.055 /s | 1 |

알림 본문에 찍힌 "10.54 req/s"가 dev 실측치와 소수점까지 일치합니다. prod는 임계의 1/10 수준이라 혼자서는 알림을 낼 수 없었습니다.

문제가 하나 더 겹쳐 있었습니다. `sum()`은 **모든 라벨을 지웁니다.** 그래서 발화한 알림에 "어느 환경인지"가 남지 않았고, Alertmanager는 환경별 라우팅을 할 수 없었으며 zzol-bot도 어느 환경 로그를 봐야 할지 알 수 없었습니다. 잘못 울린 알림을 화면에서 알아챌 단서가 없었던 이유입니다.

## 변경 내용

`docker/monitoring/conf/rules/alerts-app.yml` 한 파일만 수정했습니다.

1. **두 룰을 prod로 한정했습니다.** 식에 `{job="prod-app"}`을 붙여 dev 수치가 섞이지 않게 했습니다.

2. **`sum by (job)`으로 바꿔 job 라벨을 남깁니다.** 알림에 환경 정보가 실려야 라우팅과 진단이 가능합니다.

3. **임계값을 prod 실측 기준으로 다시 잡았습니다.** 차단 요청 `5 → 2` req/s, 신규 BAN `1 → 0.5` /s. 기존 값은 룰 주석에 "순수 추정"이라 적혀 있던 미검증 숫자였습니다.

4. **알림 설명(description)에서 원인 가설을 뺐습니다.** "X-Forwarded-For 소실로 내부 IP가 BAN되는 패턴인지 확인"이라는 문장이 웹훅으로 zzol-bot 프롬프트에 그대로 들어갑니다. 그 결과 LLM이 13건 내내 XFF 소실을 원인으로 지목했는데, 해당 시나리오는 `IpBlockFilter:72-79`에서 이미 방어된 상태였습니다. 관측된 사실만 남기고 확인할 지점만 안내하도록 고쳤습니다.

5. **임계값 근거와 재조정 계획을 주석에 남겼습니다.** 실측치와 여유 배수, 30일 베이스라인 확보 후 재조정이 필요하다는 점입니다.

# 💬 리뷰 중점사항

**dev를 알림 대상에서 뺀 이유**

dev의 대량 차단은 스캐너 탐색에 대한 **정상 동작**입니다. 차단 필터는 제 역할을 했고, 알려야 할 이상이 아닙니다. dev도 알림을 받게 하려면 별도 임계와 별도 수신자가 필요해서 이번 범위에서 뺐습니다. 필요하다는 의견 있으면 후속으로 논의하면 좋겠습니다.

**임계값 2 / 0.5의 근거**

prod 실측 최대치는 차단 요청 0.528 req/s, 신규 BAN 0.055 /s였습니다. 각각 약 4배·9배 여유를 뒀습니다. 다만 근거 구간이 Prometheus 보존 기간(7일)뿐이라 아직 짧습니다. 30일치가 쌓이면 다시 볼 필요가 있고, 그 내용을 룰 주석에 적어뒀습니다. 더 보수적인 값이 낫다는 의견 있으면 조정하겠습니다.

**검증 방법**

- `promtool check rules` 통과 (`SUCCESS: 5 rules found`)
- 바뀐 식을 실제 Prometheus 데이터에 그대로 돌려, 보존 구간 전체에서 임계를 넘지 않는 것을 확인했습니다 (0.528 < 2, 0.055 < 0.5)
- `sum by (job)` 적용 후 결과에 `{job="prod-app"}` 라벨이 남는 것을 확인했습니다

**배포 시 참고**

Prometheus는 재시작 없이 SIGHUP으로 룰을 다시 읽습니다 (ADR-0032 배포 체크리스트).

**이 PR에서 다루지 않은 것**

- zzol-bot 자체 개선(알림의 환경 라벨을 읽도록 수정, 알림과 로그가 어긋날 때 침묵하지 않도록 보완, 근본원인 가설 저장) — 별도 이슈로 진행 예정입니다. 이번 수정으로 job 라벨이 살아나 그 전제가 갖춰졌습니다.
- `AppErrorLogSpike`가 매번 00:03에 울리는 건과 Redis Stream 지연 2건 — 원인 미확정이라 #1592에 "조사 필요"로 분리해뒀습니다.
