### PR TITLE
[fix] 근거 판정을 코드로 강제해 근거 없는 결론 누출을 차단

### DIFF
--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
@@ -36,7 +36,8 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
               "summary": "현재 상황 한국어 1~2문장 요약",
               "rootCauseHypothesis": "가장 가능성 높은 근본 원인 가설",
               "suggestedActions": ["운영자가 취할 수 있는 조치 제안", "..."],
-              "evidenceFound": true 또는 false
+              "evidenceFound": true 또는 false,
+              "evidenceLine": "evidenceFound가 true일 때 근거가 된 로그 한 줄을 위 샘플에서 그대로 복사"
             }
 
             근거 판정 규칙 — 이 규칙이 다른 무엇보다 우선한다.
@@ -44,6 +45,9 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
             - 로그가 알림과 무관하거나, 알림을 설명하지 못하거나, 로그 출처 환경이 알림 대상 환경과
               다르면 evidenceFound를 false로 두고 summary에 "제공된 로그에서 이 알림을 뒷받침할
               근거를 찾지 못했다"는 사실을 명시하라.
+            - evidenceFound가 true이면 evidenceLine에 근거가 된 로그 한 줄을 위 샘플에서 한 글자도
+              바꾸지 말고 그대로 복사하라. 요약하거나 바꿔 쓰지 마라. 그대로 복사할 로그가 없으면
+              evidenceFound는 false다.
             - evidenceFound가 false이면 rootCauseHypothesis는 빈 문자열로 두고 원인을 추측하지 마라.
             - 알림 설명(description)에 적힌 원인 가설은 사람이 미리 적어둔 추측일 뿐 확인된 사실이
               아니다. 로그로 뒷받침되지 않으면 그것을 결론으로 삼지 마라.
@@ -66,7 +70,7 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
                 .build();
         final String prompt = buildPrompt(alert, logSamples, logEnvironment);
         final GenerateContentResponse response = callApi(prompt, config);
-        return parse(response.text());
+        return parse(response.text(), logSamples);
     }
 
     protected GenerateContentResponse callApi(String prompt, GenerateContentConfig config) {
@@ -98,20 +102,38 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
         return sb.toString();
     }
 
-    private MonitorAnalysis parse(String json) {
+    private MonitorAnalysis parse(String json, List<String> logSamples) {
         try {
             final JsonNode node = objectMapper.readTree(json);
             final List<String> actions = new ArrayList<>();
             node.path("suggestedActions").forEach(a -> actions.add(a.asText()));
-            // 판정이 누락되면 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
+            // 근거 판정은 모델 자체 판정(evidenceFound)에 인용 검증을 코드로 덧씌운다. 판정이 누락되면
+            // 보수적으로 false로 본다 — 근거 있다고 잘못 표시하는 쪽이 더 위험하다.
+            final boolean claimed = node.path("evidenceFound").asBoolean(false);
+            final boolean grounded = claimed && citedInLogs(node.path("evidenceLine").asText(""), logSamples);
+            // 규칙 #3을 코드로 강제한다 — 근거가 없으면 모델이 무엇을 보냈든 원인 가설은 공백이다.
+            final String hypothesis = grounded ? node.path("rootCauseHypothesis").asText("") : "";
             return new MonitorAnalysis(
                     node.path("summary").asText(""),
-                    node.path("rootCauseHypothesis").asText(""),
+                    hypothesis,
                     actions,
-                    node.path("evidenceFound").asBoolean(false));
+                    grounded);
         } catch (Exception e) {
             log.warn("[ZzolBot] 이상 분석 응답 파싱 실패. raw={}", json, e);
             return MonitorAnalysis.failed();
         }
+    }
+
+    /**
+     * 모델이 근거로 인용한 로그 줄이 실제 로그 샘플에 그대로 존재하는지 확인한다. 지어낸 이벤트명·수치를
+     * 근거로 내세우는 실패를 코드로 차단한다.
+     */
+    // ponytail: 공백 정규화 후 부분 문자열 포함만 본다. 의미 매칭·토큰 단위 매칭이 필요하면 그때 올린다.
+    private boolean citedInLogs(String evidenceLine, List<String> logSamples) {
+        if (evidenceLine.isBlank() || logSamples == null) {
+            return false;
+        }
+        final String needle = evidenceLine.strip();
+        return logSamples.stream().anyMatch(line -> line != null && line.contains(needle));
     }
 }

