### PR TITLE
[fix] 인시던트 단위 중복 분석 방지 + 알림 룰 job 스코프 회귀 방지 CI 체크

### DIFF
--- a/.github/scripts/check-alert-job-scope.py
+++ b/.github/scripts/check-alert-job-scope.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""알림 룰의 job 스코프 검사 — 집계가 job 라벨을 지우는 것을 막는다.
+
+배경(#1592·#1596·#1598): 집계 함수에 job을 빠뜨리는 같은 실수가 여러 룰에서 반복됐다.
+`sum(rate(...))`처럼 by 절 없이 집계하면 두 가지가 동시에 깨진다.
+
+  1. dev·prod 값이 합산되어, 한쪽 환경만 이상해도 다른 환경 이름으로 알림이 발화한다.
+  2. 집계가 job 라벨을 지워, 발화한 알림에 환경 정보가 남지 않는다.
+     → Alertmanager 환경별 라우팅 불가, zzol-bot이 어느 환경 로그를 볼지 판단 불가.
+
+실제로 이 결함 때문에 dev 스캐너 트래픽이 prod 알림으로 13건 발화했고, zzol-bot은
+prod 로그를 근거로 오진했다. 사람 리뷰만으로는 네 번 연속 놓쳤으므로 CI로 고정한다.
+
+검사 규칙
+  - 집계 연산자(sum/max/avg/count/...)는 `by (...)`에 job을 포함해야 한다.
+  - `without (...)`을 쓰면 job을 제외해서는 안 된다.
+  - 집계가 없는 단순 셀렉터는 라벨이 그대로 보존되므로 통과시킨다.
+
+예외 표기
+  룰 위 주석에 `# job-scope-exempt: <사유>`를 두면 그 룰 하나를 건너뛴다.
+  사유를 반드시 적게 해서, 예외가 조용히 늘어나지 않게 한다.
+"""
+import re
+import sys
+from pathlib import Path
+
+AGGREGATIONS = (
+    "sum", "min", "max", "avg", "group", "stddev", "stdvar",
+    "count", "count_values", "topk", "bottomk", "quantile",
+)
+AGG_PATTERN = re.compile(
+    r"\b(" + "|".join(AGGREGATIONS) + r")\s*"          # 집계 연산자
+    r"(?:(by|without)\s*\(([^)]*)\)\s*)?"              # 앞에 오는 by/without (sum by (job) (...))
+    r"\(",
+    re.IGNORECASE,
+)
+# 뒤에 오는 형태: sum(...) by (job)
+TRAILING_GROUPING = re.compile(r"\)\s*(by|without)\s*\(([^)]*)\)", re.IGNORECASE)
+ALERT_LINE = re.compile(r"^\s*-\s*alert:\s*(\S+)")
+EXEMPT_MARKER = re.compile(r"#\s*job-scope-exempt:\s*(.+)")
+BLOCK_END = re.compile(r"^\s*(for|labels|annotations|record):")
+
+
+def extract_rules(path):
+    """(alert명, expr 텍스트, 예외 사유) 목록을 원문 라인에서 뽑는다.
+
+    YAML 파서를 쓰지 않는 이유는 예외 표기가 주석이라 파싱 시 사라지기 때문이다.
+    주석을 룰 옆에 두는 편이 별도 예외 목록 파일보다 읽는 사람에게 낫다.
+    """
+    rules = []
+    name = None
+    expr_lines = []
+    exempt = None
+    pending_exempt = None
+    in_expr = False
+
+    def flush():
+        if name is not None:
+            rules.append((name, "\n".join(expr_lines), exempt))
+
+    for line in path.read_text(encoding="utf-8").split("\n"):
+        marker = EXEMPT_MARKER.search(line)
+        if marker:
+            pending_exempt = marker.group(1).strip()
+            continue
+
+        alert = ALERT_LINE.match(line)
+        if alert:
+            flush()
+            name, expr_lines, exempt, in_expr = alert.group(1), [], pending_exempt, False
+            pending_exempt = None
+            continue
+
+        if name is None:
+            continue
+        if re.match(r"\s*expr:", line):
+            in_expr = True
+            expr_lines.append(re.sub(r"^\s*expr:\s*\|?\s*", "", line))
+            continue
+        if in_expr and BLOCK_END.match(line):
+            in_expr = False
+            continue
+        if in_expr and not line.strip().startswith("#"):
+            expr_lines.append(line)
+
+    flush()
+    return rules
+
+
+def violations(expr):
+    """job 라벨을 보존하지 않는 집계를 찾는다."""
+    found = []
+    trailing = TRAILING_GROUPING.findall(expr)
+    for match in AGG_PATTERN.finditer(expr):
+        op, modifier, labels = match.group(1), match.group(2), match.group(3)
+        if modifier is None:
+            # sum(...) by (job) 형태를 뒤에서 찾는다. 어느 집계에 붙는지 정확히
+            # 대응시키려면 파서가 필요하므로, 하나라도 job을 보존하면 통과시킨다.
+            if any(m == "by" and "job" in lbls for m, lbls in trailing):
+                continue
+            if any(m == "without" and "job" not in lbls for m, lbls in trailing):
+                continue
+            found.append(f"{op}(...) — by 절이 없어 job 라벨이 사라진다")
+        elif modifier.lower() == "by" and "job" not in labels:
+            found.append(f"{op} by ({labels.strip()}) — job이 빠져 있다")
+        elif modifier.lower() == "without" and "job" in labels:
+            found.append(f"{op} without ({labels.strip()}) — job을 제외하고 있다")
+    return found
+
+
+def main():
+    roots = [Path(p) for p in sys.argv[1:]] or [Path(".")]
+    files = sorted({f for root in roots for f in root.rglob("*.yml")})
+    if not files:
+        print(f"검사할 룰 파일을 찾지 못했다: {[str(r) for r in roots]}", file=sys.stderr)
+        return 1
+
+    failures = []
+    exempted = []
+    checked = 0
+
+    for path in files:
+        for name, expr, exempt in extract_rules(path):
+            if exempt is not None:
+                exempted.append((path, name, exempt))
+                continue
+            checked += 1
+            for problem in violations(expr):
+                failures.append((path, name, problem))
+
+    for path, name, reason in exempted:
+        print(f"⏭️  {path}::{name} — 예외: {reason}")
+
+    if failures:
+        print(f"\n❌ job 스코프 위반 {len(failures)}건\n")
+        for path, name, problem in failures:
+            print(f"  {path}")
+            print(f"    {name}: {problem}")
+        print(
+            "\n집계는 job을 보존해야 한다 — `sum by (job) (...)` 또는 `max by (job) (...)`.\n"
+            "환경을 하나로 좁히려면 셀렉터에 `{job=\"prod-app\"}`을 함께 준다.\n"
+            "의도적으로 job이 필요 없는 룰이면 룰 위에 `# job-scope-exempt: <사유>`를 적는다."
+        )
+        return 1
+
+    print(f"\n✅ 알림 룰 {checked}개 job 스코프 검사 통과 (예외 {len(exempted)}건)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/monitoring-rules-ci.yml
+++ b/.github/workflows/monitoring-rules-ci.yml
@@ -44,3 +44,11 @@ jobs:
 
       - name: Check Prometheus rules
         run: promtool check rules backend/docker/monitoring/conf/rules/*.yml
+
+      # promtool은 문법만 본다. 집계가 job 라벨을 지우는 결함(#1592·#1596·#1598)은 잡지 못해
+      # 같은 실수가 여러 룰에서 반복됐다. Loki ruler 룰은 promtool 대상이 아니므로 함께 검사한다.
+      - name: Check alert job scope
+        run: |
+          python3 .github/scripts/check-alert-job-scope.py \
+            backend/docker/monitoring/conf/rules \
+            backend/docker/monitoring/conf/loki-rules

--- a/backend/app/src/main/resources/db/migration/V39__add_zzolbot_monitor_run_dedup_key.sql
+++ b/backend/app/src/main/resources/db/migration/V39__add_zzolbot_monitor_run_dedup_key.sql
@@ -1,0 +1,24 @@
+-- 모니터링 실행 이력에 중복 판정 키(dedup_key) 추가 (#1598)
+--
+-- 기존에는 Alertmanager fingerprint로 중복 분석을 막았다. 그런데 하나의 인시던트가
+-- 서로 다른 알림 2건으로 발화하면(예: MassIpBlockingSpike critical + IpBanRateSpike warning)
+-- fingerprint가 달라 가드를 통과해, 같은 장애에 LLM을 두 번 태웠다.
+--
+-- dedup_key는 알림의 incident_group 라벨(있으면)이고 없으면 fingerprint다. 같은 인시던트를
+-- 가리키는 알림들이 하나의 키를 공유하므로 LLM 호출이 인시던트당 1회로 묶인다.
+-- fingerprint 컬럼은 개별 알림 식별자로 그대로 남겨 어드민 표시에 쓴다.
+
+ALTER TABLE zzolbot_monitor_run
+    ADD COLUMN dedup_key VARCHAR(200) NULL AFTER fingerprint;
+
+-- 기존 행은 fingerprint가 곧 중복 판정 키였다.
+UPDATE zzolbot_monitor_run
+SET dedup_key = fingerprint
+WHERE dedup_key IS NULL;
+
+CREATE INDEX idx_zzolbot_monitor_run_dedup
+    ON zzolbot_monitor_run (dedup_key, notified, created_at DESC);
+
+-- V37이 만든 fingerprint 기반 쿨다운 인덱스는 이제 쓰이지 않는다. 쿨다운 조회가
+-- dedup_key로 옮겨갔으므로, 쓰기 비용만 남는 인덱스를 제거한다.
+DROP INDEX idx_zzolbot_monitor_run_cooldown ON zzolbot_monitor_run;

--- a/backend/docker/monitoring/conf/rules/alerts-app.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-app.yml
@@ -36,22 +36,28 @@ groups:
       # 차단 요청 수가 평소 베이스라인을 크게 벗어나 치솟는다(ADR-0026 §5).
       # ⚠️ 임계 5 req/s는 순수 추정. 정상 차단(악성 트래픽)과 구분하려면 베이스라인 필수.
       #    라벨 기반 정밀화(ip_type=private 즉발)는 후속 PR에서 오탐을 줄인다.
+      # incident_group — 아래 IpBanRateSpike와 같은 인시던트를 다른 각도에서 잡는다.
+      # zzol-bot이 이 라벨로 중복 분석을 막아, 한 인시던트에 LLM을 한 번만 쓴다(#1598).
       - alert: MassIpBlockingSpike
         expr: sum(rate(ip_block_request_blocked_total[5m])) > 5
         for: 3m
         labels:
           severity: critical
+          incident_group: ip-blocking
         annotations:
           summary: "IP 차단 요청 급증 (전 트래픽 차단 인시던트 의심)"
           description: "차단 요청이 {{ $value | printf \"%.2f\" }} req/s. X-Forwarded-For 소실로 내부 IP가 BAN되는 패턴인지 즉시 확인."
 
       # 신규 BAN 급증 — 위 증상의 선행 신호(차단보다 BAN 등록이 먼저 튄다).
       # ⚠️ 임계 추정. 짧은 창에 신규 BAN이 몰리면 비정상.
+      # 위 MassIpBlockingSpike와 같은 incident_group — 선행 신호라 억제(inhibit)로 죽이지
+      # 않는다. warning만 뜨고 critical로 번지지 않은 사례(2026-07-13)가 실제로 있다.
       - alert: IpBanRateSpike
         expr: sum(rate(ip_block_new_total[5m])) > 1
         for: 3m
         labels:
           severity: warning
+          incident_group: ip-blocking
         annotations:
           summary: "신규 IP BAN 급증"
           description: "신규 BAN이 {{ $value | printf \"%.2f\" }} /s. 정상 베이스라인 대비 비정상이면 차단 정책/프록시 헤더를 점검."

--- a/backend/docker/monitoring/conf/rules/alerts-app.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-app.yml
@@ -61,9 +61,12 @@ groups:
       # 의도적으로 HTTP 핸드셰이크 계층(http_server_requests)에서 본다(ADR-0026 §5).
       # ⚠️ uri 라벨 값(/ws/info, /ws/** 등 SockJS 매핑 패턴)은 서버에서 실측 확인 필요.
       #    실제 라벨이 다르면 이 룰은 조용히 발화하지 않으므로 배포 시 1순위로 검증한다.
+      # prod로 한정하고 job 라벨을 보존한다(#1598). 셀렉터에 job이 있어도 bare sum()이
+      # 라벨을 지워, 발화한 알림에 환경 정보가 남지 않았다.
+      # 임계 1/s 유지 — prod 실측 7일 최대 0건(uri 라벨은 `/ws/**`로 셀렉터와 매칭 확인).
       - alert: WsHandshakeFailure
         expr: |
-          sum (rate(http_server_requests_seconds_count{uri=~"/ws.*",status=~"4..|5..",job=~"dev-app|prod-app"}[5m]))
+          sum by (job) (rate(http_server_requests_seconds_count{uri=~"/ws.*",status=~"4..|5..",job="prod-app"}[5m]))
           > 1
         for: 3m
         labels:

--- a/backend/docker/monitoring/conf/rules/alerts-migrated.yml
+++ b/backend/docker/monitoring/conf/rules/alerts-migrated.yml
@@ -149,6 +149,7 @@ groups:
       # redis_commands_duration_seconds_total은 cmd 라벨이 붙은 per-command 카운터라
       # processed_total(글로벌)과 직접 나누면 매치 실패 → sum by(instance)로 집계해 dev/prod 분리 유지.
       # (원본 noDataState: OK → 단순 이식). ⚠️ 메트릭·cmd 라벨 실재는 deploy-time 검증.
+      # job-scope-exempt: job='redis-exporter' 하나에 dev·prod가 함께 들어오고 instance 라벨로 구분된다. 환경 구분자는 job이 아니라 instance라 by (instance)가 옳다.
       - alert: RedisCommandLatencyHigh
         expr: |
           sum by (instance) (rate(redis_commands_duration_seconds_total{job="redis-exporter"}[5m]))
@@ -182,6 +183,7 @@ groups:
 
       # CPU 사용률 > 90% (5분 지속). t4g.small vCPU 2개.
       # (원본 noDataState: Alerting → absent 동반룰 보강)
+      # job-scope-exempt: job='node' 타깃이 node-exporter:9100 하나뿐이다. 단일 호스트의 코어 평균이라 환경 뭉갬이 없다.
       - alert: CpuUsageHigh
         expr: 100 - (avg(rate(node_cpu_seconds_total{mode="idle", job="node"}[5m])) * 100) > 90
         for: 5m

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentService.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 public class AlertEnrichmentService implements FiringAlertEnricher {
 
     private static final int LOG_SAMPLE_LIMIT = 20;
+    private static final String INCIDENT_GROUP_LABEL = "incident_group";
 
     private final LlmCallBudget llmCallBudget;
     private final LokiLogClient lokiLogClient;
@@ -48,14 +49,18 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
             return;
         }
         final Instant now = clock.instant();
-        if (recentlyEnriched(alert.fingerprint(), now)) {
-            log.info("[ZzolBot] 중복 분석 방지 — 일정 시간 내 동일 fingerprint 분석 이력 존재. fingerprint={}",
-                    alert.fingerprint());
+        final Severity severity = toSeverity(alert.severity());
+        final String dedupKey = resolveDedupKey(alert);
+        if (recentlyEnriched(dedupKey, now)) {
+            log.info("[ZzolBot] 중복 분석 방지 — 일정 시간 내 같은 인시던트 분석 이력 존재. dedupKey={} fingerprint={}",
+                    dedupKey, alert.fingerprint());
+            monitorRunRepository.save(MonitorRunEntity.duplicate(
+                    now, severity, alert.fingerprint(), dedupKey, toJson(alertContext(alert)),
+                    "LLM 분석 생략 — 같은 인시던트(%s)가 이미 분석됨".formatted(dedupKey)));
             return;
         }
-        final Severity severity = toSeverity(alert.severity());
         final MonitorRunEntity run = monitorRunRepository.save(
-                MonitorRunEntity.of(now, severity, alert.fingerprint(), toJson(alertContext(alert))));
+                MonitorRunEntity.of(now, severity, alert.fingerprint(), dedupKey, toJson(alertContext(alert))));
 
         final MonitorAnalysis analysis = analyze(alert, now);
         run.attachAnalysis(analysis.summary(), toJson(analysis.suggestedActions()));
@@ -74,18 +79,37 @@ public class AlertEnrichmentService implements FiringAlertEnricher {
     }
 
     /**
-     * 같은 fingerprint를 일정 시간 안에는 다시 분석하지 않는다(지문별 중복 분석 방지). 웹훅 재시도·flapping을
-     * 흡수하고, 지속되는 장애를 매 재통보마다 다시 LLM에 태우지 않아 비용을 묶는다. 간격이 0이거나
-     * fingerprint가 비어 식별 불가하면 가드하지 않는다. Alertmanager {@code repeat_interval}(4h) 위의
-     * 앱측 방어선으로, 재분석을 fingerprint당 일정 시간에 한 번으로 제한한다.
+     * 중복 분석 판정 키를 정한다. 알림에 {@code incident_group} 라벨이 있으면 그것을, 없으면
+     * fingerprint를 쓴다.
+     * <p>
+     * 하나의 인시던트가 알림 2건으로 발화하는 경우가 있다 — IP 차단 급증은 신규 BAN(warning)과
+     * 차단 요청(critical) 두 룰이 같은 현상을 다른 각도에서 잡는다. fingerprint는 알림마다 다르므로
+     * 그것으로 가드하면 같은 장애에 LLM을 두 번 태운다. 관련 룰에 공통 라벨을 달아 한 번으로 묶는다.
+     * <p>
+     * 억제(inhibit)로 warning을 죽이지 않는 이유는 그것이 선행 신호이기 때문이다. warning만 뜨고
+     * critical로 번지지 않은 사례가 실제로 있어(2026-07-13), 죽이면 조기 경보를 잃는다.
      */
-    private boolean recentlyEnriched(String fingerprint, Instant now) {
+    private String resolveDedupKey(FiringAlert alert) {
+        final String incidentGroup = alert.labels().get(INCIDENT_GROUP_LABEL);
+        if (incidentGroup == null || incidentGroup.isBlank()) {
+            return alert.fingerprint();
+        }
+        return incidentGroup.trim();
+    }
+
+    /**
+     * 같은 인시던트를 일정 시간 안에는 다시 분석하지 않는다. 웹훅 재시도·flapping을 흡수하고,
+     * 지속되는 장애를 매 재통보마다 다시 LLM에 태우지 않아 비용을 묶는다. 간격이 0이거나
+     * 키가 비어 식별 불가하면 가드하지 않는다. Alertmanager {@code repeat_interval}(4h) 위의
+     * 앱측 방어선이다.
+     */
+    private boolean recentlyEnriched(String dedupKey, Instant now) {
         final Duration cooldown = properties.enrichCooldown();
-        if (cooldown.isZero() || fingerprint == null || fingerprint.isBlank()) {
+        if (cooldown.isZero() || dedupKey == null || dedupKey.isBlank()) {
             return false;
         }
-        return monitorRunRepository.existsByFingerprintAndNotifiedTrueAndCreatedAtAfter(
-                fingerprint, now.minus(cooldown));
+        return monitorRunRepository.existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(
+                dedupKey, now.minus(cooldown));
     }
 
     private MonitorAnalysis safeAnalyze(FiringAlert alert, List<String> logSamples) {

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunEntity.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunEntity.java
@@ -24,9 +24,10 @@ import lombok.NoArgsConstructor;
         name = "zzolbot_monitor_run",
         indexes = {
                 @Index(name = "idx_zzolbot_monitor_run_created_at", columnList = "created_at DESC"),
-                // firing 재배달 멱등 가드(fingerprint=? AND notified=true AND created_at>?)용 복합 인덱스.
-                // 단일 fingerprint 인덱스는 이 인덱스의 prefix라 중복이므로 두지 않는다.
-                @Index(name = "idx_zzolbot_monitor_run_cooldown", columnList = "fingerprint, notified, created_at DESC")
+                // firing 재배달 멱등 가드(dedup_key=? AND notified=true AND created_at>?)용 복합 인덱스.
+                // fingerprint가 아니라 dedup_key로 잡는다 — 한 인시던트가 알림 2건으로 발화할 때
+                // fingerprint는 서로 달라 가드를 통과해버리기 때문이다(#1598).
+                @Index(name = "idx_zzolbot_monitor_run_dedup", columnList = "dedup_key, notified, created_at DESC")
         }
 )
 @Getter
@@ -53,6 +54,13 @@ public class MonitorRunEntity {
     @Column(length = 200)
     private String fingerprint;
 
+    /**
+     * 중복 분석 판정 키. 알림의 {@code incident_group} 라벨이 있으면 그것, 없으면 fingerprint다.
+     * 같은 인시던트를 다른 각도에서 잡는 알림들이 이 키를 공유해 LLM 호출이 1회로 묶인다(#1598).
+     */
+    @Column(name = "dedup_key", length = 200)
+    private String dedupKey;
+
     @Column(name = "analysis_summary", columnDefinition = "TEXT")
     private String analysisSummary;
 
@@ -65,15 +73,31 @@ public class MonitorRunEntity {
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
 
-    public static MonitorRunEntity of(Instant now, Severity severity, String fingerprint, String signalsJson) {
+    public static MonitorRunEntity of(
+            Instant now, Severity severity, String fingerprint, String dedupKey, String signalsJson) {
         final MonitorRunEntity entity = new MonitorRunEntity();
         entity.collectedAt = now;
         entity.anomalous = true;
         entity.severity = severity;
         entity.fingerprint = fingerprint;
+        entity.dedupKey = dedupKey;
         entity.signalsJson = signalsJson;
         entity.notified = false;
         entity.createdAt = Instant.now();
+        return entity;
+    }
+
+    /**
+     * 같은 인시던트가 이미 분석돼 LLM 호출을 생략한 알림. 이력에는 남긴다 — 이전에는 중복이면
+     * 저장 없이 early return해서 "무슨 알림이 왔었는지"가 아예 사라졌다(#1598).
+     * <p>
+     * {@code notified=false}로 둔다. 쿨다운 조회가 notified=true만 세므로, 중복 기록이 다시
+     * 쿨다운의 기준점이 되어 창을 계속 연장하는 일을 막는다.
+     */
+    public static MonitorRunEntity duplicate(
+            Instant now, Severity severity, String fingerprint, String dedupKey, String signalsJson, String reason) {
+        final MonitorRunEntity entity = of(now, severity, fingerprint, dedupKey, signalsJson);
+        entity.analysisSummary = reason;
         return entity;
     }
 

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunRepository.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/MonitorRunRepository.java
@@ -9,8 +9,11 @@ public interface MonitorRunRepository extends JpaRepository<MonitorRunEntity, Lo
     List<MonitorRunEntity> findTop50ByOrderByCreatedAtDesc();
 
     /**
-     * 중복 억제 윈도우 안에 같은 fingerprint로 이미 알림한 실행이 있는지. firing 웹훅 멱등 가드용으로,
-     * {@code idx_zzolbot_monitor_run_cooldown(fingerprint, notified, created_at DESC)} 인덱스가 받친다.
+     * 중복 억제 윈도우 안에 같은 중복 판정 키로 이미 알림한 실행이 있는지. firing 웹훅 멱등 가드용으로,
+     * {@code idx_zzolbot_monitor_run_dedup(dedup_key, notified, created_at DESC)} 인덱스가 받친다.
+     * <p>
+     * fingerprint가 아니라 dedup_key로 본다 — 한 인시던트가 알림 2건으로 발화하면 fingerprint는
+     * 서로 달라 가드를 통과해, 같은 장애에 LLM을 두 번 태웠다(#1598).
      */
-    boolean existsByFingerprintAndNotifiedTrueAndCreatedAtAfter(String fingerprint, Instant threshold);
+    boolean existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(String dedupKey, Instant threshold);
 }

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/application/AlertEnrichmentServiceTest.java
@@ -2,6 +2,7 @@ package coffeeshout.zzolbot.monitor.application;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -22,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -92,15 +95,21 @@ class AlertEnrichmentServiceTest {
     }
 
     @Test
-    void 간격_내_동일_fingerprint_재배달은_분석을_생략한다() {
-        given(monitorRunRepository.existsByFingerprintAndNotifiedTrueAndCreatedAtAfter(any(), any()))
+    void 간격_내_재배달은_LLM_분석을_생략하되_이력은_남긴다() {
+        given(monitorRunRepository.existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(any(), any()))
                 .willReturn(true);
 
         service.enrich(warningAlert());
 
-        verify(monitorRunRepository, never()).save(any());
         verify(llmCallBudget, never()).tryAcquire();
         verify(notifier, never()).notifyAnomaly(any(), any());
+        final ArgumentCaptor<MonitorRunEntity> captor = ArgumentCaptor.forClass(MonitorRunEntity.class);
+        verify(monitorRunRepository).save(captor.capture());
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(captor.getValue().getAnalysisSummary()).contains("이미 분석됨");
+            // notified=false여야 이 중복 기록이 다시 쿨다운 기준점이 되어 창을 연장하지 않는다.
+            softly.assertThat(captor.getValue().isNotified()).isFalse();
+        });
     }
 
     @Test
@@ -114,7 +123,7 @@ class AlertEnrichmentServiceTest {
         noDedup.enrich(warningAlert());
 
         verify(monitorRunRepository, never())
-                .existsByFingerprintAndNotifiedTrueAndCreatedAtAfter(any(), any());
+                .existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(any(), any());
         verify(notifier).notifyAnomaly(any(), any());
     }
 
@@ -159,8 +168,73 @@ class AlertEnrichmentServiceTest {
         });
     }
 
+    @Nested
+    @DisplayName("인시던트 단위 중복 판정")
+    class IncidentDedup {
+
+        @Test
+        void 같은_incident_group_알림_쌍은_LLM을_한_번만_호출한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+            // 첫 알림(warning)이 분석된 뒤, 같은 인시던트의 critical이 뒤따르는 상황
+            given(monitorRunRepository.existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(eq("ip-blocking"), any()))
+                    .willReturn(false, true);
+
+            service.enrich(groupedAlert("warning"));
+            service.enrich(groupedAlert("critical"));
+
+            verify(analyzer, times(1)).analyze(any(), any());
+            verify(llmCallBudget, times(1)).tryAcquire();
+        }
+
+        @Test
+        void incident_group이_있으면_그것을_중복_판정_키로_저장한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+
+            service.enrich(groupedAlert("critical"));
+
+            final ArgumentCaptor<MonitorRunEntity> captor = ArgumentCaptor.forClass(MonitorRunEntity.class);
+            verify(monitorRunRepository, times(2)).save(captor.capture());
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(captor.getValue().getDedupKey()).isEqualTo("ip-blocking");
+                // fingerprint는 개별 알림 식별자로 그대로 남는다.
+                softly.assertThat(captor.getValue().getFingerprint()).isEqualTo("fp-1");
+            });
+        }
+
+        @Test
+        void incident_group이_없으면_fingerprint로_판정한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+
+            service.enrich(warningAlert());
+
+            verify(monitorRunRepository).existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(eq("fp-1"), any());
+        }
+
+        @Test
+        void 같은_그룹이라도_쿨다운이_지났으면_다시_분석한다() {
+            given(llmCallBudget.tryAcquire()).willReturn(true);
+            given(analyzer.analyze(any(), any())).willReturn(new MonitorAnalysis("요약", "", List.of()));
+            given(monitorRunRepository.existsByDedupKeyAndNotifiedTrueAndCreatedAtAfter(any(), any()))
+                    .willReturn(false);
+
+            service.enrich(groupedAlert("warning"));
+            service.enrich(groupedAlert("critical"));
+
+            verify(analyzer, times(2)).analyze(any(), any());
+        }
+    }
+
     private FiringAlert warningAlert() {
         return alert("warning");
+    }
+
+    private FiringAlert groupedAlert(String severity) {
+        return new FiringAlert("MassIpBlockingSpike", severity, "fp-1", "IP 차단 급증", "임계 초과",
+                Map.of("alertname", "MassIpBlockingSpike", "severity", severity,
+                        "incident_group", "ip-blocking"));
     }
 
     private FiringAlert alert(String severity) {

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/ui/ZzolBotMonitorControllerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/ui/ZzolBotMonitorControllerTest.java
@@ -55,7 +55,7 @@ class ZzolBotMonitorControllerTest {
     }
 
     private MonitorRunEntity run(Severity severity) {
-        final MonitorRunEntity entity = MonitorRunEntity.of(Instant.now(), severity, "fp", "{}");
+        final MonitorRunEntity entity = MonitorRunEntity.of(Instant.now(), severity, "fp", "fp", "{}");
         ReflectionTestUtils.setField(entity, "id", 1L);
         return entity;
     }


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1598

> ⚠️ **머지 순서 의존** — 이 PR의 CI 체크는 #1593·#1597이 고치는 룰 6건에서 실패합니다. **#1593·#1597 머지 후에 머지**해주세요. 아래 "검증"에 머지 상태를 재현한 결과를 적었습니다.

# 🚀 작업 내용

## 문제 상황

**① 한 인시던트가 알림 2건으로 발화해 LLM 예산을 2배 씁니다**

`MassIpBlockingSpike`(critical)와 `IpBanRateSpike`(warning)는 같은 현상을 다른 각도에서 잡습니다. 룰 주석대로 "신규 BAN 급증은 차단 요청 급증의 선행 신호"라 **하나의 인시던트가 두 알림을 냅니다.**

07/11~15 IP 인시던트 7건 중 6건이 쌍으로 들어왔습니다.

```
07/11 05:24 WARNING → 05:26 CRITICAL
07/12 05:09 WARNING + CRITICAL
07/14 14:46 WARNING + CRITICAL
07/15 01:30 WARNING + CRITICAL
07/15 10:32 WARNING + CRITICAL
```

fingerprint가 서로 달라 4시간 쿨다운이 흡수하지 못합니다. **인시던트 1건당 LLM 2회**, 일일 예산 10회 기준 실질 커버가 5건으로 반감됩니다.

부수 문제로, 중복 판정된 알림은 `enrich()`가 early return하면서 **이력에 저장조차 되지 않았습니다.** 어드민에서 "무슨 알림이 왔었는지"를 알 수 없습니다.

**② 같은 실수를 막는 장치가 없습니다**

집계에 job을 빠뜨리는 결함이 **여섯 룰에서 반복**됐습니다. `monitoring-rules-ci`의 promtool은 문법만 보고 이 결함은 잡지 못합니다. 네 번 연속 사람 리뷰를 통과한 실수입니다.

## 변경 내용

**1. 중복 판정을 인시던트 단위로** (`alerts-app.yml`, `AlertEnrichmentService`, `MonitorRunEntity`, V39)

같은 인시던트를 가리키는 룰에 공통 `incident_group` 라벨을 달고, 중복 판정 키를 fingerprint 대신 이 값으로 씁니다(없으면 fingerprint로 폴백).

억제(`inhibit_rules`)로 warning을 죽이는 방식은 택하지 않았습니다. **선행 신호이고, warning만 뜨고 critical로 번지지 않은 사례가 실제로 있습니다**(07/13 11:21). 죽이면 조기 경보를 잃습니다.

중복 판정된 알림도 이력에 남기고 생략 사유를 기록합니다. `notified=false`로 두어, 중복 기록이 다시 쿨다운 기준점이 되어 창을 무한정 연장하지 않게 했습니다.

**2. job 스코프 CI 체크** (`.github/scripts/check-alert-job-scope.py`)

검사 기준은 "expr에 `job` 문자열이 있는가"가 **아니라** "라벨을 지우는 집계가 있는가"입니다. 전자로 하면 `AlloyComponentUnhealthy`처럼 집계 없는 단순 셀렉터를 오탐으로 잡습니다.

- 집계 연산자는 `by` 절에 job을 포함해야 함
- `without` 절이면 job을 제외하면 안 됨
- 집계가 없으면 라벨이 보존되므로 통과
- promtool 대상이 아닌 Loki ruler 룰도 함께 검사

**3. 체크를 붙이며 새로 드러난 결함 수정**

`WsHandshakeFailure`가 셀렉터에 job이 있는데도 bare `sum()`이 라벨을 지우고 있었습니다. **앞선 세 번의 조사에서 모두 놓친 건**이고, 체크가 바로 잡아냈습니다. prod 한정 + `sum by (job)`으로 고쳤습니다(임계 1/s 유지, prod 실측 7일 최대 0건).

# 💬 리뷰 중점사항

**예외 표기 규약**

`# job-scope-exempt: <사유>`를 룰 위에 적으면 그 룰을 건너뜁니다. **사유를 반드시 적게 해** 예외가 조용히 늘어나지 않게 했습니다. 실제 적용 2건:

| 룰 | 사유 |
|---|---|
| `RedisCommandLatencyHigh` | `job='redis-exporter'` 하나에 dev·prod가 함께 들어오고 `instance`로 구분된다. 환경 구분자가 job이 아니라 instance라 `by (instance)`가 옳다 |
| `CpuUsageHigh` | `job='node'` 타깃이 `node-exporter:9100` 하나뿐이라 단일 호스트의 코어 평균이다 |

두 건 다 `prometheus.yml`의 스크레이프 타깃을 확인하고 판단했습니다. 예외가 아니라 수정이 맞다는 의견 있으면 바꾸겠습니다.

**스키마 변경 — `dedup_key` 컬럼 추가 (V39)**

#1595는 마이그레이션을 피해 `signals_json`에 병합했지만, 이번엔 **쿨다운 조회 조건**이라 인덱스가 필요해 컬럼을 추가했습니다. `fingerprint` 컬럼은 개별 알림 식별자로 남겨 어드민 표시에 계속 씁니다. V37이 만든 fingerprint 기반 쿨다운 인덱스는 쓰이지 않게 되므로 제거했습니다.

**⚠️ #1595와 충돌 예상**

`AlertEnrichmentService.enrich()`를 #1595도 수정합니다. 머지 시 충돌이 나며, 두 변경은 서로 배타적이지 않으니 양쪽을 합치면 됩니다(#1595는 환경 유도·근거 검증, 이 PR은 중복 판정 키).

**검증**

- `:zzolbot` 168개 테스트 통과 — 쌍 알림 1회 분석 / 이력 보존 / fingerprint 폴백 / 쿨다운 경과 후 재분석 케이스 추가
- `:app` 통합 테스트로 V39 적용 확인 (Flyway 전체 체인 기동)
- **머지 상태 재현**: 임시 브랜치에 #1593·#1597을 함께 머지해 CI 체크 실행 → **룰 25개 전부 통과, 예외 2건**. 그때 발생한 충돌은 `alerts-app.yml`의 주석 블록뿐이고 `expr`·`labels`는 깨끗이 병합됩니다
