### PR TITLE
[chore] timeout-minutes 없는 CI 잡에 실행 시간 제한 추가

### DIFF
--- a/.github/workflows/be-delete-merged-branch.yml
+++ b/.github/workflows/be-delete-merged-branch.yml
@@ -15,6 +15,7 @@ jobs:
   delete-branch:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write
@@ -90,6 +91,7 @@ jobs:
     if: github.event.pull_request.merged == true
     needs: delete-branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Log deletion

--- a/.github/workflows/chromatic-base.yml
+++ b/.github/workflows/chromatic-base.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   chromatic-base:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ./frontend

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   chromatic-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ./frontend

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     # 출력 설정
     outputs:


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- 없음 (경량 경로 — `.github/` 전용 변경, `scope.sh` 결과 `SRC_EMPTY=1`)

# 🚀 작업 내용

`timeout-minutes` 설정이 없던 잡 5개에 실행 시간 제한을 추가했다. GitHub Actions는 이 값이 없으면 기본 360분(6시간)까지 잡을 놔둔다.

계기는 [run 30619631847](https://github.com/woowacourse-teams/2025-zzol/actions/runs/30619631847)이다. `chromatic-base` 잡이 러너 통신 두절(`The hosted runner lost communication with the server`)로 **45분간 매달렸다가 실패**했다. 평소 1~3분이면 끝나는 잡이다.

제한값은 최근 실행 기록의 평소 소요시간에 여유를 둬 잡았다.

1. `.github/workflows/chromatic-base.yml` — `chromatic-base` 잡에 `timeout-minutes: 10` (평소 1~3분)
2. `.github/workflows/chromatic-pr.yml` — `chromatic-pr` 잡에 `timeout-minutes: 10` (평소 1~3분)
3. `.github/workflows/frontend-ci.yml` — `ci` 잡에 `timeout-minutes: 10` (평소 1~2분)
4. `.github/workflows/be-delete-merged-branch.yml` — `delete-branch`·`log-deleted-branch` 두 잡에 `timeout-minutes: 5` (평소 1분 미만)

이로써 워크플로 14개의 실행 잡 15개가 모두 시간 제한을 갖는다. 나머지는 이미 설정돼 있었다 (backend-ci 15분, backend-cd 30분, codeql 60분, api-mcp-ci 10분, docs-ci·monitoring-rules-ci·close-issue 5분 등).

# 💬 리뷰 중점사항

- **시간 제한은 러너 장애 자체를 막지 못한다.** 이번 건은 GitHub 인프라 문제라 우리 쪽에서 예방할 수 없다. 이 변경이 얻는 건 **낭비되는 시간과 사용량을 줄이는 것**이다 — 같은 상황이 또 나면 45분(최악의 경우 6시간)이 아니라 10분에 잘린다. 실패를 더 빨리 알게 되는 효과도 있다.
- **값이 빠듯하지 않은지** 봐주면 좋겠다. 평소의 3~5배로 잡았지만, npm 캐시가 안 먹거나 Chromatic 업로드가 느린 날에는 10분도 아슬아슬할 수 있다. 제한이 짧으면 정상 작업이 잘려 오히려 재실행 비용이 든다. 넉넉하게 가려면 15분도 괜찮다고 본다.
- **범위 밖으로 둔 것**: `chromatic-base.yml`에는 `concurrency` 그룹이 없어 `dev`에 연속으로 push하면 이전 실행이 취소되지 않고 그대로 돈다. 다른 push 워크플로에는 대부분 있다. 이번 요청 범위(실행 시간 제한)와 별개 사안이라 손대지 않았다. 필요하면 별도 PR로 하겠다.
