### PR TITLE
[chore] CLAUDE.md 감사 반영 — rules paths 글롭·명령어 문서화·리뷰 호출 서술 통일

### DIFF
--- a/backend/.claude/rules/common.md
+++ b/backend/.claude/rules/common.md
@@ -1,7 +1,7 @@
 ---
 description: 프로덕션·테스트 코드 공통 Java 규칙
 paths:
-  - "src/**/*.java"
+  - "**/src/**/*.java"
 ---
 
 # 공통 Java 코드 규칙

--- a/backend/.claude/rules/docs.md
+++ b/backend/.claude/rules/docs.md
@@ -1,8 +1,8 @@
 ---
 description: docs/ 및 .claude/ 디렉토리 Markdown 파일 작성 규칙 (markdownlint)
 paths:
-- "docs/**/*.md"
-- ".claude/**/*.md"
+- "**/docs/**/*.md"
+- "**/.claude/**/*.md"
 ---
 
 # Markdown 작성 규칙

--- a/backend/.claude/rules/production.md
+++ b/backend/.claude/rules/production.md
@@ -1,7 +1,7 @@
 ---
 description: 프로덕션 코드 작성 시 핵심 체크 항목. 전체 컨벤션은 docs/conventions-production.md 참고.
 paths:
-  - "src/main/java/**/*.java"
+  - "**/src/main/java/**/*.java"
 ---
 
 전체 컨벤션: `docs/conventions-production.md`

--- a/backend/.claude/rules/testing-domain.md
+++ b/backend/.claude/rules/testing-domain.md
@@ -1,7 +1,7 @@
 ---
 description: 도메인 단위 테스트 전용 규칙 — 순수 Java, 컨텍스트 없음. 공통은 testing.md.
 paths:
-  - "src/test/java/**/domain/**/*Test.java"
+  - "**/src/test/java/**/domain/**/*Test.java"
 ---
 
 전체 컨벤션: `docs/conventions-test.md`. 공통 체크: `testing.md`

--- a/backend/.claude/rules/testing-integration.md
+++ b/backend/.claude/rules/testing-integration.md
@@ -1,7 +1,7 @@
 ---
 description: 통합 테스트(IntegrationTest) 전용 규칙 — Docker·컨테이너·WebSocket·스트림. 공통은 testing.md.
 paths:
-  - "src/test/java/**/*IntegrationTest.java"
+  - "**/src/test/java/**/*IntegrationTest.java"
 ---
 
 전체 컨벤션: `docs/conventions-test.md` → 통합 테스트 (WebSocket). 공통 체크: `testing.md`

--- a/backend/.claude/rules/testing-service.md
+++ b/backend/.claude/rules/testing-service.md
@@ -1,7 +1,7 @@
 ---
 description: 서비스 테스트(ServiceTest) 전용 규칙 — Mock 빈·이벤트 퍼블리셔. 공통은 testing.md.
 paths:
-  - "src/test/java/**/*ServiceTest.java"
+  - "**/src/test/java/**/*ServiceTest.java"
 ---
 
 전체 컨벤션: `docs/conventions-test.md`. 공통 체크: `testing.md`

--- a/backend/.claude/rules/testing.md
+++ b/backend/.claude/rules/testing.md
@@ -1,7 +1,7 @@
 ---
 description: 모든 테스트 공통 핵심 체크. 경계별 상세는 testing-integration/service/domain.md, 전체는 docs/conventions-test.md.
 paths:
-  - "src/test/java/**/*.java"
+  - "**/src/test/java/**/*.java"
 ---
 
 전체 컨벤션: `docs/conventions-test.md`

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -31,6 +31,32 @@
 - 구조 파악이 목적이면 Grep 툴로 `public|private|class|interface` 패턴을 잡아 메서드 목록만 먼저 확인한다
 - Java는 파일명 = 클래스명 규칙이 강제되므로 클래스명을 알면 경로를 예측해 바로 Read할 수 있다 (이 경우 Grep 생략 가능)
 
