### PR TITLE
[fix] ZzolBot 이상 분석의 환경 불일치와 근거 없는 결론을 차단

### DIFF
--- a/backend/app/src/main/resources/config/zzolbot.yml
+++ b/backend/app/src/main/resources/config/zzolbot.yml
@@ -15,7 +15,7 @@ zzol-bot:
     top-p: 0.1
   monitor:
     enabled: ${ZZOL_BOT_MONITOR_ENABLED:true}    # Alertmanager firing 알림 분석 활성 여부
-    error-log-window-minutes: 240                # ERROR 로그 샘플 조회 윈도우(기본 4시간)
+    error-log-window-minutes: 30                 # ERROR 로그 샘플 조회 윈도우. 넓으면 알림과 무관한 상시 에러가 딸려 들어와 분석이 엉뚱한 근거 위에 선다(#1594). 알림 시점 전후를 좁게 본다
     enrich-cooldown-minutes: 240                 # 같은 fingerprint 재분석 최소 간격(기본 4시간). 중복 분석 방지 — 재시도·flapping 흡수 + 지속 장애 LLM 재호출 비용 절감. 0이면 비활성
   slack:
     webhook-url: ${ZZOL_BOT_SLACK_WEBHOOK_URL:}  # 미설정 시 알림 비활성

--- a/backend/app/src/main/resources/templates/admin/zzolbot.html
+++ b/backend/app/src/main/resources/templates/admin/zzolbot.html
@@ -884,6 +884,7 @@
 
     function buildMonitorDetail(a) {
         let signalsHtml;
+        let evidenceHtml = '';
         try {
             // Alertmanager 발화 알림 컨텍스트(FiringAlert): alertname·severity·요약·설명 + 라벨
             const ctx = JSON.parse(a.signalsJson || '{}');
@@ -900,6 +901,7 @@
                     + rows.map(([k, v]) => `<tr><th>${esc(k)}</th><td>${esc(String(v))}</td></tr>`).join('')
                     + '</tbody></table>'
                 : '<div class="muted">발화 정보 없음</div>';
+            evidenceHtml = buildEvidenceBlock(ctx.analysisContext);
         } catch (e) {
             signalsHtml = '<div class="muted">발화 정보 파싱 실패</div>';
         }
@@ -918,7 +920,24 @@
             + `<span class="label">🧠 분석 요약</span>`
             + `<div class="muted">${esc(a.analysisSummary || '분석 없음 (정상이거나 예산 소진)')}</div>`
             + actionsHtml
+            + evidenceHtml
             + `</div>`;
+    }
+
+    // 분석이 무엇을 근거로 삼았는지. 이게 없으면 분석이 틀렸을 때 화면만으로 검증할 수 없다.
+    function buildEvidenceBlock(ac) {
+        if (!ac) return '';
+        const rows = [
+            ['조회 환경', ac.logEnvironment],
+            ['조회 창', ac.windowMinutes != null ? `최근 ${ac.windowMinutes}분` : null],
+            ['로그 샘플', ac.logSampleCount != null ? `${ac.logSampleCount}건` : null],
+            ['근거 확인', ac.evidenceFound ? '✅ 로그가 알림을 뒷받침함' : '⚠️ 뒷받침하는 근거 없음'],
+        ].filter(([, v]) => v != null && v !== '');
+        if (ac.rootCauseHypothesis) rows.push(['근본원인 가설', ac.rootCauseHypothesis]);
+        return `<span class="label">🔍 조회 근거</span>`
+            + '<table class="data" style="margin-top:0.3rem"><tbody>'
+            + rows.map(([k, v]) => `<tr><th>${esc(k)}</th><td>${esc(String(v))}</td></tr>`).join('')
+            + '</tbody></table>';
     }
 
     loadHistory();

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,8 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
     private static final int LOG_SAMPLE_LIMIT = 20;
     private static final String JOB_LABEL = "job";
     private static final String JOB_SUFFIX = "-app";
+    // 유도한 환경명이 LogQL 셀렉터에 삽입되므로 허용 문자를 제한한다 — 인젝션 방지 + 빈 문자열 차단.
+    private static final Pattern SAFE_ENVIRONMENT = Pattern.compile("^[a-zA-Z0-9_-]+$");
 
     private final LlmCallBudget llmCallBudget;
     private final LokiLogClient lokiLogClient;
