### PR TITLE
[fix] Spring Boot 4 Flyway 오토컨피그 누락 수정 — DB 마이그레이션 미실행 회귀

### DIFF
--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     implementation(project(":profanity"))
 
     // --- Database & Migration ---
+    // Boot 4는 오토컨피그를 기술별 모듈로 분리했다(테스트 스타터도 아래 36행처럼 분리됨).
+    // flyway-core/-mysql는 라이브러리일 뿐이라, spring-boot-flyway(오토컨피그 모듈)가 없으면
+    // FlywayMigrationInitializer 빈이 생성되지 않아 마이그레이션이 조용히 실행되지 않는다(#1606).
+    implementation("org.springframework.boot:spring-boot-flyway")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-mysql")
     implementation("com.mysql:mysql-connector-j")
@@ -46,4 +50,11 @@ dependencies {
 tasks.withType<Test> {
     // :app 통합 테스트는 Spring context를 여러 개 띄우므로 힙을 더 크게 잡는다
     jvmArgs("-Xmx2g", "-XX:MaxMetaspaceSize=512m")
+
+    // Flyway 검증 테스트(FlywayMigrationIntegrationTest)가 전 마이그레이션 체인을 실제로 돌리며,
+    // 그중 V34(OAuth 이메일 백필)가 이 두 키를 System.getenv로 요구한다(운영은 배포 시크릿).
+    // 빈 DB엔 백필할 행이 없어 키는 SHA-256 파생을 통과할 길이(32자 이상)면 충분하다.
+    // 다른 테스트는 Flyway를 꺼두어 이 변수를 읽지 않으므로 태스크 전역 설정이 무해하다.
+    environment("USER_EMAIL_ENCRYPTION_KEY", "test-only-email-encryption-key-000000000000")
+    environment("USER_EMAIL_HMAC_KEY", "test-only-email-hmac-key-00000000000000000000")
 }

--- a/backend/app/src/test/java/coffeeshout/migration/FlywayMigrationIntegrationTest.java
+++ b/backend/app/src/test/java/coffeeshout/migration/FlywayMigrationIntegrationTest.java
@@ -1,0 +1,100 @@
+package coffeeshout.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import coffeeshout.support.CommonTestSchedulerConfig;
+import coffeeshout.support.app.config.IntegrationTestConfig;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Flyway가 실제로 구동되어 마이그레이션이 head까지 적용되는지 검증한다(#1606).
+ * <p>
+ * 다른 통합 테스트는 {@code flyway.enabled: false} + {@code ddl-auto: create}로 Flyway 경로를
+ * 전혀 타지 않는다 — 그래서 Spring Boot 4 전환 때 Flyway 오토컨피그가 누락돼 마이그레이션이
+ * 조용히 멈춘 것이 어떤 테스트에도 걸리지 않았다. 이 테스트는 운영과 동일하게
+ * {@code flyway.enabled: true} + {@code ddl-auto: validate}로 <b>빈 DB</b>에 부팅한다.
+ * <ul>
+ *   <li>Flyway 오토컨피그가 없으면 → 마이그레이션이 안 돌아 빈 스키마에 validate가 깨지고 컨텍스트 로드 실패.
+ *   <li>Flyway가 정상 구동되면 → 스키마를 head까지 만들고 validate 통과 → 컨텍스트 로드 성공.
+ * </ul>
+ * 공유 컨테이너(create 스키마)와 섞이면 flyway_schema_history 없는 DB를 baseline하는 오염이
+ * 생기므로, 전용 fresh 컨테이너를 쓴다.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+        properties = {
+                "spring.flyway.enabled=true",
+                "spring.jpa.hibernate.ddl-auto=validate",
+        })
+@ActiveProfiles("test")
+@Import({CommonTestSchedulerConfig.class, IntegrationTestConfig.class})
+class FlywayMigrationIntegrationTest {
+
+    private static final int VALKEY_PORT = 6379;
+
+    @SuppressWarnings({"resource", "rawtypes"})
+    static final MySQLContainer mysql = new MySQLContainer(DockerImageName.parse("mysql:8.0"))
+            .withDatabaseName("flyway_verify")
+            .withUsername("test")
+            .withPassword("test");
+
+    @SuppressWarnings("resource")
+    static final GenericContainer<?> valkey = new GenericContainer<>(DockerImageName.parse("valkey/valkey:alpine"))
+            .withExposedPorts(VALKEY_PORT)
+            .withCommand("valkey-server", "--save", "", "--appendonly", "no")
+            .waitingFor(Wait.forListeningPort());
+
+    static {
+        mysql.start();
+        valkey.start();
+    }
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.data.redis.host", valkey::getHost);
+        registry.add("spring.data.redis.port", () -> valkey.getMappedPort(VALKEY_PORT));
+    }
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    void Flyway가_구동되어_마이그레이션을_적용한다() {
+        final JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        // 컨텍스트가 flyway.enabled=true + ddl-auto=validate로 빈 DB에 떴다는 것 자체가
+        // Flyway가 스키마를 만들었다는 뜻이다(오토컨피그가 없으면 여기까지 오지 못한다).
+        // 히스토리와 실제 스키마 양쪽을 직접 확인한다.
+        final Integer flywayRuns = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE success = 1", Integer.class);
+        final boolean v39Applied = Boolean.TRUE.equals(jdbc.queryForObject(
+                "SELECT EXISTS(SELECT 1 FROM flyway_schema_history WHERE version = '39' AND success = 1)",
+                Boolean.class));
+        final Integer dedupKeyColumn = jdbc.queryForObject(
+                """
+                SELECT COUNT(*) FROM information_schema.columns
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'zzolbot_monitor_run'
+                   AND column_name = 'dedup_key'
+                """, Integer.class);
+
+        assertThat(flywayRuns).as("Flyway가 마이그레이션을 적용해야 한다").isGreaterThan(0);
+        assertThat(v39Applied).as("V39가 성공적으로 적용돼야 한다").isTrue();
+        assertThat(dedupKeyColumn).as("V39가 만든 dedup_key 컬럼이 존재해야 한다").isEqualTo(1);
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1606
- 발견 경로: #1599 배포 실패 / 출처: ADR-0020 (Spring Boot 4 마이그레이션)

# 🚀 작업 내용

## 문제 상황

**#1599 배포가 계속 실패했다.** green 컨테이너가 이 에러로 크래시 루프에 빠져 readiness timeout → 롤백됐다:

```
Schema validation: missing column [dedup_key] in table [zzolbot_monitor_run]
→ Application run failed  (crash loop → readiness timeout → 롤백)
```

표면은 "V39 컬럼 없음"이지만, 근본 원인은 **Flyway가 앱 시작 시 아예 실행되지 않는다**는 것이었다.

**dev 서버 실측으로 확정한 진단:**

- dev `flyway_schema_history` 최신 = **V37** (2026-06-23 적용). V38·V39 둘 다 미적용, `dedup_key` 컬럼 없음
- 배포 이미지에 V38·V39 파일은 **존재** (패키징 문제 아님)
- `SPRING_FLYWAY_ENABLED` 등 비활성화 env **없음**
- green 시작 로그에 `Flyway`·`Migrating` 줄이 **하나도 없음** → Flyway 빈 자체가 미생성

**근본 원인:** `app/build.gradle.kts`가 Flyway **라이브러리**만 의존했다.

```kotlin
implementation("org.flywaydb:flyway-core")   // 라이브러리
implementation("org.flywaydb:flyway-mysql")  // 라이브러리
// ← spring-boot-flyway (오토컨피그 모듈) 없음
```

Spring Boot 3은 `FlywayAutoConfiguration`이 `spring-boot-autoconfigure`에 기본 포함이라 이것만으로 동작했다. **Spring Boot 4는 오토컨피그를 기술별 모듈로 분리**했고, Flyway 오토컨피그는 `spring-boot-flyway` 모듈로 빠졌다. 이게 없으면 `FlywayMigrationInitializer` 빈이 생성되지 않아 **마이그레이션이 에러도 로그도 없이 조용히 실행되지 않는다.**

타임라인이 정확히 맞는다: V35~37은 2026-06-23 **Spring Boot 3** 시절 적용됐고, 이후 SB4 전환으로 Flyway가 멈췄으며, 그 뒤 추가된 V38·V39가 미적용으로 쌓였다. **V39가 우연히(새 컬럼을 엔티티가 기대해 validate가 깨지며) 이 잠복 버그를 처음 드러냈을 뿐이다.**

> ⚠️ 이건 우리 배포만의 문제가 아니다. **SB4 전환 이후 이 앱은 DB 마이그레이션을 하나도 적용하지 않고 있었다.**

## 변경 내용

**1. Flyway 오토컨피그 모듈 추가** (`app/build.gradle.kts`)

```kotlin
implementation("org.springframework.boot:spring-boot-flyway")
```

BOM으로 4.0.7 해석(버전 명시 불필요). 이걸 넣으면 `FlywayMigrationInitializer`가 다시 생성되어 시작 시 마이그레이션이 실행된다. **이 수정 배포가 스스로 낫는다** — green의 Flyway가 V38·V39를 자동 적용하고 validate 통과 → 배포 성공. 별도 DB 수술 불필요.

**2. Flyway 실행을 검증하는 통합 테스트 추가** (`FlywayMigrationIntegrationTest`)

운영과 동일하게 `flyway.enabled=true` + `ddl-auto=validate`로 **빈 DB**에 부팅해, Flyway가 전 체인을 적용하고 V39·`dedup_key`까지 만드는지 확인한다. 수정 전엔 실패하고 수정 후 통과하는 회귀 가드다.

# 💬 리뷰 중점사항

**왜 이 버그가 그동안 모든 테스트를 통과했나**

모든 통합 테스트가 `flyway.enabled: false` + `ddl-auto: create`다 — Hibernate가 엔티티에서 스키마를 직접 만들어 Flyway 경로를 **아예 타지 않는다.** 그래서 오토컨피그 누락이 어떤 테스트에도 안 걸렸다. 새 테스트가 이 공백을 메운다.

**새 테스트가 전용 컨테이너를 쓰는 이유**

공유 Testcontainers MySQL은 다른 테스트가 `ddl-auto: create`로 스키마를 채워 `flyway_schema_history`가 없다. 거기에 Flyway를 켜면 baseline 오염이 생기므로, 전용 fresh 컨테이너로 격리했다.

**빌드 테스트 태스크에 더미 크립토 키 2개 추가**

새 테스트가 전 체인을 돌리며 V34(OAuth 이메일 백필 Java 마이그레이션)를 실행하는데, V34가 `System.getenv`로 `USER_EMAIL_ENCRYPTION_KEY`·`USER_EMAIL_HMAC_KEY`(각 32자 이상)를 요구한다(운영은 배포 시크릿). 빈 DB엔 백필할 행이 없어 키는 길이 검증만 통과하면 되므로 더미값으로 넣었다. 다른 테스트는 Flyway를 꺼 이 변수를 안 읽으므로 무해하다.

**영향 범위**

| 프로파일 | flyway.enabled | 변화 |
|---|---|---|
| local | false | 없음 |
| test | false | 없음 (새 테스트만 명시적으로 켬) |
| **dev / prod** | true | **Flyway가 실제로 구동됨 (=이 수정의 목적)** |

**검증**

- `:app` 114개 테스트 통과 (신규 `FlywayMigrationIntegrationTest` 포함)
- `spring-boot-flyway:4.0.7` BOM 해석 확인
- 새 테스트로 fresh DB에 V39·`dedup_key` 적용 확인

**배포 후 확인 필요**

배포되면 green의 Flyway가 dev DB를 V37 → V39로 올린다. 배포 후 `flyway_schema_history`가 V39까지 갔는지 확인 권장.

**후속 (이 PR 범위 밖, #1606 TODO)**

- SB4 전환에서 누락된 다른 오토컨피그 모듈이 더 있는지 점검
- 마이그레이션 미적용을 배포 전 조기에 잡는 장치 (예: `flyway info` pending 체크)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 애플리케이션 시작 시 데이터베이스 마이그레이션이 자동으로 실행되도록 개선했습니다.
  * 빈 데이터베이스에서도 마이그레이션과 스키마 검증이 정상적으로 수행되는지 자동 확인합니다.
  * 마이그레이션 이력과 주요 데이터베이스 컬럼의 생성 여부를 검증해 초기 설정의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->