### PR TITLE
[chore] nginx 엣지에서 스캐너 트래픽 차단 + Edge CI에 nginx -t 추가

### DIFF
--- a/.github/scripts/deploy-edge.sh
+++ b/.github/scripts/deploy-edge.sh
@@ -146,6 +146,12 @@ probe_nginx() {
     _probe "api.zzol.site" "/ws/info" || failed=1
     _probe "dev.api.zzol.site" "/ws/info" || failed=1
     _probe "status.zzol.site" "/" || failed=1
+    # scanner-block.inc가 정상 경로를 잡아먹지 않는지 확인한다. 444는 연결 종료(=000)라
+    # _probe가 실패로 보고 자동 원복된다. nginx -t로는 못 잡는 라우팅 회귀다.
+    #   - IPv4 경로 파라미터: 차단 해제 수단(postmortem 0003). GET이라 405가 오지만 <500이라 통과.
+    #   - 관리자 CSS: 확장자를 쓰는 정상 경로가 ^~ 예외로 살아있는지.
+    _probe "api.zzol.site" "/admin/ip-blocks/1.2.3.4/unblock" || failed=1
+    _probe "api.zzol.site" "/css/admin.css" || failed=1
     return "$failed"
 }
 

--- a/.github/workflows/edge-config-ci.yml
+++ b/.github/workflows/edge-config-ci.yml
@@ -44,3 +44,33 @@ jobs:
 
       - name: Test the checker itself
         run: bash .github/scripts/test/test-check-nginx-proxy-headers.sh
+
+  # 문법 검증. 배포 시점에 처음 터지면 엣지가 통째로 내려가므로 PR에서 잡는다.
+  # 인증서는 실물이 없으므로 자체서명으로 대체한다(경로만 맞으면 nginx -t 는 통과).
+  syntax:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Generate self-signed cert
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -keyout certs/privkey.pem -out certs/fullchain.pem -subj "/CN=zzol.site"
+
+      - name: nginx -t
+        run: |
+          # 이미지 태그는 compose에서 읽는다 — 버전을 두 곳에 적으면 갈라진다.
+          IMAGE=$(grep -oP '^\s*image:\s*\Knginx:\S+' backend/docker/nginx/docker-compose.yml)
+          echo "image: $IMAGE"
+          docker run --rm \
+            -v "$PWD/backend/docker/nginx/conf:/etc/nginx/conf.d:ro" \
+            -v "$PWD/certs:/etc/letsencrypt/live/zzol.site:ro" \
+            "$IMAGE" nginx -t

--- a/backend/docker/nginx/conf/01-default-server.conf
+++ b/backend/docker/nginx/conf/01-default-server.conf
@@ -1,0 +1,26 @@
+# ============================================
+# Catch-all (알 수 없는 Host = IP 직접 접근)
+# ============================================
+# default_server가 없으면 알파벳 순 첫 server 블록(dev.conf)이 default_server가 되어,
+# IP 대역을 훑는 스캐너 트래픽이 그대로 dev 앱까지 들어간다.
+# 도메인을 모르고 IP만 찍는 요청은 정상 트래픽이 아니므로 여기서 끊는다.
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # 인증서 갱신(HTTP-01). 아직 어느 server_name에도 없는 도메인의 검증이 여기로 떨어질 수 있다.
+    include /etc/nginx/conf.d/acme-challenge.inc;
+
+    location / {
+        return 444;   # 응답 없이 연결 종료
+    }
+}
+
+server {
+    listen 443 ssl default_server;
+
+    # SNI가 없거나 우리 도메인이 아니면 TLS 핸드셰이크 단계에서 거절한다(인증서도 제시하지 않음).
+    # 정상 클라이언트는 모두 SNI를 보낸다 — 브라우저, 프론트, blackbox 프로브(server_name: api.zzol.site).
+    ssl_reject_handshake on;
+}