+## 모듈
+
+Gradle 멀티모듈이라 **모든 소스 경로에 모듈명이 앞에 붙는다** — `backend/src/`는 없고 `backend/game/src/main/java/…` 형태다.
+
+| 모듈 | 역할 |
+| --- | --- |
+| `common` | 순수 Java 공용 타입·유틸. **Spring 의존 없음** |
+| `infra` | Redis·MySQL 등 외부 인프라 어댑터 |
+| `web` | HTTP 공통(예외 핸들러·응답 규격) |
+| `websocket` | STOMP 설정·공통 WebSocket 인프라 |
+| `game-api` | 게임 SPI — `room`이 게임을 알기 위한 유일한 통로 |
+| `game` | 미니게임 구현체 (룰렛·사다리·카드·눈치…) |
+| `room` | 방 생성·입장·참가자. `game` 구체 클래스를 몰라야 한다 |
+| `user` | 사용자·인증 |
+| `profanity` | 비속어 필터 |
+| `admin` | 어드민 API |
+| `zzolbot` | 봇 참가자 |
+| `app` | Spring Boot 진입점 — 전 모듈 조립 |
+| `test-support` | 테스트 전용 공통(TestContainers 등). 프로덕션에서 참조 금지 |
+
+단일 클래스 빠른 확인은 모듈을 지정해 돌린다(그 외에는 `/run-tests`):
+
+```bash
+./gradlew :game:test --tests '*CardGameTest'
+```
+
 ## 아키텍처 핵심 제약
 
 위반하면 구조 파괴 또는 런타임 버그로 직결되는 불변 규칙이다.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -31,25 +31,11 @@
 - 구조 파악이 목적이면 Grep 툴로 `public|private|class|interface` 패턴을 잡아 메서드 목록만 먼저 확인한다
 - Java는 파일명 = 클래스명 규칙이 강제되므로 클래스명을 알면 경로를 예측해 바로 Read할 수 있다 (이 경우 Grep 생략 가능)
 
-## 모듈
+## 모듈 경로
 
-Gradle 멀티모듈이라 **모든 소스 경로에 모듈명이 앞에 붙는다** — `backend/src/`는 없고 `backend/game/src/main/java/…` 형태다.
+Gradle 멀티모듈이라 **모든 소스 경로에 모듈명이 앞에 붙는다** — `backend/src/`는 존재하지 않고 `backend/game/src/main/java/…` 형태다. 경로를 예측해 Read하거나 글롭을 쓸 때 이걸 놓치면 조용히 빗나간다(`.claude/rules/`의 `paths`가 이 이유로 매칭에 실패한 적이 있다).
 
-| 모듈 | 역할 |
-| --- | --- |
-| `common` | 순수 Java 공용 타입·유틸. **Spring 의존 없음** |
-| `infra` | Redis·MySQL 등 외부 인프라 어댑터 |
-| `web` | HTTP 공통(예외 핸들러·응답 규격) |
-| `websocket` | STOMP 설정·공통 WebSocket 인프라 |
-| `game-api` | 게임 SPI — `room`이 게임을 알기 위한 유일한 통로 |
-| `game` | 미니게임 구현체 (룰렛·사다리·카드·눈치…) |
-| `room` | 방 생성·입장·참가자. `game` 구체 클래스를 몰라야 한다 |
-| `user` | 사용자·인증 |
-| `profanity` | 비속어 필터 |
-| `admin` | 어드민 API |
-| `zzolbot` | 봇 참가자 |
-| `app` | Spring Boot 진입점 — 전 모듈 조립 |
-| `test-support` | 테스트 전용 공통(TestContainers 등). 프로덕션에서 참조 금지 |
+모듈 목록·역할·의존 방향은 [아키텍처 레퍼런스](docs/architecture.md)가 유일한 출처다. 여기에 옮겨 적지 않는다.
 
 단일 클래스 빠른 확인은 모듈을 지정해 돌린다(그 외에는 `/run-tests`):
 

