### PR TITLE
[chore] nginx proxy_pass의 XFF 헤더 누락 방지 CI 체크 + IpBlockFilter 주석 정정

### DIFF
--- a/.github/scripts/check-nginx-proxy-headers.py
+++ b/.github/scripts/check-nginx-proxy-headers.py
@@ -1,57 +1,88 @@
 #!/usr/bin/env python3
-"""nginx location 블록의 프록시 헤더 include 검사 — XFF 신뢰 사슬이 끊기는 것을 막는다.
+"""nginx 프록시 헤더 검사 — X-Forwarded-For 신뢰 사슬이 끊기는 것을 막는다.
 
 배경(#1620): 앱의 내부 IP 화이트리스트(IpBlockFilter)가 X-Forwarded-For 스푸핑에 뚫리지 않는
 이유는 필터 코드가 아니라 nginx + Tomcat RemoteIpValve 조합에 있다.
 
   1. nginx가 `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`로
      실제 TCP peer($remote_addr)를 XFF 맨 뒤에 덧붙인다 (proxy-http.inc·proxy-ws.inc).
-  2. RemoteIpValve가 XFF를 오른쪽부터 훑으며 internalProxies(RFC1918)만 벗겨내고
-     첫 비내부 IP에서 멈춘다 → 클라이언트가 왼쪽에 주입한 값은 도달하지 못한다.
+  2. RemoteIpValve가 XFF를 오른쪽부터 훑으며 internal-proxies에 해당하는 항목만 벗겨내고
+     첫 비내부 IP에서 멈춘다 → 공인 IP에서 온 요청이라면 클라이언트가 왼쪽에 주입한 값은
+     그 지점을 넘지 못한다.
 
-이 사슬은 1번이 있어야만 성립한다. include 없이 proxy_pass 하는 location이 생기면 클라이언트가
-보낸 XFF가 그대로 앱에 전달되고, 항목이 전부 사설 IP면 RemoteIpValve가 끝까지 벗겨내
+이 사슬은 1번이 있어야만 성립한다. XFF를 세팅하지 않는 proxy_pass가 생기면 클라이언트가 보낸
+XFF가 그대로 앱에 전달되고, 항목이 전부 사설 IP면 RemoteIpValve가 끝까지 벗겨내
 **공격자가 넣은 사설 IP가 getRemoteAddr()가 되어 화이트리스트를 통과**한다.
 
 가드가 조용히 사라지는 사고는 이미 한 번 겪었다(postmortem 0003 — 병렬 PR 머지로 화이트리스트
-유실). 사람 리뷰로 지키는 불변조건은 신뢰하지 않고 CI로 고정한다.
+유실). ADR-0023이 기록한 엣지 설정 회귀도 정확히 이 줄이었다(`X-Forwarded-For $remote_addr`로
+덮어써 체인이 끊김). 사람 리뷰로 지키는 불변조건은 신뢰하지 않고 CI로 고정한다.
 
 검사 규칙
-  - proxy_pass가 있는 블록은 자신 또는 상위 블록에서 proxy-http.inc / proxy-ws.inc를
-    include해야 한다 (nginx의 proxy_set_header는 상위 컨텍스트에서 상속된다).
+  1. proxy-http.inc·proxy-ws.inc는 `X-Forwarded-For $proxy_add_x_forwarded_for`를 세팅해야 한다.
+     `$remote_addr`·`$http_x_forwarded_for`로 덮어쓰면 include가 있어도 사슬이 끊긴다.
+  2. proxy_pass가 있는 블록은 XFF를 세팅해야 한다 — proxy-*.inc include 또는 위 지시자 직접 선언.
+     nginx는 **현재 레벨에 proxy_set_header가 하나라도 있으면 상위 레벨 값을 전부 버리므로**,
+     상위 블록의 include는 하위 블록이 자체 proxy_set_header를 선언하지 않은 경우에만 인정한다.
 
 예외 표기
-  proxy_pass와 같은 줄 또는 바로 윗줄에 `# proxy-header-exempt: <사유>` 주석을 두면
+  proxy_pass와 같은 줄 또는 바로 윗줄 **주석**에 `# proxy-header-exempt: <사유>`를 두면
   그 proxy_pass 하나를 건너뛴다. 사유를 반드시 적게 해서 예외가 조용히 늘어나지 않게 한다.