--- a/backend/docker/nginx/conf/dev.conf
+++ b/backend/docker/nginx/conf/dev.conf
@@ -24,6 +24,9 @@ server {
 
 	include /etc/nginx/conf.d/dev-service.inc;
 
+	# 스캐너 경로 차단(444). $upstream 정의 뒤에 와야 한다.
+	include /etc/nginx/conf.d/scanner-block.inc;
+
 	location / {
 		proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-http.inc;
@@ -35,7 +38,8 @@ server {
 	}
 
 	# 웹소켓 연결 요청 전용 프록시 설정
-	location /ws {
+	# ^~ : SockJS의 /ws/iframe.html 이 scanner-block.inc의 정규식에 걸리지 않도록 선점한다.
+	location ^~ /ws {
 		proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-ws.inc;
 	}

--- a/backend/docker/nginx/conf/dev.conf
+++ b/backend/docker/nginx/conf/dev.conf
@@ -24,7 +24,7 @@ server {
 
 	include /etc/nginx/conf.d/dev-service.inc;
 
-	# 스캐너 경로 차단(444). $upstream 정의 뒤에 와야 한다.
+	# 스캐너 경로 차단(444). 이 include 는 $upstream 을 참조한다(정의는 {env}-service.inc).
 	include /etc/nginx/conf.d/scanner-block.inc;
 
 	location / {
@@ -38,8 +38,15 @@ server {
 	}
 
 	# 웹소켓 연결 요청 전용 프록시 설정
-	# ^~ : SockJS의 /ws/iframe.html 이 scanner-block.inc의 정규식에 걸리지 않도록 선점한다.
-	location ^~ /ws {
+	# scanner-block.inc의 정규식보다 우선하도록 = 와 ^~ 로 선점한다(SockJS는 /ws/iframe.html 을 쓴다).
+	# ^~ /ws 하나로 묶지 않는 이유: /ws 로 시작하기만 하면 되므로 /ws.php·/wsdl.xml 같은
+	# 스캐너 경로까지 면제된다. 엔드포인트는 /ws 정확일치와 그 하위뿐이다.
+	location = /ws {
+		proxy_pass $upstream;
+		include /etc/nginx/conf.d/proxy-ws.inc;
+	}
+
+	location ^~ /ws/ {
 		proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-ws.inc;
 	}

--- a/backend/docker/nginx/conf/prod.conf
+++ b/backend/docker/nginx/conf/prod.conf
@@ -23,6 +23,9 @@ server {
 
         include /etc/nginx/conf.d/prod-service.inc;
 
+        # 스캐너 경로 차단(444). $upstream 정의 뒤에 와야 한다.
+        include /etc/nginx/conf.d/scanner-block.inc;
+
         location / {
                 proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-http.inc;
@@ -34,7 +37,8 @@ server {
         }
 
         # 웹소켓 연결 요청 전용 프록시 설정
-        location /ws {
+        # ^~ : SockJS의 /ws/iframe.html 이 scanner-block.inc의 정규식에 걸리지 않도록 선점한다.
+        location ^~ /ws {
                 proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-ws.inc;
         }

--- a/backend/docker/nginx/conf/prod.conf
+++ b/backend/docker/nginx/conf/prod.conf
@@ -23,7 +23,7 @@ server {
 
         include /etc/nginx/conf.d/prod-service.inc;
 
-        # 스캐너 경로 차단(444). $upstream 정의 뒤에 와야 한다.
+        # 스캐너 경로 차단(444). 이 include 는 $upstream 을 참조한다(정의는 {env}-service.inc).
         include /etc/nginx/conf.d/scanner-block.inc;
 
         location / {
@@ -37,8 +37,15 @@ server {
         }
 
         # 웹소켓 연결 요청 전용 프록시 설정
-        # ^~ : SockJS의 /ws/iframe.html 이 scanner-block.inc의 정규식에 걸리지 않도록 선점한다.
-        location ^~ /ws {
+        # scanner-block.inc의 정규식보다 우선하도록 = 와 ^~ 로 선점한다(SockJS는 /ws/iframe.html 을 쓴다).
+        # ^~ /ws 하나로 묶지 않는 이유: /ws 로 시작하기만 하면 되므로 /ws.php·/wsdl.xml 같은
+        # 스캐너 경로까지 면제된다. 엔드포인트는 /ws 정확일치와 그 하위뿐이다.
+        location = /ws {
+                proxy_pass $upstream;
+		include /etc/nginx/conf.d/proxy-ws.inc;
+        }
+
+        location ^~ /ws/ {
                 proxy_pass $upstream;
 		include /etc/nginx/conf.d/proxy-ws.inc;
         }

--- a/backend/docker/nginx/conf/scanner-block.inc
+++ b/backend/docker/nginx/conf/scanner-block.inc
@@ -1,0 +1,22 @@
+# 스캐너 경로 차단 (dev.conf·prod.conf에서 include)
+#
+# 이 호스트의 정상 경로에는 점(.)이 없다 — REST 엔드포인트도, Thymeleaf 관리자 페이지도 확장자를 쓰지 않는다.
+# 점이 들어간 요청(/.env, /.git/config, /wp-admin/*.php, /backup.sql, /config.json …)은 전부 스캐너다.
+# 확장자 블랙리스트 대신 이 한 줄로 잡는 이유: 블랙리스트는 늘 새 확장자에 뚫린다.
+#
+# 444 = 응답 없이 연결 종료. 앱까지 가지 않으므로 IpBlockFilter의 403 응답·WARN 로그 비용도 사라진다.
+# 앱의 MaliciousPathMatcher는 그대로 둔다(다층 방어 — nginx를 우회한 경로용).
+#
+# 점을 쓰는 정상 경로 예외는 ^~ 프리픽스 location이 정규식보다 우선하므로 아래·acme-challenge.inc가 선점한다:
+#   /.well-known/acme-challenge/  (acme-challenge.inc)
+#   /css/*.css                    (관리자 UI, 아래)
+#   /ws/**                        (SockJS iframe.html 등, dev.conf·prod.conf의 location ^~ /ws)
+
+location ^~ /css/ {
+    proxy_pass $upstream;
+    include /etc/nginx/conf.d/proxy-http.inc;
+}
+
+location ~ "\." {
+    return 444;
+}

--- a/backend/docker/nginx/conf/scanner-block.inc
+++ b/backend/docker/nginx/conf/scanner-block.inc
@@ -1,22 +1,53 @@
 # 스캐너 경로 차단 (dev.conf·prod.conf에서 include)
 #
-# 이 호스트의 정상 경로에는 점(.)이 없다 — REST 엔드포인트도, Thymeleaf 관리자 페이지도 확장자를 쓰지 않는다.
-# 점이 들어간 요청(/.env, /.git/config, /wp-admin/*.php, /backup.sql, /config.json …)은 전부 스캐너다.
-# 확장자 블랙리스트 대신 이 한 줄로 잡는 이유: 블랙리스트는 늘 새 확장자에 뚫린다.
+# 444 = 응답 없이 연결 종료. 앱까지 가지 않으므로 IpBlockFilter의 403 응답·WARN 로그 비용이 사라진다.
 #
-# 444 = 응답 없이 연결 종료. 앱까지 가지 않으므로 IpBlockFilter의 403 응답·WARN 로그 비용도 사라진다.
-# 앱의 MaliciousPathMatcher는 그대로 둔다(다층 방어 — nginx를 우회한 경로용).
+# ── 왜 "점(.)이 있으면 차단"이 아닌가 ────────────────────────────────────────
+# 정적 경로에는 점이 없지만 **경로 파라미터에는 있다.** 실제로 세 군데가 깨진다:
+#   /admin/ip-blocks/1.2.3.4/unblock   IPv4 (postmortem 0003의 차단 해제 수단)
+#   /rooms/{code}/players/{nickname}   PlayerName은 문자 집합을 제한하지 않는다
+#   /swagger-ui/swagger-ui.css         dev 프로필의 springdoc 정적 자산
+# 점 전체를 막으면 "앞으로 경로에 점을 넣지 마라"는 제약이 API 설계 전체에 생기고,
+# 어기면 조용히 444가 된다. 그래서 스캐너가 실제로 노리는 두 가지만 막는다.
 #
-# 점을 쓰는 정상 경로 예외는 ^~ 프리픽스 location이 정규식보다 우선하므로 아래·acme-challenge.inc가 선점한다:
-#   /.well-known/acme-challenge/  (acme-challenge.inc)
-#   /css/*.css                    (관리자 UI, 아래)
-#   /ws/**                        (SockJS iframe.html 등, dev.conf·prod.conf의 location ^~ /ws)
+# 실패 방향도 이쪽이 맞다. 목록에 없는 확장자는 앱까지 가지만 거기서 IpBlockFilter가
+# 받는다 — 뚫리는 게 아니라 원래 위치로 돌아갈 뿐이다. 반대 방향(정상 경로 444)은
+# 조용히 깨지고 아무도 모른다.
+#
+# ── 정상 경로 예외 ──────────────────────────────────────────────────────────
+# ^~ 프리픽스는 정규식보다 우선하므로 아래 두 블록과 acme-challenge.inc가 선점한다.
+# 둘 다 정적 자산 루트라 경로가 고정이다(경로 파라미터가 없어 늘어날 일이 없다).
 
+# 관리자 UI 스타일시트
 location ^~ /css/ {
     proxy_pass $upstream;
     include /etc/nginx/conf.d/proxy-http.inc;
 }
 
-location ~ "\." {
+# springdoc Swagger UI. dev 전용이지만(application-dev.yml) prod에서도 include한다 —
+# prod는 springdoc이 꺼져 있어 앱이 404를 주므로 무해하고, 환경별로 갈라두면 한쪽만 고치게 된다.
+location ^~ /swagger-ui {
+    proxy_pass $upstream;
+    include /etc/nginx/conf.d/proxy-http.inc;
+}
+
+# ── 차단 규칙 ───────────────────────────────────────────────────────────────
+
+# 1) 닷파일·닷디렉터리 — 세그먼트가 점으로 시작한다.
+#    /.env, /.git/config, /publics/.git/config, /api/.env.save, /.aws/credentials, /.bash_history
+#    정상 경로 파라미터(IPv4·닉네임)는 점으로 **시작**하지 않으므로 걸리지 않는다.
+#    /.well-known/acme-challenge/ 는 acme-challenge.inc의 ^~ 가 선점한다.
+location ~ "(^|/)\." {
     return 444;
 }
+
+# 2) 파일 확장자 — REST 엔드포인트도 Thymeleaf 관리자 페이지도 확장자를 쓰지 않는다.
+#    끝의 ($|[^a-z0-9]) 는 `.php.old`·`.php~`·`.php'` 처럼 뒤에 뭐가 붙은 변형까지 잡되
+#    `.phpx` 같은 무관한 문자열은 건드리지 않는다(nginx가 %2e 를 먼저 디코딩하므로
+#    로그의 /aws%2ephp%2eold 도 여기서 걸린다).
+location ~* "\.(php\d?|phtml|aspx?|jsp|cgi|pl|py|rb|sh|bash|js|ts|css|map|env|ini|conf|cfg|config|properties|toml|ya?ml|json|xml|sql|db|sqlite|dump|mongodump|mysql|pgsql|bak|backup|old|orig|save|swp|tmp|temp|log|zip|gz|tgz|bz2|xz|rar|7z|tar|pem|key|crt|cer|p12|pfx|jks|keystore|tfstate|htpasswd|htaccess|inc)($|[^a-z0-9])" {
+    return 444;
+}
+
+# 알려진 확장자 목록이라 새 확장자에는 뚫린다 — 의도한 것이다(위 "실패 방향" 참조).
+# 앱의 MaliciousPathMatcher는 그대로 둔다: nginx를 통과한 요청과 내부 리스너를 받는 뒷단이다.


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1641

# 🚀 작업 내용

**배경.** 스캐너 한 대(`185.177.72.9`)가 초당 4건씩 수백 개 경로(`/.env`, `/.git/config`, `/wp-admin/**.php`, `/backup.sql`, `/config.json` …)를 훑는 트래픽이 운영에 계속 들어온다. 지금은 앱의 `IpBlockFilter`가 막고 있는데, **nginx를 통과해 앱까지 들어온 뒤에야** 막힌다. 차단은 되지만 앱 CPU·WARN 로그·Redis 쓰기를 그대로 쓴다. 게다가 403 본문을 돌려주는 것 자체가 스캐너에게 "이 서버는 살아있다"는 신호가 된다. nginx 단에서 이미 판별 가능한 요청이므로 엣지에서 끊는다.

`444`는 nginx 전용 코드로, **아무 응답도 보내지 않고 연결을 끊는다.**

1. **`docker/nginx/conf/01-default-server.conf` 신설 — IP 직접 접근 차단**

   `default_server`를 지정한 곳이 없었다. `conf.d`는 파일명 알파벳 순으로 읽히므로 첫 server 블록인 `dev.conf`가 :80·:443의 기본 서버 노릇을 하고 있었다. 즉 **도메인 없이 IP만 찍는 대역 스캔이 dev 앱까지 그대로 들어온다.** 받아내는 전용 블록을 세워 :80은 `return 444`, :443은 `ssl_reject_handshake on`으로 처리한다.

   - `ssl_reject_handshake`는 SNI(접속할 도메인 이름)가 없거나 우리 도메인이 아니면 인증서도 내밀지 않고 TLS 협상 단계에서 거절한다.
   - **인증서 갱신이 깨지지 않도록** :80 블록은 `acme-challenge.inc`를 include한 뒤에 444한다. 아직 어느 `server_name`에도 없는 도메인의 Let's Encrypt 검증이 이 블록으로 떨어질 수 있기 때문이다.

2. **`docker/nginx/conf/scanner-block.inc` 신설 — 스캐너 경로 차단**

   두 가지만 막는다.

   | 규칙 | 잡는 것 |
   | --- | --- |
   | 세그먼트가 점으로 시작 — `(^\|/)\.` | `/.env`, `/.git/config`, `/publics/.git/config`, `/.aws/credentials`, `/.bash_history` |
   | 알려진 파일 확장자 | `.php` `.sql` `.bak` `.pem` `.tfstate` `.mongodump` 등. 끝의 `($\|[^a-z0-9])`로 `.php.old`·`.php~` 변형까지 잡되 `.phpx`는 안 건드린다 |

   > **처음엔 "경로에 점(`.`)이 있으면 전부 차단"으로 짰다가 리뷰에서 뒤집었다.** "이 호스트의 정상 경로에는 점이 없다"는 전제가 **경로 파라미터에서 거짓**이었다. 실제로 세 군데가 죽고 있었다 — `POST /admin/ip-blocks/1.2.3.4/unblock`(IPv4, **IP 차단 해제 수단**), `DELETE /rooms/{code}/players/{nickname}`(`PlayerName`은 문자 집합을 제한하지 않는다), `/swagger-ui/swagger-ui.css`(dev). 자세한 경위는 [리뷰 코멘트](https://github.com/woowacourse-teams/2025-zzol/pull/1645#issuecomment-5192887709) 참조.

   **실패 방향을 뒤집은 게 핵심이다.** 목록에 없는 확장자는 앱까지 가지만 거기서 `IpBlockFilter`가 받는다 — 뚫리는 게 아니라 원래 위치로 돌아갈 뿐이다. 반대 방향(정상 경로가 444)은 조용히 깨지고 아무도 모른다.

   정상 경로 예외는 `^~` 프리픽스가 정규식보다 먼저 매칭되는 nginx 규칙으로 선점한다. 둘 다 **정적 자산 루트**라 경로가 고정이다(경로 파라미터가 없어 늘어날 일이 없다).

   | 예외 | 위치 |
   | --- | --- |
   | `/.well-known/acme-challenge/` | `acme-challenge.inc` (기존) |
   | `/css/*.css` (관리자 UI) | `scanner-block.inc`의 `location ^~ /css/` |
   | `/swagger-ui/**` (dev springdoc) | `scanner-block.inc`의 `location ^~ /swagger-ui` |

3. **`dev.conf`·`prod.conf`: `location /ws` → `location = /ws` + `location ^~ /ws/`**

   SockJS는 폴백 전송에 `/ws/iframe.html`을 쓰므로 정규식보다 선점해야 한다. 다만 `^~ /ws` 하나로 묶으면 `/ws`로 **시작하기만** 하면 되므로 `/ws.php`·`/wsdl.xml`·`/wso.php`(웹셸 스캔) 같은 스캐너 경로까지 면제된다(리뷰에서 실측 확인). 엔드포인트는 `/ws` 정확일치와 그 하위뿐이다.

4. **`.github/workflows/edge-config-ci.yml`에 `nginx -t` job 추가**

   엣지 설정 CI가 XFF 헤더 include만 검사하고 문법 검증은 하지 않았다. 오타가 배포 시점에야 터지면 엣지가 통째로 내려간다. 인증서는 실물이 없으니 자체서명으로 대체하고, 이미지 태그는 `docker-compose.yml`에서 읽어 버전을 두 곳에 적지 않게 했다.

5. **`.github/scripts/deploy-edge.sh`의 배포 프로브 2줄 추가**

   `nginx -t`도 기존 프로브(`/ws/info`)도 위의 오차단을 통과시켰다. 라우팅 정책을 바꾸는 PR이므로 그 그물을 같이 넓힌다. 444는 연결 종료(=`000`)라 `_probe`가 실패로 보고 **자동 원복**된다.

   ```bash
   _probe "api.zzol.site" "/admin/ip-blocks/1.2.3.4/unblock"   # 경로 파라미터
   _probe "api.zzol.site" "/css/admin.css"                     # ^~ 예외
   ```

**앱의 `MaliciousPathMatcher`는 그대로 둔다.** nginx를 통과한 요청과 내부 리스너를 받는 뒷단이다. 다만 `/.env` 같은 경로가 앱에 안 닿으므로 **그 IP를 Redis에 즉시 차단하던 흐름은 끊긴다** — 444는 비용이 0이라 감수할 만하다고 봤고, `scanner-block.inc` 주석에 남겼다.

## 검증

nginx 1.30.2 컨테이너를 실제로 띄워 **40개 경로**를 확인했다(전부 통과). 테스트 환경에 upstream 앱이 없으므로 **502는 "location에 도달했다"**, 444는 "연결이 끊겼다"는 뜻이다.

**차단(444) 17건** — 닷파일·닷디렉터리·중첩(`/publics/.git/config`)·URL 인코딩(`/aws%2ephp%2eold`)·다중 확장자(`.tfstate.lock.info.conf`)·물결(`.php~`)·`/ws.php`·`/wsdl.xml`

**통과(502) 22건** — `/rooms` `/users` `/admin/login` `/api/rooms/{code}/recovery` `/admin/ip-blocks/1.2.3.4/unblock` `/rooms/X/players/a.b` `/rooms/X/players/3.14` `/css/admin.css` `/css/admin/table.css` `/swagger-ui/index.html` `/swagger-ui/swagger-ui-bundle.js` `/swagger-ui.html` `/v3/api-docs` `/ws` `/ws/info` `/ws/iframe.html` `/ws/000/abc/websocket` `/favicon.ico` OAuth2 콜백·시작 경로

**기존 유지 1건** — `/internal/**` → 404 (ADR-0032)

그 밖에 확인한 것: IP 직접 접근·SNI 없는 TLS → 거절 / `/.well-known/acme-challenge/`는 unknown Host에서도 acme location 도달(갱신 정상) / HTTP/2 유지(`curl --http2` → `http_version=2`) / blackbox WS 프로브는 SNI를 보내므로 무사 / `check-nginx-proxy-headers.py` 통과(새 `^~` location들도 XFF include 보유).

# 💬 리뷰 중점사항

1. **확장자 목록 방식으로 좁힌 판단.** 처음엔 "점 있으면 전부 차단"이었는데 리뷰에서 정상 경로 3건이 죽는 게 드러나 뒤집었습니다. 지금 방식은 **목록에 없는 확장자에 뚫립니다** — 대신 뚫려도 앱의 `IpBlockFilter`로 돌아갈 뿐이고, 반대 방향(정상 경로 444)은 조용히 깨집니다. 이 실패 방향 선택이 이 PR의 핵심 판단입니다.

2. **닉네임이 확장자로 끝나면 여전히 막힙니다.** `a.js`, `x.sh` 같은 10자 이하 닉네임은 `DELETE /rooms/X/players/a.js`가 444입니다. 실사용 확률이 낮다고 보고 남겨뒀는데, 제대로 막으려면 `PlayerName`에 문자 집합 검증을 넣는 쪽이 맞다고 봅니다(별도 이슈감). 의견 주세요.

3. **`ssl_reject_handshake on`의 영향 범위.** SNI를 보내지 않는 클라이언트는 접속이 아예 안 됩니다. 확인한 바로는 브라우저·프론트·blackbox WS 프로브(`blackbox.yml`의 `server_name: api.zzol.site`)·edge-cd 프로브(`curl --resolve`) 모두 SNI를 보냅니다. 놓친 클라이언트가 있는지 봐주세요.

4. **`monitor.conf`(Grafana)에는 적용하지 않았습니다.** Grafana는 `/public/build/*.js` 같은 점 있는 경로를 정상적으로 씁니다. 의도적으로 뺐습니다.

5. **후속 이슈 #1643** — 정찰 중 `00-common.conf`의 `limit_req_zone` 4개(`room_create`·`room_join`·`api_general`·`ws_handshake`)가 **정의만 되어 있고 `limit_req` 적용은 0건**인 걸 발견했습니다. 주석에 근거까지 적혀 있어 동작 중으로 읽히지만 실제로는 무제한입니다. 이번 PR 범위(경로 기반 차단)와 축이 달라 분리했습니다.