@@ -74,21 +77,33 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
 
     /**
      * 알림의 {@code job} 라벨에서 조회할 환경을 유도한다({@code prod-app} → {@code prod}).
-     * 라벨이 없으면 이 인스턴스의 환경으로 폴백한다 — 룰이 {@code sum()}으로 라벨을 지우면
-     * 알림에 환경 정보가 남지 않기 때문이다(#1592에서 실제로 발생).
+     * 라벨이 없거나 유도 결과가 환경명 형식에 맞지 않으면 이 인스턴스의 환경으로 폴백한다.
+     * <p>
+     * 폴백이 필요한 이유가 둘이다. (1) 룰이 {@code sum()}으로 라벨을 지우면 알림에 환경 정보가
+     * 남지 않는다(#1592에서 실제로 발생). (2) 유도한 값은 하류 {@link LokiLogClient#tailErrors}의
+     * LogQL 셀렉터에 그대로 삽입되므로, 형식을 검증하지 않으면 셀렉터 인젝션 위험이 있고
+     * {@code job}이 정확히 {@code "-app"}일 때 빈 문자열이 되어 환경 필터가 무력화된다(#1595 리뷰).
      */
     private String resolveEnvironment(FiringAlert alert) {
         final String job = alert.labels().get(JOB_LABEL);
         if (job == null || job.isBlank()) {
-            final String fallback = lokiLogClient.defaultEnvironment();
-            log.info("[ZzolBot] 알림에 job 라벨 없음 — 실행 환경({})으로 폴백. fingerprint={}",
-                    fallback, alert.fingerprint());
-            return fallback;
+            return fallbackEnvironment(alert, "job 라벨 없음");
         }
         final String trimmed = job.trim();
-        return trimmed.endsWith(JOB_SUFFIX)
+        final String derived = trimmed.endsWith(JOB_SUFFIX)
                 ? trimmed.substring(0, trimmed.length() - JOB_SUFFIX.length())
                 : trimmed;
+        if (!SAFE_ENVIRONMENT.matcher(derived).matches()) {
+            return fallbackEnvironment(alert, "환경명 형식 위반(job=%s)".formatted(job));
+        }
+        return derived;
+    }
+
+    private String fallbackEnvironment(FiringAlert alert, String reason) {
+        final String fallback = lokiLogClient.defaultEnvironment();
+        log.info("[ZzolBot] {} — 실행 환경({})으로 폴백. fingerprint={}",
+                reason, fallback, alert.fingerprint());
+        return fallback;
     }
 
     /**

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
@@ -31,6 +31,8 @@ import org.springframework.stereotype.Service;
 public class AlertEnrichmentService implements FiringAlertEnricher {
 
     private static final int LOG_SAMPLE_LIMIT = 20;
+    private static final String JOB_LABEL = "job";
+    private static final String JOB_SUFFIX = "-app";
 
     private final LlmCallBudget llmCallBudget;
     private final LokiLogClient lokiLogClient;
@@ -57,20 +59,55 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
         final MonitorRunEntity run = monitorRunRepository.save(
                 MonitorRunEntity.of(now, severity, alert.fingerprint(), toJson(alertContext(alert))));
 
-        final MonitorAnalysis analysis = analyze(alert, now);
-        run.attachAnalysis(analysis.summary(), toJson(analysis.suggestedActions()));
+        final String environment = resolveEnvironment(alert);
+        final List<String> logs = lokiLogClient.tailErrors(now, properties.window(), LOG_SAMPLE_LIMIT, environment);
+        final MonitorAnalysis analysis = analyze(alert, logs, environment);
+
+        run.attachAnalysis(
+                analysis.summary(),
+                toJson(analysis.suggestedActions()),
+                toJson(alertContext(alert, environment, logs.size(), analysis)));
         run.markNotified();
         notifier.notifyAnomaly(alert, analysis);
         monitorRunRepository.save(run);
     }
 
-    private MonitorAnalysis analyze(FiringAlert alert, Instant now) {
+    /**
+     * 알림의 {@code job} 라벨에서 조회할 환경을 유도한다({@code prod-app} → {@code prod}).
+     * 라벨이 없으면 이 인스턴스의 환경으로 폴백한다 — 룰이 {@code sum()}으로 라벨을 지우면
+     * 알림에 환경 정보가 남지 않기 때문이다(#1592에서 실제로 발생).
+     */
+    private String resolveEnvironment(FiringAlert alert) {
+        final String job = alert.labels().get(JOB_LABEL);
+        if (job == null || job.isBlank()) {
+            final String fallback = lokiLogClient.defaultEnvironment();
+            log.info("[ZzolBot] 알림에 job 라벨 없음 — 실행 환경({})으로 폴백. fingerprint={}",
+                    fallback, alert.fingerprint());
+            return fallback;
+        }
+        final String trimmed = job.trim();
+        return trimmed.endsWith(JOB_SUFFIX)
+                ? trimmed.substring(0, trimmed.length() - JOB_SUFFIX.length())
+                : trimmed;
+    }
+
+    /**
+     * 로그 근거를 먼저 확보하고, 근거가 있을 때만 예산을 소모해 LLM을 호출한다.
+     * <p>
+     * 근거 없이 LLM을 부르면 알림 메타데이터만으로 그럴듯한 인과를 지어낸다(#1594). 예산 확인을
+     * 로그 조회 뒤로 옮긴 이유이기도 하다 — 어차피 분석하지 않을 건에 예산 슬롯을 태우지 않는다.
+     */
+    private MonitorAnalysis analyze(FiringAlert alert, List<String> logs, String environment) {
+        if (logs.isEmpty()) {
+            log.info("[ZzolBot] 조회 구간에 ERROR 로그 없음 — LLM 분석 생략. environment={} fingerprint={}",
+                    environment, alert.fingerprint());
+            return MonitorAnalysis.noEvidence(environment, (int) properties.window().toMinutes());
+        }
         if (!llmCallBudget.tryAcquire()) {
             log.warn("[ZzolBot] 일일 LLM 예산 소진 — 이상 분석 생략. fingerprint={}", alert.fingerprint());
             return MonitorAnalysis.budgetExhausted();
         }
-        final List<String> logs = lokiLogClient.tailErrors(now, properties.window(), LOG_SAMPLE_LIMIT);
-        return safeAnalyze(alert, logs);
+        return safeAnalyze(alert, logs, environment);
     }
 
     /**
@@ -88,9 +125,9 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
                 fingerprint, now.minus(cooldown));
     }
 
-    private MonitorAnalysis safeAnalyze(FiringAlert alert, List<String> logSamples) {
+    private MonitorAnalysis safeAnalyze(FiringAlert alert, List<String> logSamples, String environment) {
         try {
-            return analyzer.analyze(alert, logSamples);
+            return analyzer.analyze(alert, logSamples, environment);
         } catch (Exception e) {
             log.warn("[ZzolBot] 이상 분석 실패 — 결정적 알림만 전송. fingerprint={}", alert.fingerprint(), e);
             return MonitorAnalysis.failed();
@@ -111,6 +148,26 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
         context.put("summary", nullToEmpty(alert.summary()));
         context.put("description", nullToEmpty(alert.description()));
         context.put("labels", alert.labels());
+        return context;
+    }
+
+    /**
+     * 알림 컨텍스트에 "무엇을 근거로 분석했는가"를 덧붙인다. 분석이 틀렸을 때 어드민 화면만 보고
+     * 검증할 수 있게 하려는 것으로, 진단 챗 경로가 답변에 조회 기준을 남기는 것과 같은 취지다(#1594).
+     * <p>
+     * 전용 컬럼 대신 기존 {@code signals_json}에 병합해 마이그레이션 없이 처리한다. 입력(알림)과
+     * 분석 메타데이터가 한 컬럼에 섞이는 절충이며, 별도 키로 분리해 구분한다.
+     */
+    private Map<String, Object> alertContext(
+            FiringAlert alert, String environment, int logSampleCount, MonitorAnalysis analysis) {
+        final Map<String, Object> context = alertContext(alert);
+        final Map<String, Object> analysisContext = new LinkedHashMap<>();
+        analysisContext.put("logEnvironment", environment);
+        analysisContext.put("windowMinutes", properties.window().toMinutes());
+        analysisContext.put("logSampleCount", logSampleCount);
+        analysisContext.put("evidenceFound", analysis.evidenceFound());
+        analysisContext.put("rootCauseHypothesis", nullToEmpty(analysis.rootCauseHypothesis()));
+        context.put("analysisContext", analysisContext);
         return context;
     }
 

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/domain/MonitorAnalysis.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/domain/MonitorAnalysis.java
@@ -4,18 +4,40 @@ import java.util.List;
 
 /**
  * 이상 발생 시 LLM이 생성한 근본원인 분석. 조치(suggestedActions)는 제안만 하며 자동 실행하지 않는다.
+ * <p>
+ * {@code evidenceFound}는 "이 분석이 실제 로그 근거에 기반했는가"를 나타낸다. 알림과 무관한 로그만
+ * 주어졌는데도 그럴듯한 인과를 지어내는 실패를 드러내기 위한 필드로, LLM이 스스로 판정한다(#1594).
+ * 판정이 누락되면 보수적으로 false로 본다 — 운영봇에서는 과소 주장이 과대 주장보다 안전하다.
  */