+
+한계
+  정규식 + 중괄호 깊이로만 파싱한다. 따옴표 리터럴은 비워서 그 안의 `#`·중괄호를 배제하지만,
+  따옴표 없는 정규식 location(`location ~ ^/v\\d{1,2}/`)의 중괄호는 그대로 세므로 균형이
+  맞지 않으면 블록 스코프가 어긋난다. 저장소의 설정은 모두 균형이 맞아 현재는 문제되지 않는다.
 """
 import re
 import sys
 from pathlib import Path
 
-PROXY_PASS = re.compile(r"^\s*proxy_pass\s")
-PROXY_INCLUDE = re.compile(r"^\s*include\s+\S*proxy-(http|ws)\.inc\s*;")
+PROXY_PASS = re.compile(r"(?:^|[;{])\s*proxy_pass\s")
+PROXY_INCLUDE = re.compile(r"(?:^|[;{])\s*include\s+\S*proxy-(?:http|ws)\.inc\s*;")
+SET_HEADER = re.compile(r"(?:^|[;{])\s*proxy_set_header\s")
+XFF_CHAIN = re.compile(r"proxy_set_header\s+X-Forwarded-For\s+\$proxy_add_x_forwarded_for\s*;")
 EXEMPT_MARKER = re.compile(r"#\s*proxy-header-exempt:\s*(.+)")
+QUOTED = re.compile(r"\"[^\"]*\"|'[^']*'")
 
+HEADER_INCLUDES = ("proxy-http.inc", "proxy-ws.inc")
 ROOT_BLOCK = 0
 
 
-def check_file(path):
+def check_include_content(path):
+    """규칙 1 — 프록시 헤더 include 자체가 XFF 체인을 누적하는지 확인한다."""
+    if path.name not in HEADER_INCLUDES or XFF_CHAIN.search(path.read_text(encoding="utf-8")):
+        return []
+    return [
+        f"{path} — `X-Forwarded-For $proxy_add_x_forwarded_for` 설정이 없다. "
+        f"$remote_addr / $http_x_forwarded_for로 덮어쓰면 클라이언트가 보낸 XFF가 살아남아 "
+        f"실제 접속 IP가 유실된다."
+    ]
+
+
+def check_proxy_pass(path):
+    """규칙 2 — proxy_pass가 있는 블록이 XFF를 세팅하는지(상속 포함) 확인한다."""
     parent = {ROOT_BLOCK: None}  # 블록 id -> 상위 블록 id
-    includes = set()  # 프록시 헤더를 include하는 블록 id
+    sets_xff = set()  # XFF를 세팅하는 블록 id
+    sets_headers = set()  # proxy_set_header를 선언해 상위 상속을 끊는 블록 id
     proxy_passes = []  # (블록 id, 줄번호, 예외 사유 or None)
     stack = [ROOT_BLOCK]
     next_id = ROOT_BLOCK + 1
     previous_exempt = None
 
     for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        marker = EXEMPT_MARKER.search(raw)
+        # 리터럴 내용을 비운 뒤 주석을 분리한다. 따옴표 안의 #·중괄호가 주석 시작이나
+        # 블록 경계로 오인되는 것을 막는다.
+        line, hash_sign, comment = QUOTED.sub('""', raw).partition("#")
+        marker = EXEMPT_MARKER.search(hash_sign + comment) if hash_sign else None
         exempt = marker.group(1).strip() if marker else None
-        line = raw.split("#", 1)[0]
 
         if PROXY_PASS.search(line):
             proxy_passes.append((stack[-1], lineno, exempt or previous_exempt))
-        elif PROXY_INCLUDE.search(line):
-            includes.add(stack[-1])
+        if PROXY_INCLUDE.search(line) or XFF_CHAIN.search(line):
+            sets_xff.add(stack[-1])
+        elif SET_HEADER.search(line):
+            sets_headers.add(stack[-1])
 
         # 여는 중괄호는 블록 선언과 같은 줄에 온다(nginx 관례)이므로 위 검사 뒤에 처리한다
         for char in line:
@@ -66,23 +97,29 @@ def check_file(path):
 
     errors = []
     for block, lineno, exempt in proxy_passes:
-        if has_proxy_headers(block, parent, includes):
+        if has_xff(block, parent, sets_xff, sets_headers):
             continue
         if exempt:
             print(f"  건너뜀 {path}:{lineno} — 예외 사유: {exempt}")
             continue
         errors.append(
-            f"{path}:{lineno} — proxy_pass가 있으나 proxy-http.inc / proxy-ws.inc "
-            f"include가 없다. XFF가 클라이언트 값 그대로 앱에 전달된다."
+            f"{path}:{lineno} — proxy_pass가 있으나 X-Forwarded-For를 세팅하지 않는다. "
+            f"클라이언트가 보낸 XFF가 그대로 앱에 전달된다."
         )
     return errors
 
 
-def has_proxy_headers(block, parent, includes):
-    """자신 또는 상위 블록에 프록시 헤더 include가 있는지 확인한다."""
+def has_xff(block, parent, sets_xff, sets_headers):
+    """자신 또는 상속되는 상위 블록이 XFF를 세팅하는지 확인한다.
+
+    nginx는 현재 레벨에 proxy_set_header가 있으면 상위 레벨 설정을 **대체**한다(누적 아님).
+    따라서 자체 헤더를 선언한 블록에서 상위 탐색을 멈춘다.
+    """
     while block is not None:
-        if block in includes:
+        if block in sets_xff:
             return True
+        if block in sets_headers:  # 자체 헤더 선언 → 상위 상속이 끊긴다
+            return False
         block = parent[block]
     return False
 
@@ -92,7 +129,7 @@ def main(paths):
         file
         for target in (Path(p) for p in paths)
         for file in (
-            [f for pattern in ("*.conf", "*.inc") for f in target.glob(pattern)]
+            [f for pattern in ("*.conf", "*.inc") for f in target.rglob(pattern)]
             if target.is_dir()
             else [target]
         )
@@ -101,15 +138,21 @@ def main(paths):
         print(f"검사 대상 파일이 없다: {paths}", file=sys.stderr)
         return 1
 
-    errors = [error for file in files for error in check_file(file)]
+    errors = [
+        error
+        for file in files
+        for error in check_include_content(file) + check_proxy_pass(file)
+    ]
     if errors:
-        print(f"\n프록시 헤더 include 누락 {len(errors)}건:\n", file=sys.stderr)
+        print(f"\nX-Forwarded-For 사슬 결함 {len(errors)}건:\n", file=sys.stderr)
         for error in errors:
             print(f"  ✗ {error}", file=sys.stderr)
         print(
             "\nproxy_pass 하는 location에는 다음 중 하나를 include한다:\n"
             "  include /etc/nginx/conf.d/proxy-http.inc;   # HTTP\n"
             "  include /etc/nginx/conf.d/proxy-ws.inc;     # WebSocket\n"
+            "상위 블록의 include에 기대는 경우, 그 하위 블록은 자체 proxy_set_header를 선언하면 안 된다\n"
+            "(nginx는 현재 레벨 설정이 있으면 상위 레벨을 통째로 버린다).\n"
             "의도적 예외라면 proxy_pass 위에 `# proxy-header-exempt: <사유>` 주석을 단다.",
             file=sys.stderr,
         )

--- a/.github/scripts/check-nginx-proxy-headers.py
+++ b/.github/scripts/check-nginx-proxy-headers.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""nginx location 블록의 프록시 헤더 include 검사 — XFF 신뢰 사슬이 끊기는 것을 막는다.
+
+배경(#1620): 앱의 내부 IP 화이트리스트(IpBlockFilter)가 X-Forwarded-For 스푸핑에 뚫리지 않는
+이유는 필터 코드가 아니라 nginx + Tomcat RemoteIpValve 조합에 있다.
+
+  1. nginx가 `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for`로
+     실제 TCP peer($remote_addr)를 XFF 맨 뒤에 덧붙인다 (proxy-http.inc·proxy-ws.inc).
+  2. RemoteIpValve가 XFF를 오른쪽부터 훑으며 internalProxies(RFC1918)만 벗겨내고
+     첫 비내부 IP에서 멈춘다 → 클라이언트가 왼쪽에 주입한 값은 도달하지 못한다.
+
+이 사슬은 1번이 있어야만 성립한다. include 없이 proxy_pass 하는 location이 생기면 클라이언트가
+보낸 XFF가 그대로 앱에 전달되고, 항목이 전부 사설 IP면 RemoteIpValve가 끝까지 벗겨내
+**공격자가 넣은 사설 IP가 getRemoteAddr()가 되어 화이트리스트를 통과**한다.
+
+가드가 조용히 사라지는 사고는 이미 한 번 겪었다(postmortem 0003 — 병렬 PR 머지로 화이트리스트
+유실). 사람 리뷰로 지키는 불변조건은 신뢰하지 않고 CI로 고정한다.
+
+검사 규칙
+  - proxy_pass가 있는 블록은 자신 또는 상위 블록에서 proxy-http.inc / proxy-ws.inc를
+    include해야 한다 (nginx의 proxy_set_header는 상위 컨텍스트에서 상속된다).
+
+예외 표기
+  proxy_pass와 같은 줄 또는 바로 윗줄에 `# proxy-header-exempt: <사유>` 주석을 두면
+  그 proxy_pass 하나를 건너뛴다. 사유를 반드시 적게 해서 예외가 조용히 늘어나지 않게 한다.
+"""
+import re
+import sys
+from pathlib import Path
+
+PROXY_PASS = re.compile(r"^\s*proxy_pass\s")
+PROXY_INCLUDE = re.compile(r"^\s*include\s+\S*proxy-(http|ws)\.inc\s*;")
+EXEMPT_MARKER = re.compile(r"#\s*proxy-header-exempt:\s*(.+)")
+
+ROOT_BLOCK = 0
+
+
+def check_file(path):
+    parent = {ROOT_BLOCK: None}  # 블록 id -> 상위 블록 id
+    includes = set()  # 프록시 헤더를 include하는 블록 id
+    proxy_passes = []  # (블록 id, 줄번호, 예외 사유 or None)
+    stack = [ROOT_BLOCK]
+    next_id = ROOT_BLOCK + 1
+    previous_exempt = None
+
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        marker = EXEMPT_MARKER.search(raw)
+        exempt = marker.group(1).strip() if marker else None
+        line = raw.split("#", 1)[0]
+
+        if PROXY_PASS.search(line):
+            proxy_passes.append((stack[-1], lineno, exempt or previous_exempt))
+        elif PROXY_INCLUDE.search(line):
+            includes.add(stack[-1])
+
+        # 여는 중괄호는 블록 선언과 같은 줄에 온다(nginx 관례)이므로 위 검사 뒤에 처리한다
+        for char in line:
+            if char == "{":
+                parent[next_id] = stack[-1]
+                stack.append(next_id)
+                next_id += 1
+            elif char == "}" and len(stack) > 1:
+                stack.pop()
+
+        previous_exempt = exempt
+
+    errors = []
+    for block, lineno, exempt in proxy_passes:
+        if has_proxy_headers(block, parent, includes):
+            continue
+        if exempt:
+            print(f"  건너뜀 {path}:{lineno} — 예외 사유: {exempt}")
+            continue
+        errors.append(
+            f"{path}:{lineno} — proxy_pass가 있으나 proxy-http.inc / proxy-ws.inc "
+            f"include가 없다. XFF가 클라이언트 값 그대로 앱에 전달된다."
+        )
+    return errors
+
+
+def has_proxy_headers(block, parent, includes):
+    """자신 또는 상위 블록에 프록시 헤더 include가 있는지 확인한다."""
+    while block is not None:
+        if block in includes:
+            return True
+        block = parent[block]
+    return False
+
+
+def main(paths):
+    files = sorted(
+        file
+        for target in (Path(p) for p in paths)
+        for file in (
+            [f for pattern in ("*.conf", "*.inc") for f in target.glob(pattern)]
+            if target.is_dir()
+            else [target]
+        )
+    )
+    if not files:
+        print(f"검사 대상 파일이 없다: {paths}", file=sys.stderr)
+        return 1
+
+    errors = [error for file in files for error in check_file(file)]
+    if errors:
+        print(f"\n프록시 헤더 include 누락 {len(errors)}건:\n", file=sys.stderr)
+        for error in errors:
+            print(f"  ✗ {error}", file=sys.stderr)
+        print(
+            "\nproxy_pass 하는 location에는 다음 중 하나를 include한다:\n"
+            "  include /etc/nginx/conf.d/proxy-http.inc;   # HTTP\n"
+            "  include /etc/nginx/conf.d/proxy-ws.inc;     # WebSocket\n"
+            "의도적 예외라면 proxy_pass 위에 `# proxy-header-exempt: <사유>` 주석을 단다.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✓ nginx 프록시 헤더 검사 통과 ({len(files)}개 파일)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:] or ["backend/docker/nginx/conf"]))

--- a/.github/scripts/test/test-check-nginx-proxy-headers.sh
+++ b/.github/scripts/test/test-check-nginx-proxy-headers.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# ============================================
+# nginx Proxy Header Check Test Suite
+# ============================================
+# check-nginx-proxy-headers.py의 판정을 검증한다. 임시 conf 파일만 쓰고 nginx는 띄우지 않는다:
+#   - proxy_pass + include        → 0 (통과)
+#   - proxy_pass, include 없음    → 1 (누락 탐지)
+#   - 상위 server 블록의 include  → 0 (nginx 상속 반영)
+#   - 예외 주석                   → 0 (사유 있는 예외 허용)
+#   - 실제 저장소 conf            → 0 (현재 설정은 통과해야 함)
+#
+# Usage:
+#   ./test-check-nginx-proxy-headers.sh
+#
+# Exit Codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+# ============================================
+
+# Note: set -e는 사용하지 않음 (테스트 실패 시에도 계속 실행해야 함)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_TOTAL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="${SCRIPT_DIR}/../check-nginx-proxy-headers.py"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# ============================================
+# 테스트 헬퍼
+# ============================================
+
+assert_conf() {
+    local desc="$1"
+    local expected="$2"
+    local conf="$3"
+    ((TESTS_TOTAL++))
+
+    local file="${TMP_DIR}/case-${TESTS_TOTAL}.conf"
+    printf '%s\n' "${conf}" > "${file}"
+
+    local output
+    output=$(python3 "${CHECK_SCRIPT}" "${file}" 2>&1)
+    local actual=$?
+
+    if [[ ${actual} -eq ${expected} ]]; then
+        echo -e "${GREEN}✓${NC} ${desc}"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}✗${NC} ${desc} (expected ${expected}, got ${actual})"
+        echo "${output}" | sed 's/^/    /'
+        ((TESTS_FAILED++))
+    fi
+}
+
+assert_path() {
+    local desc="$1"
+    local expected="$2"
+    local path="$3"
+    ((TESTS_TOTAL++))
+
+    local output
+    output=$(python3 "${CHECK_SCRIPT}" "${path}" 2>&1)
+    local actual=$?
+
+    if [[ ${actual} -eq ${expected} ]]; then
+        echo -e "${GREEN}✓${NC} ${desc}"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}✗${NC} ${desc} (expected ${expected}, got ${actual})"
+        echo "${output}" | sed 's/^/    /'
+        ((TESTS_FAILED++))
+    fi
+}
+
+# ============================================
+# 테스트 실행
+# ============================================
+
+echo "=== nginx 프록시 헤더 검사 테스트 ==="
+
+assert_conf "location에 include가 있으면 통과" 0 'server {
+    location / {
+        proxy_pass $upstream;
+        include /etc/nginx/conf.d/proxy-http.inc;
+    }
+}'
+
+assert_conf "include 없는 proxy_pass를 탐지" 1 'server {
+    location / {
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "형제 location의 include는 커버하지 않는다" 1 'server {
+    location /a {
+        proxy_pass $upstream;
+        include /etc/nginx/conf.d/proxy-http.inc;
+    }
+    location /b {
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "상위 server의 include를 상속으로 인정" 0 'server {
+    include /etc/nginx/conf.d/proxy-http.inc;
+    location / {
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "웹소켓 include도 인정" 0 'server {
+    location /ws {
+        proxy_pass $upstream;
+        include /etc/nginx/conf.d/proxy-ws.inc;
+    }
+}'
+
+assert_conf "사유 있는 예외 주석은 건너뛴다" 0 'server {
+    location / {
+        # proxy-header-exempt: 내부 전용, XFF 미사용
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "proxy_pass 없는 블록은 통과" 0 'server {
+    location / {
+        return 404;
+    }
+}'
+
+assert_conf "주석 처리된 proxy_pass는 무시" 0 'server {
+    location / {
+        # proxy_pass $upstream;
+        return 404;
+    }
+}'
+
+assert_path "저장소의 실제 nginx conf는 통과" 0 "${REPO_ROOT}/backend/docker/nginx/conf"
+
+# ============================================
+# 결과
+# ============================================
+
+echo ""
+echo "총 ${TESTS_TOTAL}건 / 성공 ${TESTS_PASSED} / 실패 ${TESTS_FAILED}"
+[[ ${TESTS_FAILED} -eq 0 ]]

--- a/.github/scripts/test/test-check-nginx-proxy-headers.sh
+++ b/.github/scripts/test/test-check-nginx-proxy-headers.sh
@@ -61,6 +61,32 @@ assert_conf() {
     fi
 }
 
+# include 내용 검사는 파일명(proxy-http.inc·proxy-ws.inc)으로 대상을 고르므로 이름을 지정한다
+assert_named() {
+    local desc="$1"
+    local expected="$2"
+    local name="$3"
+    local conf="$4"
+    ((TESTS_TOTAL++))
+
+    local dir="${TMP_DIR}/named-${TESTS_TOTAL}"
+    mkdir -p "${dir}"
+    printf '%s\n' "${conf}" > "${dir}/${name}"
+
+    local output
+    output=$(python3 "${CHECK_SCRIPT}" "${dir}/${name}" 2>&1)
+    local actual=$?
+
+    if [[ ${actual} -eq ${expected} ]]; then
+        echo -e "${GREEN}✓${NC} ${desc}"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}✗${NC} ${desc} (expected ${expected}, got ${actual})"
+        echo "${output}" | sed 's/^/    /'
+        ((TESTS_FAILED++))
+    fi
+}
+
 assert_path() {
     local desc="$1"
     local expected="$2"
@@ -117,6 +143,33 @@ assert_conf "상위 server의 include를 상속으로 인정" 0 'server {
     }
 }'
 