--- a/backend/docs/architecture.md
+++ b/backend/docs/architecture.md
@@ -7,7 +7,7 @@
 
 ## 모듈 구성
 
-프로젝트는 12개 Gradle 모듈로 구성된다.
+프로젝트는 13개 Gradle 모듈로 구성된다.
 
 ```text
 :common       — Spring 무관 순수 추상 (ErrorCode, BaseEvent, VO)
@@ -18,6 +18,7 @@
 :user         — User + Auth + Friend
 :room         — Room aggregate + Player + Roulette + RoomSessionToken
 :game         — 6게임 구현체 + minigame orchestration
+:profanity    — 비속어 필터 (:admin·:app 이 사용, :room·:game 은 테스트에서만)
 :admin        — dashboard + patchnote + report
 :zzolbot      — AI 운영자 어시스턴트
 :app          — Spring Boot 진입점, 모든 모듈 조합
@@ -32,6 +33,7 @@
         → :game-api → :room → :game → :admin
                                     → :zzolbot
         :infra + :web → :websocket → :user
+        :common + :infra → :profanity → :admin
         (모두) → :app
 :test-support — testImplementation 전용
 ```

--- a/frontend/.claude/rules/feature-structure.md
+++ b/frontend/.claude/rules/feature-structure.md
@@ -1,6 +1,6 @@
 ---
-globs:
-  - 'src/features/**'
+paths:
+  - '**/src/features/**'
 ---
 
 ## Feature 슬라이스 구조

--- a/frontend/.claude/rules/websocket.md
+++ b/frontend/.claude/rules/websocket.md
@@ -1,7 +1,7 @@
 ---
-globs:
-  - 'src/apis/websocket/**'
-  - 'src/contexts/**'
+paths:
+  - '**/src/apis/websocket/**'
+  - '**/src/contexts/**'
 ---
 
 ## WebSocket 컨벤션

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,5 +1,16 @@
 # CLAUDE.md
 
+## 명령어
+
+```bash
+npm run dev          # webpack dev server
+npm run lint:fix     # eslint --fix (코드 변경 후 실행)
+npm run type-check   # tsc --noEmit
+npm run test:jest    # jest
+npm run storybook    # Storybook :6006
+npm run build-storybook   # @common/@composition 수정 시 PR 전 검증
+```
+
 ## 문서
 
 특정 기능이나 설정의 맥락이 필요할 때 먼저 확인한다.
@@ -30,7 +41,7 @@
 
 | 도구 | 담당 | 호출 |
 | --- | --- | --- |
-| `/code-review` (내장 스킬) | 범용 버그(정확성)·중복·단순화·효율, 일반 React/TS 정확성. effort·`ultra`(클라우드)·`--comment`·`--fix` 지원 | Skill 툴 |
+| `/code-review` (내장 커맨드) | 범용 버그(정확성)·중복·단순화·효율, 일반 React/TS 정확성. effort·`ultra`(클라우드)·`--comment`·`--fix` 지원 | **사용자가 직접 입력** — Claude는 `Skill("code-review")`로 호출할 수 없다 |
 | `fe-code-reviewer` (에이전트) | zzol FE 고유 규칙·ADR 준수 (`/code-review`가 모르는 영역) | Agent 툴, `run_in_background: true` |
 
-실행 패턴: `fe-code-reviewer`를 백그라운드로 먼저 띄우고 `/code-review`를 돌린 뒤, 두 결과를 합쳐 보고한다. (자세한 분업은 `.claude/agents/fe-code-reviewer.md` "검토 범위" 참조)
+실행 패턴: Claude는 `fe-code-reviewer`를 백그라운드로 띄워 FE 고유 규칙을 보고, 범용 버그 렌즈가 필요하면 `Skill("deep-review")`를 함께 돌린다. `/code-review`는 사용자가 직접 입력했을 때만 도는 커맨드이므로 Claude의 실행 계획에 넣지 않는다(근거: `backend/.claude/rules/agent-dispatch.md`). (자세한 분업은 `.claude/agents/fe-code-reviewer.md` "검토 범위" 참조)