-public record MonitorAnalysis(String summary, String rootCauseHypothesis, List<String> suggestedActions) {
+public record MonitorAnalysis(
+        String summary,
+        String rootCauseHypothesis,
+        List<String> suggestedActions,
+        boolean evidenceFound
+) {
 
     public MonitorAnalysis {
         suggestedActions = List.copyOf(suggestedActions);
     }
 
     public static MonitorAnalysis budgetExhausted() {
-        return new MonitorAnalysis("LLM 분석 생략 (일일 예산 소진)", "", List.of());
+        return new MonitorAnalysis("LLM 분석 생략 (일일 예산 소진)", "", List.of(), false);
     }
 
     public static MonitorAnalysis failed() {
-        return new MonitorAnalysis("LLM 분석 실패", "", List.of());
+        return new MonitorAnalysis("LLM 분석 실패", "", List.of(), false);
+    }
+
+    /**
+     * 조회 구간에 ERROR 로그가 없어 분석 근거를 확보하지 못한 경우. LLM을 호출하지 않으므로
+     * 예산도 소모하지 않는다. 근거 없이 결론을 만드는 대신 근거가 없다는 사실 자체를 알린다.
+     */
+    public static MonitorAnalysis noEvidence(String environment, int windowMinutes) {
+        return new MonitorAnalysis(
+                "LLM 분석 생략 — %s 환경의 최근 %d분 구간에서 ERROR 로그를 찾지 못해 알림을 뒷받침할 근거가 없다."
+                        .formatted(environment, windowMinutes),
+                "",
+                List.of(),
+                false);
     }
 }

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/AnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/AnomalyAnalyzer.java
@@ -5,10 +5,12 @@ import coffeeshout.zzolbot.monitor.domain.MonitorAnalysis;
 import java.util.List;
 
 /**
- * firing 알림을 LLM으로 요약·근본원인 분석한다. 예산이 있을 때만 호출된다.
+ * firing 알림을 LLM으로 요약·근본원인 분석한다. 예산이 있고 로그 근거가 있을 때만 호출된다.
  * {@code logSamples}는 알림 시점의 실제 ERROR 로그 샘플로, 알림 메타데이터를 넘어 내용 기반 분석에 쓰인다.
+ * {@code logEnvironment}는 그 샘플을 어느 환경에서 가져왔는지로, 알림 대상 환경과 어긋나면
+ * 분석이 무관한 근거 위에 서게 되므로 LLM이 이를 인지하고 판정할 수 있도록 함께 넘긴다(#1594).
  */
 public interface AnomalyAnalyzer {
 
-    MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples);
+    MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples, String logEnvironment);
 }

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
@@ -55,6 +55,9 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             없는 수치·테이블·이벤트명을 지어내지 마라. 확인된 것과 추측을 섞지 마라.
             조치는 제안일 뿐 자동 실행되지 않는다. 설명 텍스트 없이 JSON 객체 하나만 출력하라.""";
 
+    // 근거가 확인되지 않은 분석의 요약을 대체하는 문구. 모델의 단정적 요약이 그대로 남지 않게 한다.
+    private static final String NO_EVIDENCE_SUMMARY = "제공된 로그에서 이 알림을 뒷받침할 근거를 찾지 못했습니다.";
+
     private final @Qualifier("zzolBotClient") Client zzolBotClient;
     private final ZzolBotProperties properties;
     private final ObjectMapper objectMapper;
@@ -111,13 +114,11 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             // 보수적으로 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
             final boolean claimed = node.path("evidenceFound").asBoolean(false);
             final boolean grounded = claimed && citedInLogs(node.path("evidenceLine").asText(""), logSamples);
-            // 규칙 #3을 코드로 강제한다 — 근거가 없으면 모델이 무엇을 보냈든 원인 가설은 공백이다.
+            // 근거가 없으면 모델이 무엇을 보냈든 원인 가설뿐 아니라 요약까지 안전한 문구로 강제한다.
+            // 화면엔 "근거 없음"인데 요약은 "DB에 심각한 문제" 같은 단정으로 남는 구멍을 막는다(#1595 리뷰).
+            final String summary = grounded ? node.path("summary").asText("") : NO_EVIDENCE_SUMMARY;
             final String hypothesis = grounded ? node.path("rootCauseHypothesis").asText("") : "";
-            return new MonitorAnalysis(
-                    node.path("summary").asText(""),
-                    hypothesis,
-                    actions,
-                    grounded);
+            return new MonitorAnalysis(summary, hypothesis, actions, grounded);
         } catch (Exception e) {
             log.warn("[ZzolBot] 이상 분석 응답 파싱 실패. raw={}", json, e);
             return MonitorAnalysis.failed();

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
@@ -35,8 +35,20 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             {
               "summary": "현재 상황 한국어 1~2문장 요약",
               "rootCauseHypothesis": "가장 가능성 높은 근본 원인 가설",
-              "suggestedActions": ["운영자가 취할 수 있는 조치 제안", "..."]
+              "suggestedActions": ["운영자가 취할 수 있는 조치 제안", "..."],
+              "evidenceFound": true 또는 false
             }
+
+            근거 판정 규칙 — 이 규칙이 다른 무엇보다 우선한다.
+            - 주어진 로그 샘플이 알림 내용과 실제로 관련될 때만 evidenceFound를 true로 둔다.
+            - 로그가 알림과 무관하거나, 알림을 설명하지 못하거나, 로그 출처 환경이 알림 대상 환경과
+              다르면 evidenceFound를 false로 두고 summary에 "제공된 로그에서 이 알림을 뒷받침할
+              근거를 찾지 못했다"는 사실을 명시하라.
+            - evidenceFound가 false이면 rootCauseHypothesis는 빈 문자열로 두고 원인을 추측하지 마라.
+            - 알림 설명(description)에 적힌 원인 가설은 사람이 미리 적어둔 추측일 뿐 확인된 사실이
+              아니다. 로그로 뒷받침되지 않으면 그것을 결론으로 삼지 마라.
+
+            없는 수치·테이블·이벤트명을 지어내지 마라. 확인된 것과 추측을 섞지 마라.
             조치는 제안일 뿐 자동 실행되지 않는다. 설명 텍스트 없이 JSON 객체 하나만 출력하라.""";
 
     private final @Qualifier("zzolBotClient") Client zzolBotClient;
@@ -45,14 +57,14 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
 
     @Retry(name = "zzolBotGemini")
     @Override
-    public MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples) {
+    public MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples, String logEnvironment) {
         final GenerateContentConfig config = GenerateContentConfig.builder()
                 .systemInstruction(Content.fromParts(Part.fromText(SYSTEM_INSTRUCTION)))
                 .temperature(0f)
                 .topP(0f)
                 .responseMimeType("application/json")
                 .build();
-        final String prompt = buildPrompt(alert, logSamples);
+        final String prompt = buildPrompt(alert, logSamples, logEnvironment);
         final GenerateContentResponse response = callApi(prompt, config);
         return parse(response.text());
     }
