### PR TITLE
[fix] WebSocket 브로드캐스트 순서 역전 수정 — setPreservePublishOrder 활성화

### DIFF
--- a/backend/websocket/src/main/java/coffeeshout/websocket/config/WebSocketMessageBrokerConfig.java
+++ b/backend/websocket/src/main/java/coffeeshout/websocket/config/WebSocketMessageBrokerConfig.java
@@ -66,6 +66,11 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
                 .setTaskScheduler(heartbeatScheduler);
 
         config.setApplicationDestinationPrefixes("/app");
+
+        // clientOutboundChannel이 16스레드 풀이라(configureClientOutboundChannel) 같은 세션으로 가는
+        // 브로드캐스트가 발행 순서와 다르게 도착할 수 있다. 게임 상태 전환(DESCRIPTION→PREPARE→PLAYING)은
+        // 순서가 뒤집히면 클라이언트 화면이 되돌아가므로 세션별 순서를 보존한다.
+        config.setPreservePublishOrder(true);
     }
 
     @Override

--- a/backend/websocket/src/test/java/coffeeshout/websocket/config/WebSocketMessageBrokerConfigTest.java
+++ b/backend/websocket/src/test/java/coffeeshout/websocket/config/WebSocketMessageBrokerConfigTest.java
@@ -1,0 +1,31 @@
+package coffeeshout.websocket.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coffeeshout.WebsocketModuleIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.broker.OrderedMessageChannelDecorator;
+
+class WebSocketMessageBrokerConfigTest extends WebsocketModuleIntegrationTest {
+
+    @Autowired
+    @Qualifier("clientOutboundChannel")
+    MessageChannel clientOutboundChannel;
+
+    /**
+     * clientOutboundChannel은 16스레드 풀이라(WebSocketMessageBrokerConfig#configureClientOutboundChannel)
+     * 순서 보존 설정이 없으면 같은 세션으로 가는 브로드캐스트가 뒤바뀐 순서로 도착할 수 있다.
+     *
+     * <p>실제 역전은 스레드 스케줄링에 달려 있어 재현이 확률적이다. 그래서 "역전이 일어나는가"를 재는 대신
+     * <b>순서를 보존하는 설정이 실제로 적용됐는가</b>를 잰다. {@code setPreservePublishOrder(true)}는
+     * clientOutboundChannel에 {@link OrderedMessageChannelDecorator}의 인터셉터를 설치하며,
+     * {@code supportsOrderedMessages}가 그 설치 여부를 그대로 관측한다 — 부하와 무관하게 결정론적이다.
+     */
+    @Test
+    void 클라이언트_아웃바운드_채널은_발행_순서를_보존한다() {
+        assertThat(OrderedMessageChannelDecorator.supportsOrderedMessages(clientOutboundChannel)).isTrue();
+    }
+}


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1640

# 🚀 작업 내용

1. `WebSocketMessageBrokerConfig.configureMessageBroker`에 `config.setPreservePublishOrder(true)` 추가
2. 순서 보존 설정이 실제로 적용됐는지 검증하는 회귀 테스트 `WebSocketMessageBrokerConfigTest` 추가

## 무엇이 문제였나

`clientOutboundChannel`은 16스레드 풀인데(`configureClientOutboundChannel`, 같은 파일 91줄) 순서 보존 설정이 없어 **같은 세션으로 가는 브로드캐스트의 도착 순서가 보장되지 않았다.**

`BlindTimerGameIntegrationTest > 게임_시작부터_전원_STOP까지_상태와_진행도가_순서대로_브로드캐스트된다()`가 CI에서 간헐 실패하며 드러났다 ([run 30777623132](https://github.com/woowacourse-teams/2025-zzol/actions/runs/30777623132/job/91576008923)). check-run annotation의 `raw_details`:

```text
-- failure 1 --  expected: "DESCRIPTION"  but was: "PREPARE"
-- failure 2 --  expected: "PREPARE"      but was: "DESCRIPTION"
```

메시지 유실이 아니라 **두 개가 뒤바뀌어 도착했다.** `MessageCollector.get()`은 타임아웃 시 `ConditionTimeoutException`을 던지므로, 값 단언만 깨졌다는 건 메시지가 모두 도착했다는 뜻이다.

테스트 프로파일은 `description: 500ms`라(`game/src/testFixtures/resources/application-test-game.yml:45`) DESCRIPTION → PREPARE 발행 간격이 500ms뿐이고, 두 이벤트는 서로 다른 스레드(테스트 스레드 / `blindTimerGameScheduler`)에서 발행된다. CI 러너가 밀리면 순서가 뒤집힌다. 운영은 간격이 4000ms라 드물 뿐 **위험은 동일하다** — 클라이언트가 PREPARE를 DESCRIPTION보다 먼저 받으면 화면이 되돌아간다. 테스트만의 문제가 아니다.

같은 테스트가 2026-07-22 [run 29941488879](https://github.com/woowacourse-teams/2025-zzol/actions/runs/29941488879)(전혀 다른 의존성 묶음의 dependabot PR)에서도 동일하게 실패했다 — 의존성과 무관하게 재발해 왔다.

#1410(닫힘)은 subscribe 레이스로 인한 **유실**을 barrier ping으로 잡았다. 이번 건은 **순서 역전**이라 별개 실패 모드이며 그 수정으로 덮이지 않는다.

## 회귀 테스트를 이렇게 쓴 이유

실제 역전은 스레드 스케줄링에 달려 있어 재현이 확률적이다. "역전이 일어나는가"를 재는 테스트는 그 자체로 flaky해져 원래 문제를 되풀이한다.

그래서 **순서를 보존하는 설정이 실제로 적용됐는가**를 잰다. `setPreservePublishOrder(true)`는 `clientOutboundChannel`에 `OrderedMessageChannelDecorator`의 인터셉터를 설치하며, 같은 클래스의 `supportsOrderedMessages(channel)`가 그 설치 여부를 그대로 관측한다 — 부하와 무관하게 결정론적이다.

수정 **전** 실패 → 수정 **후** 통과를 확인했다.

```text
# 수정 전
WebSocketMessageBrokerConfigTest > 클라이언트_아웃바운드_채널은_발행_순서를_보존한다() FAILED
    org.opentest4j.AssertionFailedError at WebSocketMessageBrokerConfigTest.java:29
1 test completed, 1 failed

# 수정 후
BUILD SUCCESSFUL
```

`./gradlew :websocket:test :game:test` 전체 통과 (`BUILD SUCCESSFUL in 2m 3s`).

# 💬 리뷰 중점사항

1. **성능 영향** — `setPreservePublishOrder(true)`는 세션별로 메시지를 직렬화하므로 outbound 16스레드의 병렬성이 **같은 세션 안에서는** 사라진다. 세션 간 병렬성은 유지된다. 방 하나당 브로드캐스트 볼륨을 고려할 때 수용 가능하다고 봤는데, 이견 있으면 알려달라.

2. **후속 과제(이 PR 범위 밖)** — `BlindTimerGameService.start()`(52~54줄)가 PREPARE 전환을 **먼저 스케줄한 뒤** DESCRIPTION 이벤트를 발행한다. `BlindTimerStateChangedEvent.of`가 발행 시점의 `game.getState()`를 스냅샷하므로, 두 줄 사이에서 500ms 이상 멈추면 DESCRIPTION 자리에 PREPARE가 실려 나간다. 이번 실패의 원인은 아니고(그랬다면 PREPARE가 두 번 왔어야 한다) 순서 보존으로도 안 덮이는 별개 위험이라, 이슈 #1640 TODO에 남기고 여기서는 건드리지 않았다.