### PR DESCRIPTION
# ✅ 체크리스트

- [x] merge 타겟 브랜치 잘 설정되었는지 확인하기 (dev)

# 🔥 연관 이슈

- close #1647

# 🚀 작업 내용

1. **`backend/.claude/rules/` 7개 — `paths` 글롭에 `**/` 접두 추가**
   백엔드는 Gradle 멀티모듈이라 `backend/src` 디렉터리가 없고 실제 경로는 `game/src/main/java/…` 형태다. 기존 `src/**/*.java` 패턴은 여기에 매칭되지 않아 `common`·`production`·`testing*` 규칙이 **한 번도 로드되지 않았다.** `**/src/**/*.java`로 고쳐 모듈명이 앞에 붙어도 매칭되게 했다. (`docs.md`의 `docs/**`·`.claude/**`도 같은 이유로 `**/` 접두)
2. **`frontend/.claude/rules/` 2개 — `globs:` → `paths:`**
   `globs`는 Cursor의 프론트매터 키다. Claude Code는 `paths`만 읽으므로 이 두 파일은 "범위 없는 규칙"으로 취급돼 **모든 세션에 무조건 로드**되고 있었다. 키를 바꾸고 패턴에도 `**/` 접두를 붙였다.
3. **`frontend/CLAUDE.md` — 명령어 섹션 추가**
   `dev`·`lint:fix`·`type-check`·`test:jest`·`storybook`·`build-storybook`. 기존에는 npm script가 하나도 문서화돼 있지 않았다.
4. **`backend/CLAUDE.md` — 모듈 지도 + gradle 실행 예시 추가**
   기존에는 13개 모듈 중 4개(`room`·`game`·`game-api`·`common`)만 언급돼 나머지의 존재를 알 수 없었다. 각 모듈 한 줄 역할 표와, 소스 경로에 모듈명이 앞에 붙는다는 사실(1번 문제의 원인)을 명시했다.
5. **`/code-review` 호출 서술 통일**
   `frontend/CLAUDE.md`는 "Skill 툴로 호출"이라 적혀 있었으나, `backend/.claude/rules/agent-dispatch.md`는 "사용자 입력 전용 커맨드라 Skill 툴로 호출 불가"라고 못박고 있다. 후자가 정확하므로 프론트 쪽 서술을 맞췄다.

# 💬 리뷰 중점사항

- **`**/` 접두가 안전한 이유**: 글롭이 저장소 루트 기준인지 `.claude/`를 가진 디렉터리 기준인지 공식 문서에 명시돼 있지 않다. `**/` 접두는 두 경우 모두에서 매칭되므로 앵커링과 무관하게 동작한다. 앵커 기준을 아는 분이 있으면 더 좁은 패턴으로 조여도 좋다.
- **`globs` → `paths` 전환의 부작용**: 그동안 무조건 로드되던 `feature-structure.md`·`websocket.md`가 이제 해당 경로 작업 시에만 로드된다. 의도된 변화지만, 두 규칙이 항상 필요하다고 판단되면 `paths` 자체를 빼는 편이 낫다.
- 문서 변경만이라 테스트 영향은 없다. 다만 새로 문서화한 `./gradlew :game:test --tests '*CardGameTest'` 는 실제로 돌려 `BUILD SUCCESSFUL` 확인했고, 변경한 마크다운은 `markdownlint-cli2` 0 issues다.
- `backend/.claude/skills/impl`이 스킬 목록에 노출되지 않는 문제는 원인이 달라 이 PR에 넣지 않았다(이슈 #1647 TODO에 남겨둠).