@@ -66,19 +78,19 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
         }
     }
 
-    private String buildPrompt(FiringAlert alert, List<String> logSamples) {
+    private String buildPrompt(FiringAlert alert, List<String> logSamples, String logEnvironment) {
         final StringBuilder sb = new StringBuilder();
         sb.append("심각도: ").append(alert.severity()).append('\n');
         sb.append("지문: ").append(alert.fingerprint()).append('\n');
         sb.append("알림명: ").append(alert.alertname()).append('\n');
         sb.append("요약: ").append(alert.summary()).append('\n');
-        sb.append("설명: ").append(alert.description()).append('\n');
+        sb.append("설명(사람이 적어둔 추측 — 확인된 사실 아님): ").append(alert.description()).append('\n');
         sb.append("라벨:\n");
         for (Map.Entry<String, String> label : alert.labels().entrySet()) {
             sb.append("- ").append(label.getKey()).append('=').append(label.getValue()).append('\n');
         }
         if (logSamples != null && !logSamples.isEmpty()) {
-            sb.append("\n최근 ERROR 로그 샘플:\n");
+            sb.append("\n최근 ERROR 로그 샘플 (출처 환경: ").append(logEnvironment).append("):\n");
             for (String line : logSamples) {
                 sb.append("- ").append(line).append('\n');
             }
@@ -91,10 +103,12 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             final JsonNode node = objectMapper.readTree(json);
             final List<String> actions = new ArrayList<>();
             node.path("suggestedActions").forEach(a -> actions.add(a.asText()));
+            // 판정이 누락되면 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
             return new MonitorAnalysis(
                     node.path("summary").asText(""),
                     node.path("rootCauseHypothesis").asText(""),
-                    actions);
+                    actions,
+                    node.path("evidenceFound").asBoolean(false));
         } catch (Exception e) {
             log.warn("[ZzolBot] 이상 분석 응답 파싱 실패. raw={}", json, e);
             return MonitorAnalysis.failed();

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
@@ -36,7 +36,8 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
               "summary": "현재 상황 한국어 1~2문장 요약",
               "rootCauseHypothesis": "가장 가능성 높은 근본 원인 가설",
               "suggestedActions": ["운영자가 취할 수 있는 조치 제안", "..."],
-              "evidenceFound": true 또는 false
+              "evidenceFound": true 또는 false,
+              "evidenceLine": "evidenceFound가 true일 때 근거가 된 로그 한 줄을 위 샘플에서 그대로 복사"
             }
 
             근거 판정 규칙 — 이 규칙이 다른 무엇보다 우선한다.
@@ -44,6 +45,9 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             - 로그가 알림과 무관하거나, 알림을 설명하지 못하거나, 로그 출처 환경이 알림 대상 환경과
               다르면 evidenceFound를 false로 두고 summary에 "제공된 로그에서 이 알림을 뒷받침할
               근거를 찾지 못했다"는 사실을 명시하라.
+            - evidenceFound가 true이면 evidenceLine에 근거가 된 로그 한 줄을 위 샘플에서 한 글자도
+              바꾸지 말고 그대로 복사하라. 요약하거나 바꿔 쓰지 마라. 그대로 복사할 로그가 없으면
+              evidenceFound는 false다.
             - evidenceFound가 false이면 rootCauseHypothesis는 빈 문자열로 두고 원인을 추측하지 마라.
             - 알림 설명(description)에 적힌 원인 가설은 사람이 미리 적어둔 추측일 뿐 확인된 사실이
               아니다. 로그로 뒷받침되지 않으면 그것을 결론으로 삼지 마라.
@@ -66,7 +70,7 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
                 .build();
         final String prompt = buildPrompt(alert, logSamples, logEnvironment);
         final GenerateContentResponse response = callApi(prompt, config);
-        return parse(response.text());
+        return parse(response.text(), logSamples);
     }
 
     protected GenerateContentResponse callApi(String prompt, GenerateContentConfig config) {
@@ -98,20 +102,45 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
         return sb.toString();
     }
 