+# nginx는 현재 레벨에 proxy_set_header가 있으면 상위 레벨을 통째로 버린다(누적 아님).
+assert_conf "하위 블록의 자체 헤더 선언은 상위 상속을 끊는다" 1 'server {
+    include /etc/nginx/conf.d/proxy-http.inc;
+    location / {
+        proxy_set_header X-Custom foo;
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "XFF를 직접 선언하면 include 없이도 통과" 0 'server {
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass $upstream;
+    }
+}'
+
+assert_conf "한 줄에 여러 디렉티브인 proxy_pass도 탐지" 1 'server {
+    location / { proxy_pass http://somewhere; }
+}'
+
+assert_conf "문자열 안의 예외 마커는 예외로 인정하지 않는다" 1 'server {
+    location / {
+        proxy_set_header X-Note "# proxy-header-exempt: nope";
+        proxy_pass $upstream;
+    }
+}'
+
 assert_conf "웹소켓 include도 인정" 0 'server {
     location /ws {
         proxy_pass $upstream;
@@ -143,6 +196,24 @@ assert_conf "주석 처리된 proxy_pass는 무시" 0 'server {
         return 404;
     }
 }'
+
+# ADR-0023이 기록한 실제 회귀: include는 있는데 그 안에서 XFF를 $remote_addr로 덮어썼다.
+assert_named "XFF 체인을 덮어쓴 include를 탐지" 1 "proxy-http.inc" 'proxy_set_header Host $host;
+proxy_set_header X-Forwarded-For $remote_addr;'
+
+assert_named "체인을 누적하는 include는 통과" 0 "proxy-http.inc" 'proxy_set_header Host $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;'
+
+# 디렉터리 인자는 하위 디렉터리까지 훑어야 한다 — 검사 누락이 "통과"로 보이면 안 된다
+mkdir -p "${TMP_DIR}/tree/sub"
+cat > "${TMP_DIR}/tree/sub/deep.conf" <<'NGINX'
+server {
+    location / {
+        proxy_pass $upstream;
+    }
+}
+NGINX
+assert_path "하위 디렉터리의 conf도 검사한다" 1 "${TMP_DIR}/tree"
 
 assert_path "저장소의 실제 nginx conf는 통과" 0 "${REPO_ROOT}/backend/docker/nginx/conf"
 

