### PR TITLE
[fix] 셧다운 메트릭 노이즈 제거 — XLEN 게이지 SmartLifecycle 적용 + OTLP 메트릭 export 비활성화

### DIFF
--- a/backend/app/src/main/resources/config/monitoring.yml
+++ b/backend/app/src/main/resources/config/monitoring.yml
@@ -21,6 +21,13 @@ management:
   otlp:
     tracing:
       endpoint: ${TEMPO_URL}
+    # 메트릭은 아래 prometheus scrape 로 걷는다. OTLP 메트릭 push 는 트레이싱용
+    # spring-boot-starter-opentelemetry 가 micrometer-registry-otlp 를 딸려오면서 기본값 true 로
+    # 켜진 것뿐이라, 아무도 설정하지 않은 URL(micrometer 기본값 localhost:4318/v1/metrics)로 매 step
+    # 푸시하다 실패한다. 위 tracing 과는 별개 오토컨피그(OtlpMetricsExportAutoConfiguration)라 영향 없다
+    metrics:
+      export:
+        enabled: false
   metrics:
     enable:
       tomcat: true

--- a/backend/app/src/test/java/coffeeshout/global/lifecycle/ShutdownPhaseOrderTest.java
+++ b/backend/app/src/test/java/coffeeshout/global/lifecycle/ShutdownPhaseOrderTest.java
@@ -1,0 +1,80 @@
+package coffeeshout.global.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import coffeeshout.support.app.IntegrationTestSupport;
+import coffeeshout.websocket.lifecycle.WebSocketGracefulShutdownHandler;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.server.context.WebServerGracefulShutdownLifecycle;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.socket.config.WebSocketMessageBrokerStats;
+
+/**
+ * 종료 시 {@link SmartLifecycle} 빈이 멈추는 순서를 고정한다.
+ *
+ * <p>순서표의 절반은 우리가 소유하지 않은 phase다(Spring Boot의 웹서버 라이프사이클,
+ * spring-data-redis의 커넥션 팩토리). 그 값이 바뀌면 각 클래스의 주석은 조용히 거짓말하지만
+ * 이 테스트는 깨진다 — 우리 값만 모은 상수 클래스로는 잡을 수 없는 드리프트를 잡는 것이 존재 이유다.
+ * 실제로 {@code WebSocketGracefulShutdownHandler}의 주석이 {@code WebServerGracefulShutdownLifecycle}을
+ * {@code MAX_VALUE}로 적고 있었으나 실제 값은 {@code MAX-1024}였다(#1642).</p>
+ *
+ * <p>기대 순서의 근거는 docs/architecture.md "종료 순서 (lifecycle phase)"에 있다.
+ * 표를 고치면 이 테스트도 같이 고친다.</p>
+ */
+class ShutdownPhaseOrderTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    @DisplayName("종료는 HTTP 요청 → 웹서버 → Stream 폴러 → 게이지 → Redis 커넥션 순으로 멈춘다")
+    void 컨텍스트의_lifecycle_빈이_문서화된_phase_순서를_따른다() {
+        // when: phase 내림차순 = stop 호출 순서
+        List<String> stopOrder = stopOrder();
+
+        // then: 사이에 다른 빈이 끼는 것은 무방하나, 이 다섯의 상대 순서는 계약이다
+        assertThat(stopOrder).containsSubsequence(
+                "WebServerGracefulShutdownLifecycle",
+                "WebServerStartStopLifecycle",
+                "RedisStreamContainerRegistry",
+                "RedisStreamLagMetricService",
+                "LettuceConnectionFactory"
+        );
+    }
+
+    @Test
+    @DisplayName("WS 세션 드레인은 HTTP 요청 드레인보다 먼저 멈춘다")
+    void WS_드레인_핸들러가_웹서버_드레인보다_먼저_멈춘다() {
+        // WebSocketGracefulShutdownHandler 는 @Profile("!test") 라 테스트 컨텍스트에 없다.
+        // getPhase() 는 상수 반환이므로 협력자 없이 값만 비교한다
+        int webSocketDrain = webSocketShutdownHandler().getPhase();
+
+        // then: 높은 phase 가 먼저 멈춘다. HTTP 요청 드레인이 시작되기 전에 WS 세션을 정리해야 한다
+        assertThat(webSocketDrain)
+                .isGreaterThan(WebServerGracefulShutdownLifecycle.SMART_LIFECYCLE_PHASE);
+    }
+
+    private WebSocketGracefulShutdownHandler webSocketShutdownHandler() {
+        return new WebSocketGracefulShutdownHandler(
+                mock(WebSocketMessageBrokerStats.class),
+                mock(TaskScheduler.class),
+                Duration.ofMinutes(5)
+        );
+    }
+
+    private List<String> stopOrder() {
+        return applicationContext.getBeansOfType(SmartLifecycle.class).values().stream()
+                .sorted(Comparator.comparingInt(SmartLifecycle::getPhase).reversed())
+                .map(bean -> ClassUtils.getUserClass(bean).getSimpleName())
+                .toList();
+    }
+}