-    private MonitorAnalysis parse(String json) {
+    private MonitorAnalysis parse(String json, List<String> logSamples) {
         try {
             final JsonNode node = objectMapper.readTree(json);
             final List<String> actions = new ArrayList<>();
             node.path("suggestedActions").forEach(a -> actions.add(a.asText()));
-            // 판정이 누락되면 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
+            // 근거 판정은 모델 자체 판정(evidenceFound)에 인용 검증을 코드로 덧씌운다. 판정이 누락되면
+            // 보수적으로 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
+            final boolean claimed = node.path("evidenceFound").asBoolean(false);
+            final boolean grounded = claimed && citedInLogs(node.path("evidenceLine").asText(""), logSamples);
+            // 규칙 #3을 코드로 강제한다 — 근거가 없으면 모델이 무엇을 보냈든 원인 가설은 공백이다.
+            final String hypothesis = grounded ? node.path("rootCauseHypothesis").asText("") : "";
             return new MonitorAnalysis(
                     node.path("summary").asText(""),
-                    node.path("rootCauseHypothesis").asText(""),
+                    hypothesis,
                     actions,
-                    node.path("evidenceFound").asBoolean(false));
+                    grounded);
         } catch (Exception e) {
             log.warn("[ZzolBot] 이상 분석 응답 파싱 실패. raw={}", json, e);
             return MonitorAnalysis.failed();
         }
+    }
+
+    /**
+     * 모델이 근거로 인용한 로그 줄이 실제 로그 샘플에 그대로 존재하는지 확인한다. 지어낸 이벤트명·수치를
+     * 근거로 내세우는 실패를 코드로 차단한다. 스택 트레이스처럼 로그 한 건이 여러 줄일 수 있으므로,
+     * 개행·연속 공백을 단일 공백으로 접은 뒤 비교해 인용의 줄바꿈·들여쓰기 차이는 무시한다.
+     */
+    // ponytail: 공백 정규화 후 부분 문자열 포함만 본다. 의미 매칭·토큰 단위 매칭이 필요하면 그때 올린다.
+    private boolean citedInLogs(String evidenceLine, List<String> logSamples) {
+        if (evidenceLine.isBlank() || logSamples == null) {
+            return false;
+        }
+        final String needle = normalizeWhitespace(evidenceLine);
+        return logSamples.stream()
+                .filter(line -> line != null)
+                .anyMatch(line -> normalizeWhitespace(line).contains(needle));
+    }
+
+    private static String normalizeWhitespace(String text) {
+        return text.strip().replaceAll("\\s+", " ");
     }
 }

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/LokiLogClient.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/LokiLogClient.java
@@ -28,7 +28,7 @@ public class LokiLogClient {
 
     private final RestClient restClient;
     private final String lokiBaseUrl;
-    private final String environment;
+    private final String defaultEnvironment;
     private final ObjectMapper objectMapper;
 
     public LokiLogClient(ZzolBotProperties properties, RestClient.Builder restClientBuilder, ObjectMapper objectMapper) {
@@ -36,14 +36,24 @@ public class LokiLogClient {
         this.restClient = restClientBuilder.baseUrl(lokiBaseUrl)
                 .requestFactory(ZzolBotHttpTimeouts.requestFactory())
                 .build();
-        this.environment = properties.monitoring().environment();
+        this.defaultEnvironment = properties.monitoring().environment();
         this.objectMapper = objectMapper;
     }
 
     /**
-     * 윈도우 구간의 최근 ERROR 로그 메시지를 최대 {@code limit}건 반환(LLM 분석 근거).
+     * 알림에서 환경을 판별하지 못했을 때 쓸 폴백 환경(이 인스턴스가 실행 중인 환경).
      */
-    public List<String> tailErrors(Instant end, Duration window, int limit) {
+    public String defaultEnvironment() {
+        return defaultEnvironment;
+    }
+
+    /**
+     * {@code environment} 환경의 윈도우 구간 최근 ERROR 로그를 최대 {@code limit}건 반환(LLM 분석 근거).
+     * <p>
+     * 환경을 인자로 받는다. 이전에는 이 인스턴스의 설정값으로 고정해, dev에서 발화한 알림을 prod
+     * 인스턴스가 받으면 prod 로그를 근거로 분석하는 불일치가 있었다(#1594).
+     */
+    public List<String> tailErrors(Instant end, Duration window, int limit, String environment) {
         final String logql = String.format("{environment=\"%s\"} |~ \"%s\"", environment, LEVEL_ERROR);
         final long startNano = end.minus(window).toEpochMilli() * 1_000_000L;
         final long endNano = end.toEpochMilli() * 1_000_000L;

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunEntity.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunEntity.java
@@ -77,9 +77,14 @@ public class MonitorRunEntity {
         return entity;
     }
 
-    public void attachAnalysis(String analysisSummary, String suggestedActionsJson) {
+    /**
+     * 분석 결과와, 그 분석이 무엇을 근거로 삼았는지({@code signalsJson}의 {@code analysisContext})를 함께 기록한다.
+     * 근거를 남기지 않으면 분석이 틀렸을 때 화면만으로 검증할 수 없다(#1594).
+     */
+    public void attachAnalysis(String analysisSummary, String suggestedActionsJson, String signalsJson) {
         this.analysisSummary = analysisSummary;
         this.suggestedActionsJson = suggestedActionsJson;
+        this.signalsJson = signalsJson;
     }
 
     public void markNotified() {

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/NoOpAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/NoOpAnomalyAnalyzer.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class NoOpAnomalyAnalyzer implements AnomalyAnalyzer {
 
     @Override
-    public MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples) {
-        return new MonitorAnalysis("NoOp 분석", "", List.of());
+    public MonitorAnalysis analyze(FiringAlert alert, List<String> logSamples, String logEnvironment) {
+        return new MonitorAnalysis("NoOp 분석", "", List.of(), true);
     }
 }

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
@@ -192,6 +192,26 @@ class AlertEnrichmentServiceTest {
 
             verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("staging"));
         }
+
+        @Test
+        void job이_정확히_접미사뿐이면_빈_환경_대신_실행_환경으로_폴백한다() {
+            given(lokiLogClient.defaultEnvironment()).willReturn("prod");
+
+            // "-app" → 접미사 제거 시 빈 문자열. 그대로 쓰면 {environment=""}로 필터가 무력화된다.
+            service.enrich(alertWithJob("-app"));
+
+            verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("prod"));
+        }
+
+        @Test
+        void 환경명_형식에_맞지_않는_job은_실행_환경으로_폴백한다() {
+            given(lokiLogClient.defaultEnvironment()).willReturn("prod");
+
+            // LogQL 셀렉터를 조기 종료시킬 수 있는 값 — 유도 결과가 허용 문자 밖이면 폴백해야 한다.
+            service.enrich(alertWithJob("prod\"} |~ \".*"));
+
+            verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("prod"));
+        }
     }
 
     @Nested

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
@@ -2,6 +2,8 @@ package coffeeshout.zzolbot.monitor.application;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -20,8 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Clock;
 import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -34,7 +39,8 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class AlertEnrichmentServiceTest {
 
-    private static final MonitorProperties PROPERTIES = new MonitorProperties(true, 240, 240);
+    private static final MonitorProperties PROPERTIES = new MonitorProperties(true, 30, 240);
+    private static final List<String> LOG_SAMPLES = List.of("[ERROR] 컨슈머 처리 실패");
 
     @Mock
     private LlmCallBudget llmCallBudget;
@@ -54,19 +60,20 @@ class AlertEnrichmentServiceTest {
         service = new AlertEnrichmentService(llmCallBudget, lokiLogClient, analyzer, notifier,
                 monitorRunRepository, PROPERTIES, new ObjectMapper(), Clock.systemUTC());
         given(monitorRunRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-        given(lokiLogClient.tailErrors(any(), any(), anyInt())).willReturn(List.of());
+        given(lokiLogClient.tailErrors(any(), any(), anyInt(), anyString())).willReturn(LOG_SAMPLES);
+        given(lokiLogClient.defaultEnvironment()).willReturn("prod");
     }
 
     @Test
     void 예산이_있으면_로그_샘플로_분석하고_알림_후_2회_저장한다() {
         given(llmCallBudget.tryAcquire()).willReturn(true);
-        given(analyzer.analyze(any(), any()))
-                .willReturn(new MonitorAnalysis("적체 발생", "컨슈머 지연", List.of("스케일 아웃")));
+        given(analyzer.analyze(any(), any(), anyString()))
+                .willReturn(new MonitorAnalysis("적체 발생", "컨슈머 지연", List.of("스케일 아웃"), true));
 
         service.enrich(warningAlert());
 
-        verify(lokiLogClient).tailErrors(any(), any(), anyInt());
-        verify(analyzer).analyze(any(), any());
+        verify(lokiLogClient).tailErrors(any(), any(), anyInt(), anyString());
+        verify(analyzer).analyze(any(), any(), anyString());
         verify(notifier).notifyAnomaly(any(), any());
         final ArgumentCaptor<MonitorRunEntity> captor = ArgumentCaptor.forClass(MonitorRunEntity.class);
         verify(monitorRunRepository, times(2)).save(captor.capture());
@@ -76,19 +83,6 @@ class AlertEnrichmentServiceTest {
             softly.assertThat(saved.getAnalysisSummary()).isEqualTo("적체 발생");
             softly.assertThat(saved.getSuggestedActionsJson()).contains("스케일 아웃");
         });
-    }
-
-    @Test
-    void 예산이_소진되면_로그_분석을_건너뛰고_예산소진_분석으로_알림한다() {
-        given(llmCallBudget.tryAcquire()).willReturn(false);
-
-        service.enrich(warningAlert());
-
-        verify(lokiLogClient, never()).tailErrors(any(), any(), anyInt());
-        verify(analyzer, never()).analyze(any(), any());
-        final ArgumentCaptor<MonitorAnalysis> captor = ArgumentCaptor.forClass(MonitorAnalysis.class);
-        verify(notifier).notifyAnomaly(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().summary()).contains("예산 소진");
     }
 
     @Test
@@ -106,10 +100,11 @@ class AlertEnrichmentServiceTest {
     @Test
     void 간격이_0이면_가드를_건너뛰고_분석한다() {
         final AlertEnrichmentService noDedup = new AlertEnrichmentService(llmCallBudget, lokiLogClient, analyzer,
-                notifier, monitorRunRepository, new MonitorProperties(true, 240, 0), new ObjectMapper(),
+                notifier, monitorRunRepository, new MonitorProperties(true, 30, 0), new ObjectMapper(),
                 Clock.systemUTC());
         given(llmCallBudget.tryAcquire()).willReturn(true);
-        given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+        given(analyzer.analyze(any(), any(), anyString()))
+                .willReturn(new MonitorAnalysis("요약", "", List.of(), true));
 
         noDedup.enrich(warningAlert());
 
@@ -121,7 +116,7 @@ class AlertEnrichmentServiceTest {
     @Test
     void 모니터링이_비활성이면_아무것도_하지_않는다() {
         final AlertEnrichmentService disabled = new AlertEnrichmentService(llmCallBudget, lokiLogClient, analyzer,
-                notifier, monitorRunRepository, new MonitorProperties(false, 240, 240), new ObjectMapper(),
+                notifier, monitorRunRepository, new MonitorProperties(false, 30, 240), new ObjectMapper(),
                 Clock.systemUTC());
 
         disabled.enrich(warningAlert());
@@ -133,19 +128,20 @@ class AlertEnrichmentServiceTest {
     @Test
     void 분석이_실패해도_실패_분석으로_결정적_알림을_보낸다() {
         given(llmCallBudget.tryAcquire()).willReturn(true);
-        given(analyzer.analyze(any(), any())).willThrow(new RuntimeException("Gemini 5xx"));
+        given(analyzer.analyze(any(), any(), anyString())).willThrow(new RuntimeException("Gemini 5xx"));
 
         service.enrich(warningAlert());
 
         final ArgumentCaptor<MonitorAnalysis> captor = ArgumentCaptor.forClass(MonitorAnalysis.class);
         verify(notifier).notifyAnomaly(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().summary()).contains("실패");
+        Assertions.assertThat(captor.getValue().summary()).contains("실패");
     }
 
     @Test
     void severity_문자열을_심각도로_매핑한다() {
         given(llmCallBudget.tryAcquire()).willReturn(true);
-        given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+        given(analyzer.analyze(any(), any(), anyString()))
+                .willReturn(new MonitorAnalysis("요약", "", List.of(), true));
 
         service.enrich(alert("critical"));
         service.enrich(alert("warning"));
@@ -159,6 +155,124 @@ class AlertEnrichmentServiceTest {
         });
     }
 
+    @Nested
+    @DisplayName("조회 환경 판별")
+    class ResolveEnvironment {
+
+        @Test
+        void job_라벨에서_환경을_유도해_해당_환경_로그를_조회한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any(), anyString()))
+                    .willReturn(new MonitorAnalysis("요약", "", List.of(), true));
+
+            service.enrich(alertWithJob("dev-app"));
+
+            verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("dev"));
+            verify(analyzer).analyze(any(), any(), eq("dev"));
+        }
+
+        @Test
+        void job_라벨이_없으면_실행_환경으로_폴백한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any(), anyString()))
+                    .willReturn(new MonitorAnalysis("요약", "", List.of(), true));
+
+            service.enrich(warningAlert());
+
+            verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("prod"));
+        }
+
+        @Test
+        void 접미사가_없는_job_라벨은_그대로_환경으로_쓴다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any(), anyString()))
+                    .willReturn(new MonitorAnalysis("요약", "", List.of(), true));
+
+            service.enrich(alertWithJob("staging"));
+
+            verify(lokiLogClient).tailErrors(any(), any(), anyInt(), eq("staging"));
+        }
+    }
+
+    @Nested
+    @DisplayName("근거 없는 분석 방지")
+    class NoEvidenceGuard {
+
+        @Test
+        void 로그가_없으면_LLM을_호출하지_않고_예산도_소모하지_않는다() {
+            given(lokiLogClient.tailErrors(any(), any(), anyInt(), anyString())).willReturn(List.of());
+
+            service.enrich(warningAlert());
+
+            verify(analyzer, never()).analyze(any(), any(), anyString());
+            verify(llmCallBudget, never()).tryAcquire();
+        }
+
+        @Test
+        void 로그가_없으면_근거_없음을_명시해_알린다() {
+            given(lokiLogClient.tailErrors(any(), any(), anyInt(), anyString())).willReturn(List.of());
+
+            service.enrich(warningAlert());
+
+            final ArgumentCaptor<MonitorAnalysis> captor = ArgumentCaptor.forClass(MonitorAnalysis.class);
+            verify(notifier).notifyAnomaly(any(), captor.capture());
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(captor.getValue().summary()).contains("근거가 없다");
+                softly.assertThat(captor.getValue().evidenceFound()).isFalse();
+            });
+        }
+
+        @Test
+        void 예산이_소진되면_LLM_분석을_건너뛰고_예산소진_분석으로_알린다() {
+            given(llmCallBudget.tryAcquire()).willReturn(false);
+
+            service.enrich(warningAlert());
+
+            verify(analyzer, never()).analyze(any(), any(), anyString());
+            final ArgumentCaptor<MonitorAnalysis> captor = ArgumentCaptor.forClass(MonitorAnalysis.class);
+            verify(notifier).notifyAnomaly(any(), captor.capture());
+            Assertions.assertThat(captor.getValue().summary()).contains("예산 소진");
+        }
+    }
+
+    @Nested
+    @DisplayName("조회 근거 기록")
+    class AnalysisContextRecording {
+
+        @Test
+        void 무엇을_근거로_분석했는지_저장한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any(), anyString()))
+                    .willReturn(new MonitorAnalysis("적체 발생", "컨슈머 지연", List.of(), true));
+
+            service.enrich(alertWithJob("prod-app"));
+
+            final ArgumentCaptor<MonitorRunEntity> captor = ArgumentCaptor.forClass(MonitorRunEntity.class);
+            verify(monitorRunRepository, times(2)).save(captor.capture());
+            final String signals = captor.getValue().getSignalsJson();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(signals).contains("\"logEnvironment\":\"prod\"");
+                softly.assertThat(signals).contains("\"windowMinutes\":30");
+                softly.assertThat(signals).contains("\"logSampleCount\":1");
+                softly.assertThat(signals).contains("\"evidenceFound\":true");
+                softly.assertThat(signals).contains("컨슈머 지연");
+            });
+        }
+
+        @Test
+        void 근거가_없다는_판정도_그대로_기록한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any(), anyString()))
+                    .willReturn(new MonitorAnalysis("무관한 로그뿐", "", List.of(), false));
+
+            service.enrich(warningAlert());
+
+            final ArgumentCaptor<MonitorRunEntity> captor = ArgumentCaptor.forClass(MonitorRunEntity.class);
+            verify(monitorRunRepository, times(2)).save(captor.capture());
+            Assertions.assertThat(captor.getValue().getSignalsJson()).contains("\"evidenceFound\":false");
+        }
+    }
+
     private FiringAlert warningAlert() {
         return alert("warning");
     }