--- a/.github/workflows/edge-cd.yml
+++ b/.github/workflows/edge-cd.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # 서버의 nginx -t는 문법만 본다(ADR-0023 §3). XFF 사슬이 끊긴 설정은 문법상 정상이라
+      # 통과하므로 전송 전에 여기서 막는다. edge-config-ci는 PR 단계 피드백용이고, push 시에는
+      # 이 워크플로와 병렬로 떠서 배포를 게이트하지 못한다(#1620).
+      - name: Check proxy header chain
+        run: python3 .github/scripts/check-nginx-proxy-headers.py backend/docker/nginx/conf
+
       - name: Transfer config & scripts via SCP
         uses: appleboy/scp-action@v1.0.0
         with:

--- a/.github/workflows/edge-config-ci.yml
+++ b/.github/workflows/edge-config-ci.yml
@@ -7,16 +7,16 @@ name: Edge Config CI
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, prod]
     paths:
-      - "backend/docker/nginx/conf/**"
+      - "backend/docker/nginx/**"
       - ".github/scripts/check-nginx-proxy-headers.py"
       - ".github/scripts/test/test-check-nginx-proxy-headers.sh"
       - ".github/workflows/edge-config-ci.yml"
   push:
-    branches: [dev]
+    branches: [dev, prod]
     paths:
