### PR TITLE
[fix] 로그 로테이션 재수집으로 인한 중복 적재와 자정 오탐 해소 + 나머지 알림 룰 환경 분리

### DIFF
--- a/backend/docker/alloy/modules/app-logs.alloy
+++ b/backend/docker/alloy/modules/app-logs.alloy
@@ -33,7 +33,11 @@ declare "app_logs_ingest_time" {
 	loki.source.file "source" {
 		targets = [{
 			__address__ = "localhost",
-			__path__    = "/app/logs/application*.log",
+			// 활성 로그 파일만 따라간다. 이전 글롭(application*.log)은 회전 파일
+			// (application-YYYY-MM-DD.log)까지 매칭해, 자정 로테이션 때 새 타깃으로 인식된
+			// 회전 파일을 처음부터 다시 읽었다. 그 결과 하루치 로그가 중복 적재되고
+			// 재수집분이 자정 한 지점에 몰려 ERROR 급증 알림이 오발화했다(#1596).
+			__path__    = "/app/logs/application.log",
 			environment = argument.environment.value,
 			job         = argument.job.value,
 		}]
@@ -81,7 +85,11 @@ declare "app_logs_log_time" {
 	loki.source.file "source" {
 		targets = [{
 			__address__ = "localhost",
-			__path__    = "/app/logs/application*.log",
+			// 활성 로그 파일만 따라간다. 이전 글롭(application*.log)은 회전 파일
+			// (application-YYYY-MM-DD.log)까지 매칭해, 자정 로테이션 때 새 타깃으로 인식된
+			// 회전 파일을 처음부터 다시 읽었다. 그 결과 하루치 로그가 중복 적재되고
+			// 재수집분이 자정 한 지점에 몰려 ERROR 급증 알림이 오발화했다(#1596).
+			__path__    = "/app/logs/application.log",
 			environment = argument.environment.value,
 			job         = argument.job.value,
 		}]

--- a/backend/docker/monitoring/conf/loki-rules/fake/zzolbot-log-signals.yml
+++ b/backend/docker/monitoring/conf/loki-rules/fake/zzolbot-log-signals.yml
@@ -6,20 +6,23 @@
 #
 # 'fake' = auth_enabled:false 일 때 Loki의 기본 테넌트. 룰 파일은 이 하위에 둬야 인식된다.
 #
-# TODO(후속 PR):
-#   - 라벨 셀렉터를 실제 Alloy 로그 파이프라인(app-logs.alloy) 라벨에 맞춘다(아래는 placeholder).
-#   - 임계값은 추정치다(ADR-0026 계승). 배포 후 베이스라인 측정으로 보정한다.
-#   - zzol-bot 자체 폴링(MonitorCollector/Scheduler/AnomalyGate) 제거와 같은 PR에서 활성화한다.
 groups:
   - name: zzolbot-log-signals
     rules:
+      # ERROR 로그 급증 — prod로 한정하고 job 라벨을 보존한다(#1596).
+      # 이전에는 job 필터 없는 sum()이라 dev·prod를 합산했고, 07/18에는 dev 22건 / prod 2건으로
+      # dev가 단독으로 임계를 넘겨 오발화했다. sum()이 라벨까지 지워 발화한 알림에 환경 정보가
+      # 남지 않았고, Alertmanager 라우팅과 zzol-bot의 환경 식별도 불가능했다.
+      #
+      # 임계 30 — prod 관측 최대 16건/5분 대비 약 2배 여유(2026-07 실측).
+      # ⚠️ 이 실측치는 로그 재수집 아티팩트가 섞인 값이다. #1596의 __path__ 수정이 배포되어
+      #    자정 중복 적재가 사라진 뒤 재측정해 보정한다.
       - alert: AppErrorLogSpike
-        # TODO: {service_name="..."} 셀렉터를 실제 라벨로 교체.
         expr: |
-          sum(count_over_time({job=~"dev-app|prod-app"} |= "ERROR" [5m])) > 20
+          sum by (job) (count_over_time({job="prod-app"} |= "ERROR" [5m])) > 30
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "ERROR 로그 급증(최근 5분)"
-          description: "ERROR 로그 카운트가 임계(20/5m)를 초과했습니다. zzol-bot이 근본원인을 분석합니다."
+          summary: "ERROR 로그 급증(최근 5분, {{ $labels.job }})"
+          description: "ERROR 로그가 {{ $value }}건(임계 30/5m)입니다. zzol-bot이 근본원인을 분석합니다."

--- a/backend/docker/monitoring/conf/rules/alerts-redis-stream.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-redis-stream.yml
@@ -14,41 +14,46 @@ groups:
     rules:
       # E2E 처리 지연 p95 — 발행부터 처리 완료까지.
       # 버킷이 있으므로 histogram_quantile로 분위수를 직접 계산한다(ADR-0026 line 22).
-      # ⚠️ 임계 0.5s 추정. 레이싱 등 실시간 게임에서 0.5초 지연은 "렉"으로 체감.
+      # prod로 한정하고 job 라벨을 보존한다(#1596) — 이전에는 sum by (le)가 dev·prod 히스토그램을
+      # 합쳐, 07/17 21:05 알림은 dev 2.201s에서 나왔고 prod는 표본조차 없었다.
+      # 임계 0.5s 유지 — prod 관측 최대 p95가 65ms라 여유가 충분하다(2026-07 실측).
       - alert: RedisStreamE2eLatencyHigh
         expr: |
           histogram_quantile(
             0.95,
-            sum by (le) (rate(redis_stream_e2e_latency_seconds_bucket[5m]))
+            sum by (le, job) (rate(redis_stream_e2e_latency_seconds_bucket{job="prod-app"}[5m]))
           ) > 0.5
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "Redis Stream E2E 지연 p95 > 500ms"
+          summary: "Redis Stream E2E 지연 p95 > 500ms ({{ $labels.job }})"
           description: "스트림 처리 p95 지연이 {{ $value | printf \"%.3f\" }}s. 컨슈머 처리 적체 또는 다운스트림(App Service) 지연 가능성."
 
       # 스트림 적체 — 컨슈머가 발행 속도를 못 따라가면 length가 쌓인다.
-      # ⚠️ 임계 1000 추정. 정상 운영 시 length는 0 근처여야 한다.
+      # max()는 blue/green 두 인스턴스가 같은 값을 보고하는 중복을 제거하려는 것이지만, job 필터가
+      # 없으면 dev·prod까지 뭉갠다. prod로 한정하고 job별로 집계해 두 의도를 모두 지킨다(#1596).
+      # 임계 1000 유지 — prod 관측 최대가 117이라 여유가 충분하다(2026-07 실측).
       - alert: RedisStreamBacklogHigh
-        expr: max(redis_stream_length) > 1000
+        expr: max by (job) (redis_stream_length{job="prod-app"}) > 1000
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "Redis Stream 적체 (length > 1000)"
+          summary: "Redis Stream 적체 (length > 1000, {{ $labels.job }})"
           description: "스트림 길이가 {{ $value }}. 컨슈머 처리 속도가 발행을 못 따라가고 있습니다."
 
       # Outbox DEAD_LETTER 적체 — 재시도 초과로 죽은 이벤트가 쌓이면 메시지 유실.
       # 과거 zzol-bot 자체 폴링(DB count ≥ 10)을 Prometheus로 이관(ADR-0032). "적체 깊이" 신호라
       # 로그 율 기반 룰(Loki ERROR 카운트)로는 못 잡는 느린 누적을 잡는다.
       # blue/green 두 인스턴스가 같은 DB를 보므로 값이 동일 → max()로 중복 제거.
+      # 다만 dev·prod는 DB가 다르므로 job으로 한정하지 않으면 두 환경까지 뭉갠다(#1596).
       # ⚠️ 임계 10은 옛 self-poll 임계 보존(추정치). 배포 후 정상 범위로 보정.
       - alert: OutboxDeadLetterHigh
-        expr: max(outbox_dead_letter_count) > 10
+        expr: max by (job) (outbox_dead_letter_count{job="prod-app"}) > 10
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Outbox DEAD_LETTER 적체 (> 10)"
+          summary: "Outbox DEAD_LETTER 적체 (> 10, {{ $labels.job }})"
           description: "재시도 초과로 DEAD_LETTER 전환된 outbox 이벤트가 {{ $value }}건. 다운스트림 발행 경로 점검 필요."


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1596

# 🚀 작업 내용

## 문제 상황

어드민 모니터링에 쌓인 알림 18건을 전수 확인한 결과 **prod의 실제 이상은 0건**이었습니다. 13건은 dev 스캐너(#1593에서 수정), 나머지 5건이 이 PR의 대상입니다.

**① Alloy가 자정마다 회전 로그 파일을 다시 읽습니다** (`AppErrorLogSpike` 3건의 원인)

```
__path__ = "/app/logs/application*.log"
```

이 글롭이 회전 파일(`application-2026-07-17.log`)까지 매칭합니다. 자정에 회전 파일이 생기면 **새 타깃으로 인식해 처음부터 다시 읽습니다.**

재수집된 라인은 인입 시각으로 인덱싱되어 자정 한 지점에 몰립니다.

| | 인덱스 시각 | 로그 내용 시각 |
|---|---|---|
| 07/18 dev (22건) | 21건이 `00:00:06` | 전날 17:22~20:42 |
| 07/10 prod (45건) | 44건이 `00:00:05~08` | 전날 10:37~17:20 |

임계(20건/5분)를 넘고 `for: 2m`가 지나 **00:02~00:03에 발화**합니다. 07/08·07/10·07/18 세 번 모두 00:03이었던 이유입니다. **실제 에러 급증이 아니라 몇 시간 전에 지나간 에러의 재인덱싱입니다.**

부수 피해로 **로그가 매일 중복 적재됩니다.** 07/17 prod 기준 `application.log` 21,137건에 더해 `application-2026-07-17.log`로 9,180건이 다시 들어왔습니다.

**② 나머지 알림 룰도 dev·prod를 합산합니다**

#1593에서 고친 것과 같은 결함이 남아 있었습니다. 실측:

- `RedisStreamE2eLatencyHigh` — 07/17 21:05 알림 값 `2.20117073815`가 **dev 2.201s와 일치**, prod는 표본조차 없음
- `AppErrorLogSpike` — 07/18 dev 22건 / prod 2건으로 dev가 단독으로 임계 초과

## 변경 내용

**1. 활성 로그 파일만 따라갑니다** (`app-logs.alloy`, dev·prod 두 declare)

`__path__`를 `application.log`로 좁혔습니다. 로테이션으로 inode가 바뀌어도 Alloy가 같은 경로를 계속 따라가므로 수집은 이어집니다.

**2. 나머지 룰에 job 분리를 적용했습니다**

| 룰 | 변경 | 임계 |
|---|---|---|
| `AppErrorLogSpike` | `sum()` → `sum by (job)`, prod 한정 | 20 → **30** (prod 최대 16건/5분) |
| `RedisStreamE2eLatencyHigh` | `sum by (le)` → `sum by (le, job)`, prod 한정 | 0.5s 유지 (prod 최대 65ms) |
| `RedisStreamBacklogHigh` | `max()` → `max by (job)`, prod 한정 | 1000 유지 (prod 최대 117) |
| `OutboxDeadLetterHigh` | `max()` → `max by (job)`, prod 한정 | 10 유지 |

# 💬 리뷰 중점사항

**`OutboxDeadLetterHigh`는 원래 TODO에 없었는데 함께 고쳤습니다**

이슈 작성 시점에는 놓쳤는데, 같은 파일에 같은 결함이 있었습니다. `max()`는 blue/green 두 인스턴스의 중복 제거가 목적이라 주석에 근거가 적혀 있었지만, job 필터가 없으면 dev·prod까지 뭉갭니다. `max by (job)` + prod 한정으로 원래 의도는 유지됩니다. 범위를 벗어난 수정이라 판단되면 빼겠습니다.

**⚠️ 검증의 한계 — 07/10은 룰 수정만으로 여전히 발화합니다**

새 LogQL을 과거 오발화 3건에 재현한 결과입니다.

| 날짜 | 결과 |
|---|---|
| 07/08 00:03 | 미발화 ✅ |
| 07/10 00:03 | **발화 (prod 45건 > 30)** |
| 07/18 00:03 | 미발화 ✅ |

07/10의 45건은 **전부 재수집 중복**이라 `__path__` 수정으로 사라집니다. 다만 이미 적재된 과거 데이터로는 그 효과를 재현할 수 없어 이렇게 나옵니다. **임계를 45 위로 올리는 것은 증상 가리기라 하지 않았습니다.**

**임계 30의 근거가 아직 오염돼 있습니다**

prod 관측 최대 16건/5분을 기준으로 잡았는데, 이 값 자체에 재수집 아티팩트가 섞여 있습니다. `__path__` 수정 배포 후 자정 중복이 사라지면 재측정해 보정해야 하며, 룰 주석에 남겼습니다.

**검증**

- `promtool check rules` 통과 (`alerts-redis-stream.yml` 3 rules)
- `alloy fmt` 통과
- 새 LogQL 식을 실제 Loki에 질의해 파싱·결과 확인 (위 표)

**배포 시 참고**

- Alloy는 `pull_frequency`(60s) 주기로 Git에서 모듈을 pull해 핫리로드합니다 — 컨테이너 재시작 불필요 (ADR-0028)
- Loki ruler 룰은 Loki 재시작 필요, Prometheus 룰은 SIGHUP (ADR-0032 체크리스트)

**후속 확인 필요 (호스트 접근)**

prod 호스트의 배포된 bootstrap config가 저장소와 일치하는지 확인이 필요합니다. 저장소는 `app_logs_log_time`(KST 파싱)을 인스턴스화하는데, 재수집분이 인입 시각으로 들어온 것은 실제로는 `app_logs_ingest_time`이 돌고 있을 가능성을 시사합니다. ADR-0028대로 bootstrap config는 호스트 1회 수동 배치라 드리프트 여지가 있습니다. #1596에 체크리스트로 남겼습니다.

```bash
docker exec alloy cat /etc/alloy/config.alloy | grep app_logs
```