@@ -166,5 +280,10 @@ class AlertEnrichmentServiceTest {
     private FiringAlert alert(String severity) {
         return new FiringAlert("AppErrorLogSpike", severity, "fp-1", "ERROR 급증", "임계 초과",
                 Map.of("alertname", "AppErrorLogSpike", "severity", severity));
+    }
+
+    private FiringAlert alertWithJob(String job) {
+        return new FiringAlert("AppErrorLogSpike", "warning", "fp-1", "ERROR 급증", "임계 초과",
+                Map.of("alertname", "AppErrorLogSpike", "severity", "warning", "job", job));
     }
 }

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
@@ -27,6 +27,8 @@ class GeminiAnomalyAnalyzerTest {
     private static final FiringAlert ALERT = new FiringAlert(
             "AppErrorLogSpike", "warning", "fp-1", "ERROR 급증", "임계 초과",
             Map.of("alertname", "AppErrorLogSpike"));
+    // 프로덕션 상수(GeminiAnomalyAnalyzer.NO_EVIDENCE_SUMMARY)와 동일해야 한다. private이라 값으로 고정한다.
+    private static final String NO_EVIDENCE_SUMMARY = "제공된 로그에서 이 알림을 뒷받침할 근거를 찾지 못했습니다.";
 
     // client·properties는 callApi 안에서만 쓰이고 그 메서드를 스텁하므로 null로 둔다.
     @Spy
@@ -70,6 +72,26 @@ class GeminiAnomalyAnalyzerTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(result.evidenceFound()).isFalse();
                 softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+                // 근거 없음이면 모델의 단정적 요약("DB 문제로 보임")이 아니라 표준 문구로 대체된다.
+                softly.assertThat(result.summary()).isEqualTo(NO_EVIDENCE_SUMMARY);
+            });
+        }
+
+        @Test
+        void 근거없음으로_강등되면_요약도_표준_문구로_대체한다() {
+            // 모델이 근거 있다며 단정적 요약을 냈지만 인용은 실재하지 않는다.
+            final String json = """
+                    {"summary":"서비스에 심각한 장애 발생","rootCauseHypothesis":"커넥션 풀 고갈",
+                     "suggestedActions":["재시작"],"evidenceFound":true,
+                     "evidenceLine":"ERROR pool exhausted"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("2026-07-22 ERROR consumer lag 12000"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.summary())
+                        .isEqualTo(NO_EVIDENCE_SUMMARY)
+                        .doesNotContain("심각한 장애");
             });
         }
 

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
@@ -1,0 +1,129 @@
+package coffeeshout.zzolbot.monitor.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import coffeeshout.zzolbot.monitor.domain.MonitorAnalysis;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiAnomalyAnalyzerTest {
+
+    private static final FiringAlert ALERT = new FiringAlert(
+            "AppErrorLogSpike", "warning", "fp-1", "ERROR 급증", "임계 초과",
+            Map.of("alertname", "AppErrorLogSpike"));
+
+    // client·properties는 callApi 안에서만 쓰이고 그 메서드를 스텁하므로 null로 둔다.
+    @Spy
+    private GeminiAnomalyAnalyzer analyzer = new GeminiAnomalyAnalyzer(null, null, new ObjectMapper());
+
+    private MonitorAnalysis analyzeWith(String responseJson, List<String> logSamples) {
+        final GenerateContentResponse response = mock(GenerateContentResponse.class);
+        given(response.text()).willReturn(responseJson);
+        doReturn(response).when(analyzer).callApi(anyString(), any(GenerateContentConfig.class));
+        return analyzer.analyze(ALERT, logSamples, "dev");
+    }
+
+    @Nested
+    class 근거_판정 {
+
+        @Test
+        void 인용_로그가_샘플에_실재하면_근거를_인정하고_가설을_유지한다() {
+            final String json = """
+                    {"summary":"컨슈머 지연","rootCauseHypothesis":"컨슈머가 밀렸다",
+                     "suggestedActions":["스케일 아웃"],"evidenceFound":true,
+                     "evidenceLine":"ERROR consumer lag 12000"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("2026-07-22 ERROR consumer lag 12000 group=g1"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isTrue();
+                softly.assertThat(result.rootCauseHypothesis()).isEqualTo("컨슈머가 밀렸다");
+            });
+        }
+
+        @Test
+        void 모델이_근거있다_해도_인용이_샘플에_없으면_근거없음으로_강등하고_가설을_비운다() {
+            // evidenceLine "table orders" 는 로그 어디에도 없다 — 지어낸 근거.
+            final String json = """
+                    {"summary":"DB 문제로 보임","rootCauseHypothesis":"orders 테이블 잠금",
+                     "suggestedActions":["인덱스 점검"],"evidenceFound":true,
+                     "evidenceLine":"ERROR lock wait on table orders"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("2026-07-22 ERROR consumer lag 12000"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void evidenceFound가_false면_가설을_비운다_규칙3() {
+            final String json = """
+                    {"summary":"근거 못 찾음","rootCauseHypothesis":"그래도 컨슈머 지연일 듯",
+                     "suggestedActions":[],"evidenceFound":false,"evidenceLine":""}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("무관한 로그"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void evidenceFound가_true여도_evidenceLine이_없으면_근거없음으로_본다() {
+            final String json = """
+                    {"summary":"요약","rootCauseHypothesis":"가설","suggestedActions":[],
+                     "evidenceFound":true}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("ERROR something"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void 여러_줄_로그를_개행_대신_공백으로_인용해도_근거로_인정한다() {
+            // 로그 한 건이 스택 트레이스(개행·탭 포함)인데 모델은 한 줄로 펴서 인용한다.
+            final List<String> logSamples = List.of("ERROR OutOfMemoryError\n\tat com.foo.Bar(Bar.java:42)");
+            final String json = """
+                    {"summary":"OOM","rootCauseHypothesis":"힙 부족",
+                     "suggestedActions":["힙 상향"],"evidenceFound":true,
+                     "evidenceLine":"ERROR OutOfMemoryError at com.foo.Bar(Bar.java:42)"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, logSamples);
+
+            assertThat(result.evidenceFound()).isTrue();
+        }
+    }
+
+    @Nested
+    class 파싱_실패 {
+
+        @Test
+        void JSON이_아니면_실패_분석을_반환한다() {
+            final MonitorAnalysis result = analyzeWith("이건 JSON이 아니다", List.of("ERROR x"));
+
+            assertThat(result.summary()).isEqualTo(MonitorAnalysis.failed().summary());
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1594

# 🚀 작업 내용

## 문제 상황

#1593이 알림 룰을 고쳐 오발화는 막았지만, **봇이 잘못된 입력을 받았을 때 그것을 드러내지 않고 그럴듯한 결론을 만들어내는 성질**은 그대로 남아 있었습니다. 원인이 아니라 증상을 막은 상태입니다.

**① 분석이 알림의 환경을 무시했습니다.**

```java
this.environment = properties.monitoring().environment();   // 인스턴스 설정값으로 고정
```

dev에서 발화한 알림을 prod 인스턴스가 받아 **prod 로그를 근거로 분석**했습니다. 07/11~15 알림 13건이 이렇게 진단됐습니다. `FiringAlert`는 `labels`를 이미 갖고 있었지만 쓰이지 않았습니다.

**② 근거가 없어도 결론을 만들었습니다.**

알림과 무관한 로그를 받아도 그대로 LLM에 넘겼습니다. 그 결과 "동시에 `SelectCardCommandEvent` 처리 실패 로그가 다수 발생" 같은 서술이 나왔는데, 전부 무관한 배경 에러였습니다. **매번 다른 이벤트가 지목된 것 자체가** 특정 인과가 아니라 4시간 창이 만든 잡음이라는 신호였습니다.

여기에 알림 `description`의 원인 가설("X-Forwarded-For 소실 확인")이 프롬프트로 들어가, LLM이 그것을 결론으로 되돌려줬습니다. 해당 시나리오는 `IpBlockFilter:72-79`에서 이미 방어된 상태였는데도요.

**③ 무엇을 근거로 분석했는지 남지 않았습니다.**

`attachAnalysis`가 `summary`와 `suggestedActions`만 저장해, 어느 환경을 몇 분 창으로 몇 건 조회했는지 기록되지 않았습니다. **분석이 틀렸을 때 화면에서 검증할 방법이 없어**, #1592 조사에서 Loki·Prometheus를 직접 조회해야 했습니다. `rootCauseHypothesis`는 생성만 되고 Slack에도 DB에도 나가지 않아 버려지고 있었습니다.

## 변경 내용

**1. 조회 환경을 알림에서 유도합니다** (`LokiLogClient`, `AlertEnrichmentService`)

`tailErrors`가 환경을 인자로 받고, 알림의 `job` 라벨에서 유도합니다(`prod-app` → `prod`). 라벨이 없으면 실행 환경으로 폴백합니다 — 룰이 `sum()`으로 라벨을 지우는 경우가 실제로 있었기 때문입니다.

**2. 근거가 없으면 결론을 내지 않습니다** (`MonitorAnalysis`, `GeminiAnomalyAnalyzer`)

```java
if (logs.isEmpty()) {
    return MonitorAnalysis.noEvidence(environment, windowMinutes);  // LLM 호출 안 함
}
if (!llmCallBudget.tryAcquire()) { ... }
```

로그가 있어도 무관할 수 있으므로 응답 스키마에 `evidenceFound` 판정을 강제했고, 판정이 누락되면 `false`로 봅니다. 프롬프트에는 알림 설명이 "사람이 적어둔 추측 — 확인된 사실 아님"임을 명시했습니다.

**3. 무엇을 근거로 분석했는지 남깁니다** (`MonitorRunEntity`, `zzolbot.html`)

조회 환경·윈도우·샘플 수·근거 판정·근본원인 가설을 저장하고, 어드민에 "🔍 조회 근거" 블록으로 표시합니다.

**4. 로그 조회 윈도우를 240분 → 30분으로 줄였습니다** (`zzolbot.yml`)

# 💬 리뷰 중점사항

**설계 절충 — `analysisContext`를 `signals_json`에 병합했습니다**

전용 컬럼(V38 마이그레이션) 대신 기존 컬럼에 별도 키로 병합했습니다. 이 컬럼은 원래 알림 입력을 담는 곳이라 **입력과 분석 메타데이터가 한 컬럼에 섞입니다.** 마이그레이션을 피하려는 선택이었고, 전용 컬럼이 낫다는 의견이 있으면 바꾸겠습니다. 되돌리기 어려운 결정은 아닙니다.

**동작 변경 — 예산 확인 순서를 로그 조회 뒤로 옮겼습니다**

이전에는 예산 소진 시 Loki도 호출하지 않았습니다. 지금은 로그를 먼저 조회하고 근거가 있을 때만 예산을 씁니다. **어차피 분석하지 않을 건에 예산 슬롯을 태우지 않기 위해서**입니다. Loki는 내부 호출이라 비용이 낮아 이 방향이 낫다고 봤는데, 이견 있으면 논의하면 좋겠습니다.

**`evidenceFound` 기본값을 false로 둔 이유**

LLM이 필드를 누락하면 "근거 없음"으로 표시됩니다. 정상 분석이 근거 없음으로 잘못 표시될 여지가 있지만, 반대 방향(근거 없는데 있다고 표시)이 더 위험하다고 판단했습니다. 운영봇에서는 과소 주장이 과대 주장보다 안전합니다.

**검증**

`:zzolbot` 171개 테스트 통과. 추가한 케이스:

- `ResolveEnvironment` — job 라벨에서 유도 / 라벨 없으면 폴백 / 접미사 없는 값
- `NoEvidenceGuard` — 로그 없으면 LLM·예산 미소모 / 근거 없음 명시 / 예산 소진 분기
- `AnalysisContextRecording` — 근거 저장 / 근거 없음 판정도 기록

**남은 것**

`AppErrorLogSpike`가 매번 00:03에 울리는 건과 Redis Stream 지연 2건은 원인 미확정이라 #1594에 "조사 필요"로 분리해뒀습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모니터링 알림 상세 화면에 로그 조회 환경, 조회 범위, 샘플 수, 근거 확인 결과 및 근본원인 가설을 표시합니다.
  - 알림 라벨에 따라 해당 환경의 로그를 조회하고, 환경을 확인할 수 없으면 기본 환경을 사용합니다.
  - 근거가 확인된 로그만 근본원인 분석에 반영하며, 검증되지 않은 가설은 제외합니다.

- **개선 사항**
  - ERROR 로그 조회 기본 범위를 4시간에서 30분으로 단축해 알림 시점과 가까운 로그를 우선 분석합니다.
  - 분석 근거가 없을 때 불필요한 분석 요청을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->