--- a/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
+++ b/backend/zzolbot/src/main/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzer.java
@@ -126,14 +126,21 @@ public class GeminiAnomalyAnalyzer implements AnomalyAnalyzer {
 
     /**
      * 모델이 근거로 인용한 로그 줄이 실제 로그 샘플에 그대로 존재하는지 확인한다. 지어낸 이벤트명·수치를
-     * 근거로 내세우는 실패를 코드로 차단한다.
+     * 근거로 내세우는 실패를 코드로 차단한다. 스택 트레이스처럼 로그 한 건이 여러 줄일 수 있으므로,
+     * 개행·연속 공백을 단일 공백으로 접은 뒤 비교해 인용의 줄바꿈·들여쓰기 차이는 무시한다.
      */
     // ponytail: 공백 정규화 후 부분 문자열 포함만 본다. 의미 매칭·토큰 단위 매칭이 필요하면 그때 올린다.
     private boolean citedInLogs(String evidenceLine, List<String> logSamples) {
         if (evidenceLine.isBlank() || logSamples == null) {
             return false;
         }
-        final String needle = evidenceLine.strip();
-        return logSamples.stream().anyMatch(line -> line != null && line.contains(needle));
+        final String needle = normalizeWhitespace(evidenceLine);
+        return logSamples.stream()
+                .filter(line -> line != null)
+                .anyMatch(line -> normalizeWhitespace(line).contains(needle));
+    }
+
+    private static String normalizeWhitespace(String text) {
+        return text.strip().replaceAll("\\s+", " ");
     }
 }

