### PR TITLE
[refactor] 닉네임 검열 등록을 닉네임 저장 트랜잭션에 참여시킴

### DIFF
--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -8,7 +8,7 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
-import java.time.Instant;
+import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -31,6 +32,7 @@ public class ProfanityAuditService {
     private final ProfanityWordManagementService profanityWordManagementService;
     private final NicknameAuditProperties properties;
     private final MeterRegistry meterRegistry;
+    private final Clock clock;
 
     private final AtomicLong unauditedQueueDepth = new AtomicLong(0);
 
@@ -59,6 +61,13 @@ public class ProfanityAuditService {
         return auditRepository.findByStatus(status, pageable);
     }
 
+    /**
+     * 트랜잭션을 요구한다. {@code insertUnaudited}가 {@code @Modifying} 네이티브 쿼리라
+     * 주변 트랜잭션이 없으면 {@code TransactionRequiredException}으로 실패한다 —
+     * {@code save()}가 리포지토리 자체 트랜잭션으로 동작하던 것과 달라진 지점이다.
+     * ({@code OutboxEventRecorder.record()}와 같은 이유로 REQUIRED를 명시한다)
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
     public void register(String nickname) {
         if (profanityWordManagementService.isOperatorAllowed(nickname)) {
             log.debug("운영자 허용 닉네임 — 검열 등록 생략: {}", nickname);
@@ -74,7 +83,7 @@ public class ProfanityAuditService {
         // save가 아니라 충돌 무시 INSERT다. 위 조회를 통과한 동시 등록 둘이 겹치면 유니크 제약에
         // 걸리는데, 이제 호출자(닉네임 변경·룰렛 결과 저장) 트랜잭션 안이라 예외가 나면 그쪽까지
         // 롤백된다. 충돌은 "이미 큐에 있다"는 뜻이라 무시해도 손실이 없다.
-        auditRepository.insertUnaudited(nickname, Instant.now());
+        auditRepository.insertUnaudited(nickname, clock.instant());
     }
 
     public void auditPending() {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/ProfanityAuditService.java
@@ -8,19 +8,18 @@ import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -42,8 +41,15 @@ public class ProfanityAuditService {
                 .register(meterRegistry);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    /**
+     * 닉네임 저장 트랜잭션에 참여해 검열 대기 행을 함께 커밋한다 (트랜잭셔널 아웃박스, #1618).
+     * <p>
+     * AFTER_COMMIT + REQUIRES_NEW였을 때는 닉네임이 커밋된 뒤 별개 트랜잭션으로 큐에 적재해서,
+     * 그 사이 인스턴스가 죽으면 해당 닉네임이 검열 큐에 영영 들어가지 않았다. 미검열 닉네임을
+     * 다시 주워담는 복구 스윕도 없어 유실이 곧 영구 누락이었다.
+     */
+    @EventListener
+    @Transactional
     public void onNicknameSubmitted(NicknameSubmittedEvent event) {
         log.debug("닉네임 검열 등록 요청 수신: {}", event.nickname());
         register(event.nickname());
@@ -65,7 +71,10 @@ public class ProfanityAuditService {
             log.debug("이미 등록된 닉네임 — 검열 등록 생략: {}", nickname);
             return;
         }
-        auditRepository.save(new NicknameAudit(nickname));
+        // save가 아니라 충돌 무시 INSERT다. 위 조회를 통과한 동시 등록 둘이 겹치면 유니크 제약에
+        // 걸리는데, 이제 호출자(닉네임 변경·룰렛 결과 저장) 트랜잭션 안이라 예외가 나면 그쪽까지
+        // 롤백된다. 충돌은 "이미 큐에 있다"는 뜻이라 무시해도 손실이 없다.
+        auditRepository.insertUnaudited(nickname, Instant.now());
     }
 
     public void auditPending() {

--- a/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/application/port/NicknameAuditRepository.java
@@ -2,6 +2,7 @@ package coffeeshout.profanity.application.port;
 
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 public interface NicknameAuditRepository {
 
     NicknameAudit save(NicknameAudit entity);
+
+    void insertUnaudited(String nickname, Instant createdAt);
 
     List<NicknameAudit> saveAll(Iterable<NicknameAudit> entities);
 

--- a/backend/profanity/src/main/java/coffeeshout/profanity/infra/persistence/audit/NicknameAuditJpaRepository.java
+++ b/backend/profanity/src/main/java/coffeeshout/profanity/infra/persistence/audit/NicknameAuditJpaRepository.java
@@ -3,13 +3,22 @@ package coffeeshout.profanity.infra.persistence.audit;
 import coffeeshout.profanity.application.port.NicknameAuditRepository;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Set;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
 public interface NicknameAuditJpaRepository extends Repository<NicknameAudit, Long>, NicknameAuditRepository {
+
+    @Override
+    @Modifying
+    @Query(value = "INSERT INTO player_name_audit (player_name, status, created_at) "
+            + "VALUES (:nickname, 'UNAUDITED', :createdAt) "
+            + "ON DUPLICATE KEY UPDATE id = id", nativeQuery = true)
+    void insertUnaudited(@Param("nickname") String nickname, @Param("createdAt") Instant createdAt);
 
     @Override
     @Query("SELECT DISTINCT n.nickname FROM NicknameAudit n WHERE n.status = :status")

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
@@ -33,15 +33,20 @@ class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
     private NicknameAuditJpaRepository auditRepository;
 
     @Autowired
+    private ProfanityAuditService service;
+
+    @Autowired
     private TransactionTemplate transactionTemplate;
 
     @Test
-    void 닉네임_저장_트랜잭션이_커밋되면_검열_대기_행도_함께_커밋된다() {
-        transactionTemplate.executeWithoutResult(status ->
-                eventPublisher.publishEvent(new NicknameSubmittedEvent("커밋닉네임")));
+    void 트랜잭션_없는_호출자도_검열_등록에_성공한다() {
+        // insertUnaudited는 @Modifying 네이티브 쿼리라 주변 트랜잭션이 없으면 TransactionRequiredException이다.
+        // save()는 리포지토리 자체 트랜잭션으로 동작했으므로, register()가 스스로 트랜잭션을 열지 않으면
+        // 어드민·초기화 코드처럼 트랜잭션 밖에서 부르는 호출자가 조용히 깨진다.
+        assertThatCode(() -> service.register("비트랜잭션")).doesNotThrowAnyException();
 
         assertThat(auditRepository.findNicknamesByStatus(NicknameAuditStatus.UNAUDITED))
-                .containsOnly("커밋닉네임");
+                .containsOnly("비트랜잭션");
     }
 
     @Test
@@ -62,11 +67,12 @@ class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
-    void 같은_닉네임이_동시에_등록돼도_유니크_충돌이_호출자_트랜잭션을_깨뜨리지_않는다() {
-        // 서로 다른 트랜잭션 둘이 조회 가드(existsByNickname)를 모두 통과한 뒤 같은 행을 INSERT하는
+    void 서로_다른_트랜잭션이_같은_닉네임을_동시에_등록해도_INSERT가_예외를_던지지_않는다() {
+        // 조회 가드(existsByNickname)를 둘 다 통과한 뒤 서로 다른 트랜잭션이 같은 행을 INSERT하는
         // 상황이다 — 방 참가 닉네임은 전역 유니크가 아니라 서로 다른 방에서 같은 이름이 동시에
         // 당첨될 수 있다. 예전 save()였다면 늦게 커밋하는 쪽이 uq_player_name_audit_name_status에
-        // 걸려, 이제 같은 트랜잭션을 쓰는 호출자(룰렛 결과 저장)까지 함께 롤백됐다.
+        // 걸리고, 이제 검열 등록이 호출자 트랜잭션 안이라 룰렛 결과 저장까지 함께 롤백됐다.
+        // 여기서 검증하는 건 그 예외가 애초에 발생하지 않는다는 것이다.
         //
         // 가드 통과를 래치로 맞춰야 의미가 있다. 한쪽이 먼저 커밋해버리면 다른 쪽 가드가 그 행을
         // 보고 INSERT를 건너뛰어 충돌 자체가 일어나지 않는다.
@@ -74,7 +80,12 @@ class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             final Runnable register = () -> transactionTemplate.executeWithoutResult(status -> {
-                assertThat(auditRepository.existsByNickname("동시닉네임")).isFalse();
+                try {
+                    assertThat(auditRepository.existsByNickname("동시닉네임")).isFalse();
+                } finally {
+                    // 단언이 실패해도 반대 스레드를 래치에서 굶기지 않는다.
+                    guardPassed.countDown();
+                }
                 awaitBothGuardsPassed(guardPassed);
                 auditRepository.insertUnaudited("동시닉네임", Instant.now());
             });
@@ -92,7 +103,6 @@ class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
 
     private void awaitBothGuardsPassed(CountDownLatch guardPassed) {
         try {
-            guardPassed.countDown();
             if (!guardPassed.await(10, TimeUnit.SECONDS)) {
                 throw new IllegalStateException("두 트랜잭션이 모두 조회 가드를 통과하지 못했습니다");
             }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
@@ -1,0 +1,71 @@
+package coffeeshout.profanity.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coffeeshout.global.nickname.NicknameSubmittedEvent;
+import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
+import coffeeshout.profanity.infra.persistence.audit.NicknameAuditJpaRepository;
+import coffeeshout.support.IntegrationTestSupport;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 닉네임 검열 등록이 닉네임 저장 트랜잭션에 참여하는지 검증한다 (트랜잭셔널 아웃박스, #1618).
+ *
+ * <p>비트랜잭션 베이스({@link IntegrationTestSupport})를 상속해 실제 commit·rollback 경계에서
+ * 확인한다. @Transactional 롤백 베이스에서는 트랜잭션 참여 여부 자체를 구분할 수 없다.
+ */
+class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private NicknameAuditJpaRepository auditRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Test
+    void 닉네임_저장_트랜잭션이_커밋되면_검열_대기_행도_함께_커밋된다() {
+        transactionTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(new NicknameSubmittedEvent("커밋닉네임")));
+
+        assertThat(auditRepository.findNicknamesByStatus(NicknameAuditStatus.UNAUDITED))
+                .containsOnly("커밋닉네임");
+    }
+
+    @Test
+    void 검열_등록은_커밋_이후가_아니라_같은_트랜잭션_안에서_이뤄진다() {
+        transactionTemplate.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(new NicknameSubmittedEvent("동일트랜잭션"));
+
+            // 유실 창의 정체가 여기다. AFTER_COMMIT 리스너였다면 이 시점엔 아직 등록되지 않았고,
+            // 커밋과 등록 사이에 인스턴스가 죽으면 그 닉네임은 검열 큐에 영영 들어가지 않았다.
+            assertThat(auditRepository.findNicknamesByStatus(NicknameAuditStatus.UNAUDITED))
+                    .containsOnly("동일트랜잭션");
+
+            status.setRollbackOnly();
+        });
+
+        // 같은 트랜잭션이므로 비즈니스 롤백이 검열 등록까지 되돌린다.
+        assertThat(auditRepository.findNicknamesByStatus(NicknameAuditStatus.UNAUDITED)).isEmpty();
+    }
+
+    @Test
+    void 같은_닉네임이_동시에_등록돼도_유니크_충돌이_호출자_트랜잭션을_깨뜨리지_않는다() {
+        // 조회 가드(existsByNickname)를 둘 다 통과한 동시 등록 상황. 예전 save()였다면 두 번째
+        // INSERT가 uq_player_name_audit_name_status에 걸려, 이제 같은 트랜잭션을 쓰는 호출자
+        // (닉네임 변경·룰렛 결과 저장)까지 함께 롤백됐다.
+        assertThatCode(() -> transactionTemplate.executeWithoutResult(status -> {
+            auditRepository.insertUnaudited("동시닉네임", Instant.now());
+            auditRepository.insertUnaudited("동시닉네임", Instant.now());
+        })).doesNotThrowAnyException();
+
+        assertThat(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED)).isEqualTo(1);
+    }
+}

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditRegistrationIntegrationTest.java
@@ -8,6 +8,11 @@ import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.infra.persistence.audit.NicknameAuditJpaRepository;
 import coffeeshout.support.IntegrationTestSupport;
 import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
@@ -58,14 +63,42 @@ class ProfanityAuditRegistrationIntegrationTest extends IntegrationTestSupport {
 
     @Test
     void 같은_닉네임이_동시에_등록돼도_유니크_충돌이_호출자_트랜잭션을_깨뜨리지_않는다() {
-        // 조회 가드(existsByNickname)를 둘 다 통과한 동시 등록 상황. 예전 save()였다면 두 번째
-        // INSERT가 uq_player_name_audit_name_status에 걸려, 이제 같은 트랜잭션을 쓰는 호출자
-        // (닉네임 변경·룰렛 결과 저장)까지 함께 롤백됐다.
-        assertThatCode(() -> transactionTemplate.executeWithoutResult(status -> {
-            auditRepository.insertUnaudited("동시닉네임", Instant.now());
-            auditRepository.insertUnaudited("동시닉네임", Instant.now());
-        })).doesNotThrowAnyException();
+        // 서로 다른 트랜잭션 둘이 조회 가드(existsByNickname)를 모두 통과한 뒤 같은 행을 INSERT하는
+        // 상황이다 — 방 참가 닉네임은 전역 유니크가 아니라 서로 다른 방에서 같은 이름이 동시에
+        // 당첨될 수 있다. 예전 save()였다면 늦게 커밋하는 쪽이 uq_player_name_audit_name_status에
+        // 걸려, 이제 같은 트랜잭션을 쓰는 호출자(룰렛 결과 저장)까지 함께 롤백됐다.
+        //
+        // 가드 통과를 래치로 맞춰야 의미가 있다. 한쪽이 먼저 커밋해버리면 다른 쪽 가드가 그 행을
+        // 보고 INSERT를 건너뛰어 충돌 자체가 일어나지 않는다.
+        final CountDownLatch guardPassed = new CountDownLatch(2);
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            final Runnable register = () -> transactionTemplate.executeWithoutResult(status -> {
+                assertThat(auditRepository.existsByNickname("동시닉네임")).isFalse();
+                awaitBothGuardsPassed(guardPassed);
+                auditRepository.insertUnaudited("동시닉네임", Instant.now());
+            });
+            final Future<?> first = executor.submit(register);
+            final Future<?> second = executor.submit(register);
+
+            assertThatCode(() -> first.get(10, TimeUnit.SECONDS)).doesNotThrowAnyException();
+            assertThatCode(() -> second.get(10, TimeUnit.SECONDS)).doesNotThrowAnyException();
+        } finally {
+            executor.shutdownNow();
+        }
 
         assertThat(auditRepository.countByStatusAndAuditedAtIsNull(NicknameAuditStatus.UNAUDITED)).isEqualTo(1);
+    }
+
+    private void awaitBothGuardsPassed(CountDownLatch guardPassed) {
+        try {
+            guardPassed.countDown();
+            if (!guardPassed.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("두 트랜잭션이 모두 조회 가드를 통과하지 못했습니다");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -1,6 +1,7 @@
 package coffeeshout.profanity.application;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -11,6 +12,7 @@ import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -47,7 +49,7 @@ class ProfanityAuditServiceTest {
 
             service.register("새닉네임");
 
-            then(auditRepository).should().save(any(NicknameAudit.class));
+            then(auditRepository).should().insertUnaudited(eq("새닉네임"), any(Instant.class));
         }
 
         @Test
@@ -60,7 +62,7 @@ class ProfanityAuditServiceTest {
 
             service.register("이미검열된닉네임");
 
-            then(auditRepository).should(never()).save(any());
+            then(auditRepository).should(never()).insertUnaudited(any(), any());
         }
 
         @Test
@@ -70,7 +72,7 @@ class ProfanityAuditServiceTest {
 
             service.register("허용닉네임");
 
-            then(auditRepository).should(never()).save(any());
+            then(auditRepository).should(never()).insertUnaudited(any(), any());
         }
     }
 

--- a/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
+++ b/backend/profanity/src/test/java/coffeeshout/profanity/application/ProfanityAuditServiceTest.java
@@ -12,6 +12,7 @@ import coffeeshout.profanity.config.NicknameAuditProperties;
 import coffeeshout.profanity.domain.audit.NicknameAuditStatus;
 import coffeeshout.profanity.domain.audit.NicknameAudit;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,8 @@ class ProfanityAuditServiceTest {
         final NicknameAuditProperties properties = new NicknameAuditProperties(
                 "api-key", "gemini-2.0-flash", 0.8, 10, 5, 2
         );
-        service = new ProfanityAuditService(auditRepository, batchProcessor, profanityWordManagementService, properties, new SimpleMeterRegistry());
+        service = new ProfanityAuditService(auditRepository, batchProcessor, profanityWordManagementService, properties,
+                new SimpleMeterRegistry(), Clock.systemDefaultZone());
         service.initMetrics();
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1618

# 🚀 작업 내용

1. **검열 등록을 닉네임 저장과 같은 트랜잭션에서 처리** (`ProfanityAuditService`)
   기존에는 닉네임이 DB에 저장되고 **커밋된 뒤에** 별도 트랜잭션으로 검열 대기 행(`player_name_audit`)을 넣었습니다(`@TransactionalEventListener(AFTER_COMMIT)` + `REQUIRES_NEW`). 그 사이에 서버가 죽으면 닉네임만 저장되고 검열 대기열에는 안 들어갑니다. 빠진 닉네임을 나중에 다시 주워담는 장치도 없어서 그대로 영구 누락입니다. `@EventListener` + `@Transactional`로 바꿔 닉네임과 검열 대기 행이 **함께 커밋되거나 함께 취소**되도록 했습니다.

2. **중복 등록 시 예외 대신 무시하는 INSERT로 교체** (`NicknameAuditJpaRepository`, `NicknameAuditRepository`)
   `save()` 대신 `ON DUPLICATE KEY UPDATE id = id` 네이티브 INSERT(`insertUnaudited`)를 씁니다. 같은 트랜잭션을 쓰게 됐으니, 중복으로 예외가 나면 닉네임 변경이나 룰렛 결과 저장까지 같이 취소되기 때문입니다.

3. **`register()`에 트랜잭션 요구를 명시** (코드 리뷰 반영)
   `@Modifying` 네이티브 쿼리는 주변 트랜잭션이 없으면 실패합니다(`TransactionRequiredException`). 기존 `save()`는 Spring Data 리포지토리가 자체 트랜잭션을 열어줘서 트랜잭션 밖에서도 동작했기 때문에, 2번 변경만으로는 `register()`가 그 성질을 조용히 잃습니다. 지금은 유일한 호출자가 트랜잭션 안이라 안 터지지만, 어드민이나 초기화 코드가 다음에 부르면 바로 실패합니다. `@Transactional(REQUIRED)`를 명시하고 이를 고정하는 테스트를 넣었습니다.

4. **등록 시각을 `Clock` 주입으로 변경** (코드 리뷰 반영)
   `Instant.now()`가 이전에는 `NicknameAudit` 생성자 안에 숨어 있었는데, 포트가 `createdAt`을 받게 되면서 서비스 본문에 드러났습니다. 프로젝트 컨벤션(시간 같은 외부 의존은 주입)에 맞춰 `Clock`으로 바꿨습니다.

5. **테스트**
   - `ProfanityAuditRegistrationIntegrationTest` 신규 3건: 트랜잭션 참여 판별, 트랜잭션 없는 호출자 보호, 동시 등록 시 충돌 무해화
   - `ProfanityAuditServiceTest` 3건은 `insertUnaudited` 검증으로 수정

# 💬 리뷰 중점사항

**실제 장애가 난 적은 없습니다.** 코드를 보다 발견한 잠재 위험이고, 이미 저장소에 트랜잭셔널 아웃박스 구현(`global/outbox`)이 있는데 검열 등록만 반쪽 형태로 남아 있어 형태를 맞췄습니다. 검열이 12시간 배치 + AI 호출이라 급한 작업은 아닙니다.

> 용어 주의: 여기서 말하는 "아웃박스"는 `OutboxEventRecorder` 인프라를 가져다 쓴 게 아니라 **철학만 차용**한 것입니다. 이 변경은 `outbox_event` 테이블을 거치지 않고 `player_name_audit`에 직접 씁니다.

**"검열 등록이 실패하면 닉네임 변경까지 취소되는 게 맞나?"** — 이번 설계의 핵심 논점이었습니다. 결론은 "같은 트랜잭션에 넣되, 취소를 부를 수 있는 유일한 경우를 없앤다"입니다.
- 같은 DB에 같은 트랜잭션으로 넣는 INSERT라, 중복 키 말고는 실패 조건이 닉네임 UPDATE 자체와 똑같습니다. "검열 등록만 실패" 상황이 사실상 없습니다.
- 남는 위험은 중복 키 하나인데, 이게 특히 위험한 곳이 `RouletteService.saveRouletteResult`입니다. 방 참가 닉네임은 전체 유일하지 않아서 서로 다른 방에서 같은 이름이 동시에 당첨될 수 있고, 여기서 예외가 나면 **룰렛 결과 저장이 통째로 취소**됩니다.
- 그런데 이 충돌은 "이미 대기열에 있다"는 뜻이라 무시해도 잃는 정보가 없습니다. 그래서 예외 자체를 안 만드는 방향(`ON DUPLICATE KEY`)을 택했습니다.
- 값 잘림 같은 다른 실패 요인은 `PlayerName`·`UserNickname`의 길이 상한 10자가 `player_name VARCHAR(10)`와 일치해 두 경로 모두 막혀 있습니다. 남는 건 DB 자체 장애뿐이고, 그 경우 호출자도 어차피 커밋에 실패합니다.

**새로 생긴 결합 한 가지**: 검열 등록 INSERT가 커밋까지 락을 잡으므로, 같은 닉네임에 대해 룰렛 결과 저장과 닉네임 변경이 서로를 잠깐 기다릴 수 있습니다. 별도 트랜잭션으로 즉시 커밋되던 예전엔 없던 결합입니다. 두 트랜잭션 모두 짧아 실질 위험은 낮다고 봤지만, 리뷰 때 봐주시면 좋겠습니다.

**`INSERT IGNORE`를 안 쓴 이유**: 중복 키뿐 아니라 값 잘림 같은 무관한 오류까지 경고로 삼켜버립니다. `ON DUPLICATE KEY UPDATE`는 중복 키만 무해하게 넘깁니다.

**앱 코드의 `existsByNickname` 검사는 남겼습니다.** `ON DUPLICATE KEY`가 삼키는 충돌은 `(닉네임, UNAUDITED)` 하나뿐입니다. 이미 `CLEAN`인 닉네임에 새 `UNAUDITED` 행이 들어가는 경우는 유니크 키가 `(player_name, status)`라 충돌하지 않고 그냥 삽입되는데, 이게 바로 V38 마이그레이션이 청소한 사고 데이터입니다(같은 닉네임이 CLEAN과 UNAUDITED로 공존 → 배치가 승격하려다 충돌 → 대기열 영구 적체, #1467). 앱 검사는 규칙, DB 제약은 동시성을 맡는 분업입니다.

**MySQL 전용 문법**입니다. 통합 테스트가 TestContainers MySQL이고 H2 의존이 없어 검증에 문제 없습니다.

**SQL에 `'UNAUDITED'` 문자열이 박혀 있는 건 의도한 선택입니다.** `status` 컬럼이 `ENUM('UNAUDITED', 'FLAGGED', ...)`라 자바 상수를 리네임하면 `@Enumerated(STRING)` 매핑이 즉시 DB ENUM 제약에 걸려 요란하게 실패합니다 — 조용히 깨지는 경로가 아니고, 애초에 리네임하려면 `MODIFY COLUMN` 마이그레이션이 필수입니다.

## 테스트가 헛돌지 않는지 확인했습니다

세 테스트 모두 대상 코드를 되돌리면 실패하는 것을 확인했습니다.

| 테스트 | 되돌린 것 | 결과 |
| --- | --- | --- |
| `검열_등록은_커밋_이후가_아니라_같은_트랜잭션_안에서_이뤄진다` | `@TransactionalEventListener(AFTER_COMMIT)` + `REQUIRES_NEW` | FAILED |
| `서로_다른_트랜잭션이_같은_닉네임을_동시에_등록해도_INSERT가_예외를_던지지_않는다` | `ON DUPLICATE KEY UPDATE` 제거 | FAILED |
| `트랜잭션_없는_호출자도_검열_등록에_성공한다` | `register()`의 `@Transactional` 제거 | FAILED |

동시성 테스트는 스레드 둘이 각자 트랜잭션을 열어 조회 가드를 통과한 뒤 `CountDownLatch` 배리어로 서로를 기다렸다가 INSERT합니다. 배리어가 없으면 한쪽이 먼저 커밋해버려 다른 쪽 가드가 INSERT를 건너뛰고, 충돌 자체가 일어나지 않아 테스트가 무의미해집니다.

검증: `:profanity` `:admin` `:user` `:room` 모듈 테스트 전량 통과.