-      - "backend/docker/nginx/conf/**"
+      - "backend/docker/nginx/**"
       - ".github/scripts/check-nginx-proxy-headers.py"
       - ".github/scripts/test/test-check-nginx-proxy-headers.sh"
       - ".github/workflows/edge-config-ci.yml"

--- a/.github/workflows/edge-config-ci.yml
+++ b/.github/workflows/edge-config-ci.yml
@@ -1,0 +1,46 @@
+name: Edge Config CI
+
+# nginx 설정(backend/docker/nginx/conf/**)을 PR 단계에서 검증한다.
+# 앱의 내부 IP 화이트리스트가 XFF 스푸핑에 뚫리지 않는 근거는 nginx가 실제 TCP peer를
+# X-Forwarded-For 맨 뒤에 덧붙이는 것(proxy-http.inc·proxy-ws.inc)이다. include 없는
+# proxy_pass가 하나라도 생기면 그 사슬이 끊긴다(#1620). 사람 리뷰에 맡기지 않고 CI로 고정한다.
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "backend/docker/nginx/conf/**"
+      - ".github/scripts/check-nginx-proxy-headers.py"
+      - ".github/scripts/test/test-check-nginx-proxy-headers.sh"
+      - ".github/workflows/edge-config-ci.yml"
+  push:
+    branches: [dev]
+    paths:
+      - "backend/docker/nginx/conf/**"
+      - ".github/scripts/check-nginx-proxy-headers.py"
+      - ".github/scripts/test/test-check-nginx-proxy-headers.sh"
+      - ".github/workflows/edge-config-ci.yml"
+
+# 같은 ref의 이전 실행은 취소해 중복 CI 낭비를 줄인다
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proxy-headers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Check proxy header includes
+        run: python3 .github/scripts/check-nginx-proxy-headers.py backend/docker/nginx/conf
+
+      - name: Test the checker itself
+        run: bash .github/scripts/test/test-check-nginx-proxy-headers.sh

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
@@ -68,9 +68,10 @@ public class IpBlockFilter extends OncePerRequestFilter {
         final Ip ip = clientIp.get();
 
         // 사설/내부 IP(프록시·헬스체크·내부 서비스)는 클라이언트가 아니므로 차단·카운트 대상에서 제외한다.
-        // 프록시 뒤에서 getRemoteAddr()는 항상 내부 IP이며, 이를 차단하면 nginx 경유 트래픽 전체가 막혀
-        // 장애로 번진다(postmortem 0003). 내부 IP의 악성 경로 접근은 프록시/XFF 설정 이상 신호이므로
-        // 차단 없이 경고만 남기고 통과시킨다.
+        // XFF 신뢰 체인이 정상이면 여기 오는 값은 실제 클라이언트 IP이므로 내부 IP는 거의 나오지 않는다.
+        // 체인이 끊기면(프록시가 XFF를 세팅하지 않으면) nginx의 도커 IP가 그대로 잡히고, 이를 차단하면
+        // nginx 경유 트래픽 전체가 막혀 장애로 번진다(postmortem 0003). 내부 IP의 악성 경로 접근은
+        // 프록시/XFF 설정 이상 신호이므로 차단 없이 경고만 남기고 통과시킨다.
         if (isInternalIp(ip.value())) {
             if (maliciousPathMatcher.isMalicious(uri)) {
                 log.warn("내부 IP에서 악성 경로 접근 — 차단하지 않고 통과(프록시/XFF 설정 점검 필요): ip={} uri={}", ip, uri);
@@ -157,6 +158,18 @@ public class IpBlockFilter extends OncePerRequestFilter {
         return false;
     }
 
+    /**
+     * 클라이언트 IP. Tomcat {@code RemoteIpValve}({@code server.forward-headers-strategy: native})가
+     * 이미 X-Forwarded-For를 해석해 넣어둔 값이므로 여기서 헤더를 직접 읽지 않는다.
+     *
+     * <p>Valve는 XFF를 <b>오른쪽부터</b> 훑으며 {@code internal-proxies}(RFC1918·루프백)에 해당하는
+     * 항목만 벗겨내고 첫 비내부 IP에서 멈춘다. nginx가 {@code $proxy_add_x_forwarded_for}로 실제
+     * TCP peer를 XFF 맨 뒤에 덧붙이므로(proxy-http.inc·proxy-ws.inc), 클라이언트가 헤더 왼쪽에
+     * 주입한 사설 IP는 이 값이 될 수 없다 — 즉 XFF 스푸핑으로 아래 내부 IP 화이트리스트를 통과할 수 없다.
+     *
+     * <p>이 보장은 "모든 {@code proxy_pass}가 프록시 헤더 include를 동반한다"에 의존한다.
+     * {@code .github/scripts/check-nginx-proxy-headers.py}가 CI에서 이를 강제한다(#1620).
+     */
     private String getClientIp(HttpServletRequest request) {
         return request.getRemoteAddr();
     }

--- a/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
+++ b/backend/infra/src/main/java/coffeeshout/global/ipblock/IpBlockFilter.java
@@ -162,13 +162,21 @@ public class IpBlockFilter extends OncePerRequestFilter {
      * 클라이언트 IP. Tomcat {@code RemoteIpValve}({@code server.forward-headers-strategy: native})가
      * 이미 X-Forwarded-For를 해석해 넣어둔 값이므로 여기서 헤더를 직접 읽지 않는다.
      *
-     * <p>Valve는 XFF를 <b>오른쪽부터</b> 훑으며 {@code internal-proxies}(RFC1918·루프백)에 해당하는
-     * 항목만 벗겨내고 첫 비내부 IP에서 멈춘다. nginx가 {@code $proxy_add_x_forwarded_for}로 실제
-     * TCP peer를 XFF 맨 뒤에 덧붙이므로(proxy-http.inc·proxy-ws.inc), 클라이언트가 헤더 왼쪽에
-     * 주입한 사설 IP는 이 값이 될 수 없다 — 즉 XFF 스푸핑으로 아래 내부 IP 화이트리스트를 통과할 수 없다.
+     * <p>Valve는 XFF를 <b>오른쪽부터</b> 훑으며 {@code internal-proxies}에 매칭되는 항목만 벗겨내고
+     * 첫 비매칭 IP에서 멈춘다. dev·prod는 Tomcat 기본값을 덮어써 {@code 127.0.0.1}과 RFC1918
+     * 세 대역만 신뢰한다(application-{dev,prod}.yml). nginx가 {@code $proxy_add_x_forwarded_for}로
+     * 실제 TCP peer를 XFF 맨 뒤에 덧붙이므로(proxy-http.inc·proxy-ws.inc), <b>공인 IP에서 온 요청이라면</b>
+     * 클라이언트가 헤더 왼쪽에 주입한 사설 IP는 이 값이 될 수 없다 — XFF 스푸핑으로 아래 내부 IP
+     * 화이트리스트를 통과할 수 없다. TCP peer 자체가 사설 IP인 요청은 주입값이 남을 수 있으나,
+     * 그런 출발지는 스푸핑 없이도 이미 화이트리스트 대상이다.
      *
-     * <p>이 보장은 "모든 {@code proxy_pass}가 프록시 헤더 include를 동반한다"에 의존한다.
-     * {@code .github/scripts/check-nginx-proxy-headers.py}가 CI에서 이를 강제한다(#1620).
+     * <p>이 보장은 두 전제에 의존한다.
+     * <ol>
+     *   <li>모든 {@code proxy_pass}가 XFF 체인을 누적한다 —
+     *       {@code .github/scripts/check-nginx-proxy-headers.py}가 CI에서 강제한다(#1620).</li>
+     *   <li>앱 포트가 nginx를 통해서만 도달 가능하다 — 앱 컨테이너는 host 포트를 열지 않고
+     *       nginx만 80·443을 연다(docker/{dev,prod}/docker-compose.yml). 강제 장치는 없다.</li>
+     * </ol>
      */
     private String getClientIp(HttpServletRequest request) {
         return request.getRemoteAddr();


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1620

# 🚀 작업 내용

1. **`.github/scripts/check-nginx-proxy-headers.py`** — nginx 설정에서 `proxy_pass`가 있는 블록이 `proxy-http.inc` 또는 `proxy-ws.inc`를 include하는지 검사한다. nginx는 상위 블록의 `proxy_set_header`를 물려받으므로, 상위 `server` 블록의 include도 인정한다. 어쩔 수 없는 예외는 `# proxy-header-exempt: <사유>` 주석으로만 허용해 사유 없는 예외가 늘지 않게 했다.
2. **`.github/workflows/edge-config-ci.yml`** — nginx 설정이나 위 스크립트가 바뀐 PR에서 검사를 실행한다.
3. **`.github/scripts/test/test-check-nginx-proxy-headers.sh`** — 검사 스크립트 자체의 테스트 9건(누락 탐지·상위 블록 상속·형제 블록 미인정·예외 주석·주석 처리된 `proxy_pass` 무시·실제 저장소 설정 통과). 기존 `.github/scripts/test/` 방식(bash + 임시 파일)을 따랐고 CI에서 함께 돌린다.
4. **`IpBlockFilter`** — 주석만 수정했다. 동작 변경 없음.

# 💬 리뷰 중점사항

**왜 필요한가.** `IpBlockFilter`는 내부 IP(사설망 IP)를 차단 대상에서 빼준다. 그런데 `X-Forwarded-For`(요청을 거쳐온 IP를 적는 헤더)는 클라이언트가 마음대로 채워 보낼 수 있다. 지금 이게 뚫리지 않는 이유는 필터 코드가 아니라 아래 두 단계가 맞물려 있기 때문이다.

1. nginx가 `$proxy_add_x_forwarded_for`로 **실제 접속 IP를 헤더 맨 뒤에 덧붙인다** (`proxy-http.inc` / `proxy-ws.inc`).
2. 톰캣이 그 헤더를 **오른쪽부터** 읽으면서 사설 IP만 걷어내고, 처음 만난 공인 IP에서 멈춘다. 그 값이 `getRemoteAddr()`가 된다.

그래서 공격자가 헤더에 `10.0.0.1`을 넣어도 오른쪽 끝은 nginx가 붙인 진짜 IP라 화이트리스트를 통과하지 못한다.

문제는 **이 방어가 1번에만 의존하는데 그걸 지키는 장치가 없었다**는 점이다. 앞으로 누군가 include 없이 `proxy_pass` 하는 설정을 추가하면, 클라이언트가 보낸 헤더가 그대로 앱까지 전달된다. 헤더 값이 전부 사설 IP면 톰캣이 끝까지 걷어내서 **공격자가 넣은 사설 IP가 `getRemoteAddr()`가 되고, 화이트리스트가 그대로 뚫린다.**

현재 설정(`dev.conf`·`prod.conf`·`internal.conf`·`monitor.conf`)은 모두 정상이라 이번 PR로 동작이 바뀌는 건 없다. 지금이 가드를 박아두기 가장 싼 시점이라 넣는다. 가드가 조용히 사라지는 사고는 [postmortem 0003](../blob/dev/backend/docs/postmortem/0003-internal-ip-block-dev-webhook.md)에서 이미 한 번 겪었고, 그때도 사람 리뷰가 놓쳤다.

**주석을 왜 고쳤나.** `IpBlockFilter`에 "프록시 뒤에서 `getRemoteAddr()`는 항상 내부 IP"라고 적혀 있었는데, 톰캣의 `RemoteIpValve` 설정(`server.forward-headers-strategy: native`)이 들어온 뒤로는 사실이 아니다. 실제로는 진짜 클라이언트 IP다. 보안 판단에 직접 영향을 주는 주석이라 정정했다.

**검토해주실 부분**

- 검사 규칙이 너무 빡빡하거나 느슨한지. 지금은 `monitor.conf`의 grafana 프록시까지 전부 검사 대상이다(앱 upstream만 볼 수도 있지만, 나중에 앱 경로가 추가될 때 빠지는 게 더 위험하다고 봤다).
- 예외 허용 방식(`# proxy-header-exempt: <사유>`)이 적절한지. 기존 `check-alert-job-scope.py`의 예외 표기 방식과 맞췄다.
- 설정 파일을 정규식으로 읽는 방식이라 완벽한 nginx 파서는 아니다. 중괄호 깊이만 세고, `{`가 블록 선언과 같은 줄에 온다는 관례를 전제한다. 저장소의 모든 설정 파일이 이 관례를 따르고 있어 충분하다고 판단했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Nginx 프록시 설정에 필요한 헤더 포함 여부를 자동으로 검사하는 검증 기능을 추가했습니다.
  * 관련 설정 변경 시 자동으로 검사를 실행하는 CI 워크플로를 추가했습니다.

* **버그 수정**
  * 프록시 헤더 처리 및 클라이언트 IP 판별 기준에 대한 설명을 명확히 정비했습니다.

* **테스트**
  * 정상 설정, 누락된 헤더, 웹소켓, 예외 처리 등 다양한 프록시 설정 검증 시나리오를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->