--- a/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
+++ b/backend/zzolbot/src/test/java/coffeeshout/zzolbot/monitor/infra/GeminiAnomalyAnalyzerTest.java
@@ -1,0 +1,129 @@
+package coffeeshout.zzolbot.monitor.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.zzolbot.monitor.domain.FiringAlert;
+import coffeeshout.zzolbot.monitor.domain.MonitorAnalysis;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GeminiAnomalyAnalyzerTest {
+
+    private static final FiringAlert ALERT = new FiringAlert(
+            "AppErrorLogSpike", "warning", "fp-1", "ERROR 급증", "임계 초과",
+            Map.of("alertname", "AppErrorLogSpike"));
+
+    // client·properties는 callApi 안에서만 쓰이고 그 메서드를 스텁하므로 null로 둔다.
+    @Spy
+    private GeminiAnomalyAnalyzer analyzer = new GeminiAnomalyAnalyzer(null, null, new ObjectMapper());
+
+    private MonitorAnalysis analyzeWith(String responseJson, List<String> logSamples) {
+        final GenerateContentResponse response = mock(GenerateContentResponse.class);
+        given(response.text()).willReturn(responseJson);
+        doReturn(response).when(analyzer).callApi(anyString(), any(GenerateContentConfig.class));
+        return analyzer.analyze(ALERT, logSamples, "dev");
+    }
+
+    @Nested
+    class 근거_판정 {
+
+        @Test
+        void 인용_로그가_샘플에_실재하면_근거를_인정하고_가설을_유지한다() {
+            final String json = """
+                    {"summary":"컨슈머 지연","rootCauseHypothesis":"컨슈머가 밀렸다",
+                     "suggestedActions":["스케일 아웃"],"evidenceFound":true,
+                     "evidenceLine":"ERROR consumer lag 12000"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("2026-07-22 ERROR consumer lag 12000 group=g1"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isTrue();
+                softly.assertThat(result.rootCauseHypothesis()).isEqualTo("컨슈머가 밀렸다");
+            });
+        }
+
+        @Test
+        void 모델이_근거있다_해도_인용이_샘플에_없으면_근거없음으로_강등하고_가설을_비운다() {
+            // evidenceLine "table orders" 는 로그 어디에도 없다 — 지어낸 근거.
+            final String json = """
+                    {"summary":"DB 문제로 보임","rootCauseHypothesis":"orders 테이블 잠금",
+                     "suggestedActions":["인덱스 점검"],"evidenceFound":true,
+                     "evidenceLine":"ERROR lock wait on table orders"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("2026-07-22 ERROR consumer lag 12000"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void evidenceFound가_false면_가설을_비운다_규칙3() {
+            final String json = """
+                    {"summary":"근거 못 찾음","rootCauseHypothesis":"그래도 컨슈머 지연일 듯",
+                     "suggestedActions":[],"evidenceFound":false,"evidenceLine":""}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("무관한 로그"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void evidenceFound가_true여도_evidenceLine이_없으면_근거없음으로_본다() {
+            final String json = """
+                    {"summary":"요약","rootCauseHypothesis":"가설","suggestedActions":[],
+                     "evidenceFound":true}""";
+
+            final MonitorAnalysis result = analyzeWith(json, List.of("ERROR something"));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(result.evidenceFound()).isFalse();
+                softly.assertThat(result.rootCauseHypothesis()).isEmpty();
+            });
+        }
+
+        @Test
+        void 여러_줄_로그를_개행_대신_공백으로_인용해도_근거로_인정한다() {
+            // 로그 한 건이 스택 트레이스(개행·탭 포함)인데 모델은 한 줄로 펴서 인용한다.
+            final List<String> logSamples = List.of("ERROR OutOfMemoryError\n\tat com.foo.Bar(Bar.java:42)");
+            final String json = """
+                    {"summary":"OOM","rootCauseHypothesis":"힙 부족",
+                     "suggestedActions":["힙 상향"],"evidenceFound":true,
+                     "evidenceLine":"ERROR OutOfMemoryError at com.foo.Bar(Bar.java:42)"}""";
+
+            final MonitorAnalysis result = analyzeWith(json, logSamples);
+
+            assertThat(result.evidenceFound()).isTrue();
+        }
+    }
+
+    @Nested
+    class 파싱_실패 {
+
+        @Test
+        void JSON이_아니면_실패_분석을_반환한다() {
+            final MonitorAnalysis result = analyzeWith("이건 JSON이 아니다", List.of("ERROR x"));
+
+            assertThat(result.summary()).isEqualTo(MonitorAnalysis.failed().summary());
+        }
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (base: `fix/1594-zzolbot-monitor-evidence` — #1594 PR 위에 쌓는 스택 PR)

# 🔥 연관 이슈

- 없음 (#1594 PR의 근거 판정 강화 후속)

# 🚀 작업 내용

`GeminiAnomalyAnalyzer` 한 파일. 지금까지 프롬프트(모델에게 하는 부탁)에만 있던 근거 판정 규칙 중, 코드로 확실히 지킬 수 있는 두 가지를 코드로 옮겼습니다. 프롬프트는 "지켜주길 바라는 것"이라 모델이 어길 수 있지만, 코드로 옮기면 무조건 지켜집니다.

1. **근거 없으면 원인 가설은 무조건 공백** — 모델이 "근거 없음(evidenceFound=false)"이라고 답하면서도 원인 가설을 채워 보내는 경우가 있습니다. 이제 `parse()`에서 근거가 없으면 모델이 뭘 보냈든 원인 가설(rootCauseHypothesis)을 공백으로 만듭니다.
2. **인용한 로그가 진짜 있는지 검증** — 응답에 `evidenceLine`(근거가 된 로그 한 줄) 필드를 추가하고, 그 줄이 실제로 준 로그 샘플 안에 있는지 코드로 확인합니다. 없으면(= 지어낸 근거) 근거 없음으로 강등합니다.

최종적으로 "근거 있음"은 **모델이 근거 있다고 판정 + 인용한 로그가 실재** 둘 다 만족할 때만 인정됩니다.

# 💬 리뷰 중점사항

- **과소 주장 쪽으로 더 보수적이 됩니다.** 모델이 로그를 그대로 인용하지 않고 살짝 바꿔 쓰면, 정당한 분석이라도 "근거 없음"으로 강등될 수 있습니다. `MonitorAnalysis` 주석의 "과소 주장이 과대 주장보다 안전" 원칙과는 맞지만, 놓치는 경우(false negative)가 늘 수 있는 점을 봐주세요.
- **인용 검증은 단순 포함(substring) 검사입니다.** `"ERROR"` 같은 짧은 인용이 무의미하게 통과할 여지가 있습니다. 지금은 단순하게 두고, 필요하면 토큰/의미 단위 매칭으로 올리자는 취지로 코드에 `ponytail:` 주석을 남겼습니다.
- **이 로직 자체의 단위 테스트는 아직 없습니다.** public 시그니처가 안 바뀌어(parse는 private) 기존 테스트는 그대로 통과하지만, 이 강제 로직을 직접 검증하려면 `callApi`를 오버라이드해 JSON을 주입하는 테스트가 필요합니다. 필요하면 이어서 추가하겠습니다.