--- a/backend/app/src/test/java/coffeeshout/global/lifecycle/ShutdownPhaseOrderTest.java
+++ b/backend/app/src/test/java/coffeeshout/global/lifecycle/ShutdownPhaseOrderTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.context.WebServerGracefulShutdownLifecycle;
+import org.springframework.boot.web.server.context.WebServerApplicationContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.scheduling.TaskScheduler;
@@ -60,7 +60,7 @@ class ShutdownPhaseOrderTest extends IntegrationTestSupport {
 
         // then: 높은 phase 가 먼저 멈춘다. HTTP 요청 드레인이 시작되기 전에 WS 세션을 정리해야 한다
         assertThat(webSocketDrain)
-                .isGreaterThan(WebServerGracefulShutdownLifecycle.SMART_LIFECYCLE_PHASE);
+                .isGreaterThan(WebServerApplicationContext.GRACEFUL_SHUTDOWN_PHASE);
     }
 
     private WebSocketGracefulShutdownHandler webSocketShutdownHandler() {

--- a/backend/app/src/test/resources/application-mysql-performance.yml
+++ b/backend/app/src/test/resources/application-mysql-performance.yml
@@ -36,6 +36,10 @@ management:
   otlp:
     tracing:
       endpoint: http://localhost:4318
+    # 트레이싱과 마찬가지로 메트릭 push 도 끈다 — 수집기가 없어 매 step 실패한다
+    metrics:
+      export:
+        enabled: false
 
 logging:
   level:

--- a/backend/app/src/test/resources/application-test.yml
+++ b/backend/app/src/test/resources/application-test.yml
@@ -69,6 +69,11 @@ management:
   otlp:
     tracing:
       endpoint: http://localhost:4318
+    # 이 파일은 application-test-base.yml 을 import 하지 않으므로 여기에도 따로 끈다 —
+    # 켜두면 컨텍스트 종료마다 localhost:4318 로 메트릭 푸시를 시도해 실패 스택트레이스가 찍힌다
+    metrics:
+      export:
+        enabled: false
   endpoint:
     health:
       group:

--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -130,6 +130,36 @@
 
 ---
 
+## 종료 순서 (lifecycle phase)
+
+`SmartLifecycle` 빈의 `stop()`은 **phase 내림차순**으로 호출된다. 값 자체보다 **상대 순서**가 계약이며,
+표의 절반은 우리가 소유하지 않은 값이다 — 라이브러리가 바꾸면 우리 주석은 조용히 거짓말한다.
+그래서 순서는 `ShutdownPhaseOrderTest`가 실제 컨텍스트에서 검증한다. **이 표를 고치면 그 테스트도 같이 고친다.**
+
+| phase | 빈 | 하는 일 | 소유 |
+| --- | --- | --- | --- |
+| `MAX-1` | `WebSocketGracefulShutdownHandler` | WS 세션 드레인 | **우리** (`:websocket`) |
+| `MAX-1024` | `WebServerGracefulShutdownLifecycle` | HTTP 요청 드레인 | Spring Boot |
+| `MAX-2048` | `WebServerStartStopLifecycle` | 웹서버 stop | Spring Boot |
+| `1024` | `RedisStreamContainerRegistry` | Stream 폴러 정지 | **우리** (`:infra`) |
+| `512` | `RedisStreamLagMetricService` | XLEN 게이지 소등 | **우리** (`:infra`) |
+| `0` | `LettuceConnectionFactory` | Redis 커넥션 정지 | spring-data-redis |
+
+각 자리의 근거:
+
+- **WS 세션 드레인이 가장 먼저** — HTTP 요청 드레인이 시작되기 전에 클라이언트를 정리해야 세션이 끊기지 않는다.
+- **폴러 정지(1024)가 커넥션 팩토리(0)보다 먼저** — 순서가 뒤집히면 폴러가 정지된 팩토리에 무한 재시도한다 (ADR-0022).
+- **게이지 소등(512)이 폴러 정지 뒤, 커넥션 팩토리 앞** — 폴러가 멈춘 뒤에도 백로그는 관측 대상이다.
+  기본값(`Integer.MAX_VALUE`)으로 두면 드레인(`spring.lifecycle.timeout-per-shutdown-phase: 5m`) 내내
+  액추에이터는 살아 스크레이핑되는데 게이지만 NaN이 된다 (#1642).
+
+컨텍스트 종료 전체 순서는 `AbstractApplicationContext.doClose()`가 정한다 —
+① `ContextClosedEvent` 발행 → ② 위 표의 lifecycle stop → ③ 빈 파괴. **이벤트가 stop보다 먼저**이므로,
+`ContextClosedEvent` 리스너(예: 마지막 metric publish를 수행하는 `MeterRegistryCloser`)와
+lifecycle stop 사이의 순서는 phase로 조정할 수 없다.
+
+---
+
 ## 게임 SPI 패턴
 
 새 게임을 추가할 때 기존 코드를 수정하지 않아도 된다 (OCP).

--- a/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
@@ -35,15 +36,25 @@ import org.springframework.stereotype.Component;
  *   <li>redis_stream_threadpool_active_count (tag: stream)</li>
  * </ul>
  * </p>
+ *
+ * <p>종료 시 Redis를 조회하지 않는다({@link SmartLifecycle}). 컨텍스트 종료는
+ * ① Lifecycle 빈 stop → ② {@code ContextClosedEvent} → ③ {@code MeterRegistryCloser}가
+ * 마지막 publish를 수행하며 <b>모든 Gauge를 평가</b> 순서로 진행된다. ①에서 이미 멈춘
+ * {@code LettuceConnectionFactory}(phase 0)를 ③의 게이지가 호출하면
+ * {@code IllegalStateException: ... has been STOPPED}가 스트림 수만큼 터진다(#1642).
+ * 기본 phase({@link SmartLifecycle#DEFAULT_PHASE})는 0보다 크므로 이 빈은 커넥션 팩토리보다
+ * 먼저 stop 신호를 받고, 그 뒤 게이지는 Redis를 건드리지 않고 NaN을 낸다.</p>
  */
 @Slf4j
 @Component
-public class RedisStreamLagMetricService {
+public class RedisStreamLagMetricService implements SmartLifecycle {
 
     private final StringRedisTemplate stringRedisTemplate;
     private final RedisStreamProperties redisStreamProperties;
     private final MeterRegistry meterRegistry;
     private final ApplicationContext applicationContext;
+
+    private volatile boolean running = true;
 
     public RedisStreamLagMetricService(
             StringRedisTemplate stringRedisTemplate,
@@ -99,7 +110,28 @@ public class RedisStreamLagMetricService {
                 redisStreamProperties.keys().keySet());
     }
 
+    @Override
+    public void start() {
+        running = true;
+    }
+
+    /**
+     * 컨텍스트 종료 시작 신호. 이후 Redis 조회 게이지는 호출 자체를 건너뛴다.
+     */
+    @Override
+    public void stop() {
+        running = false;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
     private double getStreamLength(String streamKey) {
+        if (!running) {
+            return Double.NaN;
+        }
         try {
             Long length = stringRedisTemplate.opsForStream().size(streamKey);
             return length != null ? length.doubleValue() : 0.0;

--- a/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -37,13 +37,16 @@ import org.springframework.stereotype.Component;
  * </ul>
  * </p>
  *
- * <p>종료 시 Redis를 조회하지 않는다({@link SmartLifecycle}). 컨텍스트 종료는
- * ① Lifecycle 빈 stop → ② {@code ContextClosedEvent} → ③ {@code MeterRegistryCloser}가
- * 마지막 publish를 수행하며 <b>모든 Gauge를 평가</b> 순서로 진행된다. ①에서 이미 멈춘
- * {@code LettuceConnectionFactory}(phase 0)를 ③의 게이지가 호출하면
+ * <p>종료 시 Redis를 조회하지 않는다({@link SmartLifecycle}). {@code AbstractApplicationContext.doClose()}는
+ * ① {@code ContextClosedEvent} 발행 → ② Lifecycle 빈 stop → ③ 빈 파괴 순으로 진행하고,
+ * ①의 이벤트를 받은 {@code MeterRegistryCloser}가 마지막 publish를 수행하며 <b>모든 Gauge를 평가</b>한다.
+ * 이벤트가 stop보다 <b>먼저</b>이므로, 평범한 close에서는 게이지 평가 시점에 커넥션 팩토리가 아직 살아 있다.</p>
+ *
+ * <p>문제가 되는 건 <b>close 이전에 이미 lifecycle이 멈춘 컨텍스트</b>다 — Spring Framework 7의 테스트
+ * 컨텍스트 pause가 그렇다. pause가 lifecycle을 통째로 멈춘 뒤 JVM 종료 시점에 close가 오면, ①의 게이지
+ * 평가가 이미 STOPPED인 {@code LettuceConnectionFactory}를 호출해
  * {@code IllegalStateException: ... has been STOPPED}가 스트림 수만큼 터진다(#1642).
- * 기본 phase({@link SmartLifecycle#DEFAULT_PHASE})는 0보다 크므로 이 빈은 커넥션 팩토리보다
- * 먼저 stop 신호를 받고, 그 뒤 게이지는 Redis를 건드리지 않고 NaN을 낸다.</p>
+ * {@code stop()}에서 내린 플래그가 그 호출 자체를 막아 NaN을 낸다.</p>
  */
 @Slf4j
 @Component
@@ -126,6 +129,16 @@ public class RedisStreamLagMetricService implements SmartLifecycle {
     @Override
     public boolean isRunning() {
         return running;
+    }
+
+    // 종료(stop)는 phase 내림차순이다. 기본값(SmartLifecycle.DEFAULT_PHASE)이면 모든 lifecycle
+    // 빈보다 먼저 멈춰, graceful shutdown 드레인(spring.lifecycle.timeout-per-shutdown-phase=5m) 내내
+    // 액추에이터는 살아 스크레이핑되는데 XLEN 게이지만 NaN이 된다 — 백로그가 빠지는 걸 봐야 할 창이다.
+    // 폴러 정지(RedisStreamContainerRegistry, 1024)보다 뒤, LettuceConnectionFactory(0)보다는 앞이면
+    // 되고, 512는 그 표식이다
+    @Override
+    public int getPhase() {
+        return 512;
     }
 
     private double getStreamLength(String streamKey) {

--- a/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
+++ b/backend/infra/src/main/java/coffeeshout/global/metric/RedisStreamLagMetricService.java
@@ -131,11 +131,8 @@ public class RedisStreamLagMetricService implements SmartLifecycle {
         return running;
     }
 
-    // 종료(stop)는 phase 내림차순이다. 기본값(SmartLifecycle.DEFAULT_PHASE)이면 모든 lifecycle
-    // 빈보다 먼저 멈춰, graceful shutdown 드레인(spring.lifecycle.timeout-per-shutdown-phase=5m) 내내
-    // 액추에이터는 살아 스크레이핑되는데 XLEN 게이지만 NaN이 된다 — 백로그가 빠지는 걸 봐야 할 창이다.
-    // 폴러 정지(RedisStreamContainerRegistry, 1024)보다 뒤, LettuceConnectionFactory(0)보다는 앞이면
-    // 되고, 512는 그 표식이다
+    // 폴러가 멈춘 뒤에도 백로그는 관측 대상이므로 폴러 정지보다 뒤, 조회가 불가능해지는
+    // 커넥션 팩토리 정지보다는 앞에 선다. 전체 순서표는 docs/architecture.md "종료 순서 (lifecycle phase)"
     @Override
     public int getPhase() {
         return 512;

--- a/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
+++ b/backend/infra/src/main/java/coffeeshout/global/redis/config/RedisStreamContainerRegistry.java
@@ -54,10 +54,9 @@ public class RedisStreamContainerRegistry implements SmartLifecycle {
         return containers.values().stream().anyMatch(StreamMessageListenerContainer::isRunning);
     }
 
-    // 종료(stop)는 phase 내림차순이다. 폴러는 웹 트래픽 드레인이 모두 끝난 뒤 멈춰야
-    // 드레인 중 수신된 커맨드의 소비·브로드캐스트가 유지되고(WS 세션 드레인 MAX-1,
-    // Tomcat 드레인 MAX-1024, 웹서버 stop MAX-2048), LettuceConnectionFactory(phase 0)보다는
-    // 먼저 멈춰야 정지된 팩토리에 폴링하지 않는다. 그 사이 값이면 되고, 1024는 그 표식이다
+    // 폴러는 웹 트래픽 드레인이 모두 끝난 뒤 멈춰야 드레인 중 수신된 커맨드의 소비·브로드캐스트가
+    // 유지되고, 커넥션 팩토리 정지보다는 먼저 멈춰야 정지된 팩토리에 폴링하지 않는다 (ADR-0022).
+    // 전체 순서표는 docs/architecture.md "종료 순서 (lifecycle phase)"
     @Override
     public int getPhase() {
         return 1024;

--- a/backend/infra/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
@@ -2,7 +2,10 @@ package coffeeshout.global.metric;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 import coffeeshout.global.redis.config.RedisStreamProperties;
 import coffeeshout.global.redis.config.RedisStreamProperties.CommonSettings;
@@ -145,6 +148,26 @@ class RedisStreamLagMetricServiceTest {
         // then
         Gauge gauge = meterRegistry.find("redis.stream.length").gauge();
         assertThat(gauge).isNull();
+    }
+
+    @Test
+    void 종료_신호를_받으면_게이지가_Redis를_조회하지_않고_Nan를_반환한다() {
+        // given: 종료 전에는 정상 조회된다
+        lagMetricService.initializeMetrics();
+        Gauge gauge = meterRegistry.find("redis.stream.length")
+                .tag("stream", "room")
+                .gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo(42.0);
+
+        // when: 컨텍스트 종료 — Lifecycle stop 은 커넥션 팩토리(phase 0)보다 먼저 온다
+        clearInvocations(stringRedisTemplate);
+        lagMetricService.stop();
+
+        // then: 마지막 publish 가 게이지를 평가해도 이미 닫힌 커넥션을 건드리지 않는다 (#1642)
+        assertThat(gauge.value()).isNaN();
+        assertThat(lagMetricService.isRunning()).isFalse();
+        then(stringRedisTemplate).should(never()).opsForStream();
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/infra/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
+++ b/backend/infra/src/test/java/coffeeshout/global/metric/RedisStreamLagMetricServiceTest.java
@@ -160,14 +160,23 @@ class RedisStreamLagMetricServiceTest {
         assertThat(gauge).isNotNull();
         assertThat(gauge.value()).isEqualTo(42.0);
 
-        // when: 컨텍스트 종료 — Lifecycle stop 은 커넥션 팩토리(phase 0)보다 먼저 온다
+        // when: 종료 신호 (컨텍스트 pause 또는 close 의 lifecycle stop 단계)
         clearInvocations(stringRedisTemplate);
         lagMetricService.stop();
 
-        // then: 마지막 publish 가 게이지를 평가해도 이미 닫힌 커넥션을 건드리지 않는다 (#1642)
+        // then: 이후 게이지가 평가돼도 이미 닫힌 커넥션을 건드리지 않는다 (#1642)
         assertThat(gauge.value()).isNaN();
         assertThat(lagMetricService.isRunning()).isFalse();
         then(stringRedisTemplate).should(never()).opsForStream();
+    }
+
+    @Test
+    void 게이지는_폴러_정지_뒤_커넥션_팩토리_정지_전에_멈춘다() {
+        // 종료는 phase 내림차순이다. RedisStreamContainerRegistry(1024)가 폴러를 멈춘 뒤에도
+        // 백로그는 관측 대상이고, LettuceConnectionFactory(0)가 멈춘 뒤에는 조회가 불가능하다
+        assertThat(lagMetricService.getPhase())
+                .isGreaterThan(0)
+                .isLessThan(1024);
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/test-support/src/main/resources/application-test-base.yml
+++ b/backend/test-support/src/main/resources/application-test-base.yml
@@ -126,6 +126,11 @@ management:
   otlp:
     tracing:
       endpoint: http://localhost:4318
+    # 테스트 컨텍스트도 OtlpMeterRegistry 를 만들어 종료마다 localhost:4318 로 푸시를 시도한다.
+    # 이 파일은 config/monitoring.yml 을 import 하지 않으므로 여기에도 따로 끈다
+    metrics:
+      export:
+        enabled: false
 
 resilience4j:
   ratelimiter:

--- a/backend/websocket/src/main/java/coffeeshout/websocket/lifecycle/WebSocketGracefulShutdownHandler.java
+++ b/backend/websocket/src/main/java/coffeeshout/websocket/lifecycle/WebSocketGracefulShutdownHandler.java
@@ -173,8 +173,9 @@ public class WebSocketGracefulShutdownHandler implements SmartLifecycle {
 
     @Override
     public int getPhase() {
-        // WebServerGracefulShutdownLifecycle(MAX_VALUE)이 먼저 Tomcat을 닫은 뒤
-        // 이 핸들러가 남은 WS 세션을 드레인한다
+        // 가장 먼저 멈춘다 — HTTP 요청 드레인(WebServerGracefulShutdownLifecycle, MAX-1024)이
+        // 시작되기 전에 WS 세션을 정리해야 한다.
+        // 전체 순서표는 docs/architecture.md "종료 순서 (lifecycle phase)"
         return Integer.MAX_VALUE - 1;
     }
 


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1642

# 🚀 작업 내용

1. `RedisStreamLagMetricService`가 `SmartLifecycle`을 구현한다. `stop()`에서 `running` 플래그를 내리고, `getStreamLength()`는 플래그가 내려가 있으면 **Redis 호출 없이** 바로 `Double.NaN`을 반환한다.
2. `getPhase()`를 **512**로 명시한다. 기본값이면 드레인 내내 게이지가 NaN이 된다(아래 상세).
3. **OTLP 메트릭 export를 끈다.** 같은 종료 경로에서 나던 `ConnectException` 스택트레이스의 원인이다(아래 상세).
4. **종료 순서표를 `docs/architecture.md`에 모으고**, `ShutdownPhaseOrderTest`로 순서를 고정한다(아래 상세).
5. 종료 후 게이지가 `StringRedisTemplate`을 호출하지 않는지, phase가 의도한 구간에 있는지 검증하는 테스트를 추가했다.

## 무엇이 문제였나

애플리케이션·테스트 컨텍스트를 내릴 때마다 등록된 스트림 수만큼(`racinggame`·`nunchi`·`laddergame`·`cardgame:select`·`minigame` …) 아래 로그가 스택트레이스째 반복됐다.

```text
WARN c.g.metric.RedisStreamLagMetricService : XLEN 조회 실패: stream=racinggame
java.lang.IllegalStateException: LettuceConnectionFactory has been STOPPED. Use start() to initialize it
    at ...RedisStreamLagMetricService.getStreamLength(RedisStreamLagMetricService.java:104)
    at ...OtlpMeterRegistry.close(OtlpMeterRegistry.java:320)
    at ...MetricsAutoConfiguration$MeterRegistryCloser.onApplicationEvent(...)
```

그리고 같은 `MeterRegistryCloser` 트리거로 이것도 함께 나왔다.

```text
java.lang.Exception: java.net.ConnectException
    at io.micrometer.registry.otlp.OtlpHttpMetricsSender.send(OtlpHttpMetricsSender.java:64)
    at io.micrometer.registry.otlp.OtlpMeterRegistry.publish(OtlpMeterRegistry.java:193)
    at ...PushMeterRegistry.close(PushMeterRegistry.java:143)
```

## ⚠️ 정정 — 초기 PR의 종료 순서 설명이 반대였다

이 PR은 처음에 근거를 "① Lifecycle 빈 stop → ② `ContextClosedEvent` → ③ `MeterRegistryCloser`"로 적었다. **①②가 반대다.**

`spring-context-7.0.8`의 `AbstractApplicationContext.doClose()` 바이트코드:

```text
offset 52-61  (line 1190)  publishEvent(new ContextClosedEvent(this))
offset 88-92  (line 1199)  lifecycleProcessor.onClose()
offset 115                 destroyBeans()
```

실제 컨텍스트를 띄워 재확인:

```text
--- closing ---
1) ContextClosedEvent 리스너            (MeterRegistryCloser 자리)
2) SmartLifecycle.stop() phase=2147483647
3) SmartLifecycle.stop() phase=0        (LettuceConnectionFactory 자리)
```

이벤트가 stop보다 **먼저**다. 그러므로:

- 평범한 `close()`에서는 게이지 평가 시점에 커넥션 팩토리가 **아직 살아 있다** — 이 경로에서는 애초에 예외가 나지 않는다.
- 예외가 나는 건 **close 이전에 이미 lifecycle이 멈춘 컨텍스트**다. Spring Framework 7의 테스트 컨텍스트 pause가 그렇다(`RedisStreamContainerRegistry` 주석이 이미 언급한다). pause가 lifecycle을 통째로 멈춘 뒤 JVM 종료 시점에 close가 오면, 이벤트 단계의 게이지 평가가 STOPPED 상태의 팩토리를 잡는다.

**수정 자체는 그대로 유효하다.** pause가 끝난 뒤 close가 오므로 플래그는 이미 내려가 있다. 다만 근거가 틀렸으므로 Javadoc·테스트 주석·이슈 본문을 모두 바로잡았다.

# 💬 리뷰 중점사항

### `getPhase()`를 512로 명시한 이유 (초기 PR에서 뒤집힌 결론)

초기 PR은 "기본 phase가 `Integer.MAX_VALUE`라 커넥션 팩토리(0)보다 먼저 멈추니 오버라이드하지 않는다"고 했다. 위 정정에 따라 **phase는 `MeterRegistryCloser`와의 순서에 아무 영향이 없다.** 이벤트가 언제나 먼저이기 때문이다.

대신 phase를 명시할 **다른** 이유가 있다. 기본값 `Integer.MAX_VALUE`는 이 빈을 **모든** lifecycle 빈보다 먼저 멈춘다 — 드레인 단계(WS `MAX-1`, Tomcat `MAX-1024`, 웹서버 `MAX-2048`)보다도 앞이다. `config/server.yml`이 `server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase: 5m`이므로, **드레인이 도는 최대 5분 내내 액추에이터는 살아 스크레이핑되는데 `redis_stream_length`만 전 스트림 NaN**이 된다. 백로그가 빠지는 걸 봐야 할 바로 그 창이다.

512는 `RedisStreamContainerRegistry`(1024, 폴러 정지)보다 뒤 · `LettuceConnectionFactory`(0)보다 앞이라는 표식이다. 팩토리의 phase가 0인 것은 `spring-data-redis-4.1.0` 바이트코드에서 필드 초기화가 `iconst_0`임을 확인했다. 순서는 **폴러 정지(1024) → 게이지 소등(512) → 커넥션 팩토리 정지(0)** 이 된다.

### OTLP 메트릭 export를 끈 이유

`management.otlp.metrics.export.enabled: false`.

**왜 켜져 있었나.** `OtlpMetricsExportAutoConfiguration`의 클래스 레벨 조건은 `@ConditionalOnEnabledMetricsExport("otlp")` + `@ConditionalOnClass(OtlpMeterRegistry.class)`이고, 그 프로퍼티의 **기본값이 `true`**다(`spring-boot-micrometer-metrics-4.1.0` 설정 메타데이터 확인). `infra/build.gradle.kts:27`의 `spring-boot-starter-opentelemetry`는 **트레이싱용**으로 넣은 것인데, 이게 `micrometer-registry-otlp`를 딸려오는 순간 메트릭 exporter까지 자동으로 켜졌다. 아무도 의도한 적 없다.

**왜 꺼야 하나.** 이 프로젝트는 메트릭을 **Prometheus scrape(풀)** 로 걷는다. OTLP는 **푸시**라 `management.otlp.metrics.export.url`로 매 step(기본 1분) 전송하는데, 그 URL을 설정한 적이 없어 micrometer 기본값 `http://localhost:4318/v1/metrics`로 나간다. 즉 **같은 메트릭을 이미 스크레이핑으로 걷는 상태에서**, 존재하지 않는 수집기로 1분마다 커넥트 타임아웃(1s)을 태우고 종료 때 한 번 더 실패한다. 로그 오염이자 실비용이다.

**영향 없음.**

| 항목 | 영향 | 근거 |
| --- | --- | --- |
| Prometheus 메트릭 | **없음** | `management.prometheus.metrics.export.enabled: true`는 그대로. 레지스트리가 서로 독립이라 미터 등록·`/actuator/prometheus` 노출 모두 불변 |
| Tempo 트레이싱 | **없음** | 트레이싱은 `OtlpTracingAutoConfiguration`이 `management.otlp.tracing.*`로 따로 설정한다. OTLP라는 **프로토콜만** 공유할 뿐 오토컨피그·프로퍼티 트리·엔드포인트가 전부 별개 |
| 애플리케이션 코드 | **없음** | 설정 4줄. `@ConditionalOnEnabledMetricsExport`가 클래스 레벨이라 `false`면 오토컨피그가 아예 안 돌고 `OtlpMeterRegistry` 빈이 생기지 않는다 — "빈은 있는데 조용한" 상태가 아니라 존재 자체가 없어진다 |
| 나중에 OTLP 수집기를 붙일 때 | 없음 | 이 한 줄을 `true`로 되돌리고 `management.otlp.metrics.export.url`을 지정하면 된다 |

**넣은 위치가 4곳인 이유.** 설정 import 체인이 갈라져 있어 한 곳으로 모을 수 없다.

- `app/src/main/resources/config/monitoring.yml` — `application.yml`이 import하므로 local·dev·prod 전부 커버
- `test-support/src/main/resources/application-test-base.yml` — 이걸 import하는 7개 모듈 테스트
- `app/src/test/resources/application-test.yml` — test-base를 import하지 않는다(`application-test-game.yml`만 import)
- `app/src/test/resources/application-mysql-performance.yml` — 별도 프로파일. 이미 `OtlpTracingAutoConfiguration`을 제외하고 있어 의도가 일치한다

### 종료 순서표를 문서 한 곳으로 모았다 (상수 클래스를 만들지 않은 이유)

phase 값이 3개 클래스에 흩어져 있고 각자 전체 순서를 주석으로 되풀이하고 있었다. 상수 클래스로 모으는 안을 검토했으나 **하지 않았다.**

**이유 1 — 놓을 데가 없다.** `:infra`와 `:websocket`은 서로 의존하지 않는다. 공유 지점은 `:common`뿐인데 CLAUDE.md가 `:common`에 Spring 의존 금지로 못박고 있다.

**이유 2 — 순서표의 절반이 우리 소유가 아니다.** 6칸 중 3칸이 Spring Boot·spring-data-redis 소유다. 복사해 넣으면 라이브러리가 값을 바꿔도 우리 상수는 조용히 거짓말하는 **낡은 거울**이 된다.

**이유 3 — 이미 그 일이 나 있었다.** `WebSocketGracefulShutdownHandler:175` 주석이 `WebServerGracefulShutdownLifecycle`을 `MAX_VALUE`로 적고 있었는데 실제는 **`MAX-1024`**(바이트코드 확인)다. 게다가 `MAX-1 > MAX-1024`이므로 이 핸들러가 **먼저** 멈추는데, 주석은 "Tomcat을 닫은 뒤 이 핸들러가 드레인한다"고 반대로 적혀 있었다. **상수 클래스였어도 이건 못 잡는다** — 틀린 값이 우리 것이 아니기 때문이다. 이번에 주석만 바로잡았다(값은 그대로, 동작은 의도대로다).

그래서 **문서 한 곳 + 순서를 고정하는 테스트**로 갔다.

`docs/architecture.md`의 새 절 "종료 순서 (lifecycle phase)" — **소유자 컬럼**을 남겨 무엇이 우리 계약이고 무엇이 라이브러리 사정인지 구분한다.

| phase | 빈 | 하는 일 | 소유 |
| --- | --- | --- | --- |
| `MAX-1` | `WebSocketGracefulShutdownHandler` | WS 세션 드레인 | **우리** (`:websocket`) |
| `MAX-1024` | `WebServerGracefulShutdownLifecycle` | HTTP 요청 드레인 | Spring Boot |
| `MAX-2048` | `WebServerStartStopLifecycle` | 웹서버 stop | Spring Boot |
| `1024` | `RedisStreamContainerRegistry` | Stream 폴러 정지 | **우리** (`:infra`) |
| `512` | `RedisStreamLagMetricService` | XLEN 게이지 소등 | **우리** (`:infra`) |
| `0` | `LettuceConnectionFactory` | Redis 커넥션 정지 | spring-data-redis |

각 `getPhase()` 주석은 "왜 그 자리인가" 한 줄 + 표 링크로 줄였다.

`ShutdownPhaseOrderTest`(`:app`)가 순서를 고정한다 — **상수 클래스가 못 하는 일이 이것이다. 라이브러리 phase가 바뀌면 CI가 깨진다.**

- 실제 컨텍스트의 `SmartLifecycle` 빈을 phase 내림차순 정렬해 `containsSubsequence`로 상대 순서만 검증한다(사이에 다른 빈이 끼는 건 무방 → Spring이 라이프사이클 빈을 추가해도 깨지지 않는다).
- `WebSocketGracefulShutdownHandler`는 `@Profile("!test")`라 테스트 컨텍스트에 없다. `getPhase()`가 상수 반환이므로 `WebServerGracefulShutdownLifecycle.SMART_LIFECYCLE_PHASE`(public 상수)와 값만 비교하는 별도 테스트로 덮었다.

> 이 테스트를 쓰면서 실제로 첫 실행이 실패했다 — `@Profile("!test")` 때문에 WS 핸들러가 컨텍스트에 없다는 걸 그때 알았다. 나머지 5개의 순서는 첫 실행부터 기대대로였다.

**상수 클래스가 값어치를 하게 되는 때**: 한 모듈 안에서 우리 라이프사이클 빈이 여러 개가 되어 *서로 간의* 상대 순서가 문제될 때. 지금은 3개가 2개 모듈에 걸쳐 있어 해당하지 않는다.

### 그대로 둔 판단

- **`running` 초기값 `true`**: `isRunning()`이 처음부터 true라 라이프사이클 프로세서가 `start()`를 건너뛴다(플래그를 세우는 것 외에 할 일이 없어 무해하다). 게이지 등록은 지금처럼 `@PostConstruct`가 하므로 시작 순서에 새 결합이 생기지 않는다.
- **예외를 삼키던 기존 동작과의 차이**: 전에도 결과값은 NaN이었지만 매번 예외 생성 + 스택트레이스 로깅 비용을 치렀다. 이제는 호출 자체를 하지 않는다. 종료 전 정상 동작(XLEN 조회, 실패 시 warn)은 그대로다.
- **형제 클래스는 범위 밖**: `SettlementConsumerMetrics`·`RedisStreamLatencyMetricService`도 게이지에서 Redis를 읽지만 실패를 `log.debug`로 삼켜 종료 로그가 조용하다. 구조적 위험은 같으나 증상이 없어 이번 변경에는 넣지 않았다 — 함께 정리하는 게 낫다는 의견이면 말씀 주세요.

### 검증

- `./gradlew :infra:test` — **227건 전부 통과** (52개 테스트 클래스, failures 0 / errors 0). `--rerun` 강제 재실행도 동일.
- 같은 실행 로그에서 `OtlpHttpMetricsSender` **0건**, `java.net.ConnectException` **0건**. 변경 전 종료마다 찍히던 스택트레이스가 사라졌다.
- `./gradlew :app:test --tests "…ShutdownPhaseOrderTest"` — 2건 통과.
- `./gradlew :infra:test :websocket:test` — BUILD SUCCESSFUL.
- `npx markdownlint-cli2` — 0 issues.
- 종료 순서 검증은 `spring-context-7.0.8`을 직접 띄워 확인했다(위 "정정" 절의 출력). Spring 측 phase 값(`MAX-1024`·`MAX-2048`·`0`)은 각 jar의 바이트코드로 확인했다.
